### PR TITLE
Adjusted system equipment sizing and Resolved nonlinear system warnings.

### DIFF
--- a/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/BaseClasses/HVACSide/BaseClasses/AirSide.mo
+++ b/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/BaseClasses/HVACSide/BaseClasses/AirSide.mo
@@ -31,8 +31,8 @@ model Airside "Air side system"
       mAirFloRat5[3])/1.2*2}} "Volume flow rate curve";
   parameter Real HydEff[n,:] = {{0.93*0.65,0.93*0.7,0.93,0.93*0.6} for i in linspace(1,n,n)} "Hydraulic efficiency";
   parameter Real MotEff[n,:] = {{0.6045*0.65,0.6045*0.7,0.6045,0.6045*0.6} for i in linspace(1,n,n)} "Motor efficiency";
-  parameter Modelica.Units.SI.Pressure SupPreCur[n,:]={{1400,1000,700,700*0.5} for i in linspace(1,n,n)} "Pressure curve";
-  parameter Modelica.Units.SI.Pressure RetPreCur[n,:]={{600,400,200,100} for i in linspace(1,n,n)} "Pressure curve";
+  parameter Modelica.Units.SI.Pressure SupPreCur[n,:]={{1400*beta,1000*beta,700*beta,700*0.5*beta} for i in linspace(1,n,n)} "Pressure curve";
+  parameter Modelica.Units.SI.Pressure RetPreCur[n,:]={{600*beta,400*beta,200*beta,100*beta} for i in linspace(1,n,n)} "Pressure curve";
   parameter Modelica.Units.SI.Pressure PreAirDroMai1=140
     "Pressure drop 1 across the duct";
   parameter Modelica.Units.SI.Pressure PreAirDroMai2=140
@@ -131,6 +131,7 @@ model Airside "Air side system"
   parameter Modelica.Units.SI.Efficiency eps5(max=1) = 0.8
     "Heat exchanger effectiveness of vav 1";
   final parameter Real alpha = 0.8  "Sizing factor";
+  final parameter Real beta = 2  "Sizing factor for AHU fan pressure";
 
   //package MediumAir = Buildings.Media.Air "Medium model for air";
   package MediumAir = Buildings.Media.Air(extraPropertiesNames={"CO2"}) "Buildings library air media package with CO2";
@@ -261,8 +262,8 @@ model Airside "Air side system"
     redeclare package MediumHeaWat = MediumHeaWat,
     C_start=fill(400e-6*Modelica.Media.IdealGases.Common.SingleGasesData.CO2.MM/Modelica.Media.IdealGases.Common.SingleGasesData.Air.MM, MediumAir.nC),
     m_flow_lea={10*0.206*1.2, 10*0.137*1.2, 10*0.206*1.2, 10*0.137*1.2},
-    PreDroCoiAir=PreDroCoiAir*10,
-    PreDroMixingBoxAir=PreDroMixingBoxAir*10,
+    PreDroCoiAir=PreDroCoiAir,
+    PreDroMixingBoxAir=PreDroMixingBoxAir,
     PreDroCooWat=PreDroCooWat/2,
     TemEcoHig=TemEcoHig,
     TemEcoLow=TemEcoLow,
@@ -273,24 +274,24 @@ model Airside "Air side system"
     VolFloCur=VolFloCur[2, :],
     SupPreCur=SupPreCur[2, :],
     RetPreCur=RetPreCur[2, :],
-    PreAirDroMai1=PreAirDroMai1*10,
-    PreAirDroMai2=PreAirDroMai2*10,
-    PreAirDroMai3=PreAirDroMai3*10,
-    PreAirDroMai4=PreAirDroMai4*10,
-    PreAirDroBra1=PreAirDroBra1*10,
-    PreAirDroBra2=PreAirDroBra2*10,
-    PreAirDroBra3=PreAirDroBra3*10,
-    PreAirDroBra4=PreAirDroBra4*10,
-    PreAirDroBra5=PreAirDroBra5*10,
-    PreWatDroMai1=PreWatDroMai1*10,
-    PreWatDroMai2=PreWatDroMai2*10,
-    PreWatDroMai3=PreWatDroMai3*10,
-    PreWatDroMai4=PreWatDroMai4*10,
-    PreWatDroBra1=PreWatDroBra1*10,
-    PreWatDroBra2=PreWatDroBra2*10,
-    PreWatDroBra3=PreWatDroBra3*10,
-    PreWatDroBra4=PreWatDroBra4*10,
-    PreWatDroBra5=PreWatDroBra5*10,
+    PreAirDroMai1=PreAirDroMai1,
+    PreAirDroMai2=PreAirDroMai2,
+    PreAirDroMai3=PreAirDroMai3,
+    PreAirDroMai4=PreAirDroMai4,
+    PreAirDroBra1=PreAirDroBra1,
+    PreAirDroBra2=PreAirDroBra2,
+    PreAirDroBra3=PreAirDroBra3,
+    PreAirDroBra4=PreAirDroBra4,
+    PreAirDroBra5=PreAirDroBra5,
+    PreWatDroMai1=PreWatDroMai1,
+    PreWatDroMai2=PreWatDroMai2,
+    PreWatDroMai3=PreWatDroMai3,
+    PreWatDroMai4=PreWatDroMai4,
+    PreWatDroBra1=PreWatDroBra1,
+    PreWatDroBra2=PreWatDroBra2,
+    PreWatDroBra3=PreWatDroBra3,
+    PreWatDroBra4=PreWatDroBra4,
+    PreWatDroBra5=PreWatDroBra5,
     mAirFloRat1=mAirFloRat1[2],
     mAirFloRat2=mAirFloRat2[2],
     mAirFloRat3=mAirFloRat3[2],
@@ -301,20 +302,20 @@ model Airside "Air side system"
     mWatFloRat3=mWatFloRat3[2],
     mWatFloRat4=mWatFloRat4[2],
     mWatFloRat5=mWatFloRat5[2],
-    PreDroAir1=PreDroAir1*10,
-    PreDroWat1=PreDroWat1*10,
+    PreDroAir1=PreDroAir1,
+    PreDroWat1=PreDroWat1,
     eps1=eps1,
-    PreDroAir2=PreDroAir2*10,
-    PreDroWat2=PreDroWat2*10,
+    PreDroAir2=PreDroAir2,
+    PreDroWat2=PreDroWat2,
     eps2=eps2,
-    PreDroAir3=PreDroAir3*10,
-    PreDroWat3=PreDroWat3*10,
+    PreDroAir3=PreDroAir3,
+    PreDroWat3=PreDroWat3,
     eps3=eps3,
-    PreDroAir4=PreDroAir4*10,
-    PreDroWat4=PreDroWat4*10,
+    PreDroAir4=PreDroAir4,
+    PreDroWat4=PreDroWat4,
     eps4=eps4,
-    PreDroAir5=PreDroAir5*10,
-    PreDroWat5=PreDroWat5*10,
+    PreDroAir5=PreDroAir5,
+    PreDroWat5=PreDroWat5,
     eps5=eps5,
     redeclare package MediumCooWat = MediumCHW,
     mWatFloRat=mWatFloRatMid)
@@ -337,7 +338,7 @@ model Airside "Air side system"
     m_flow_lea={1*0.206*1.2, 1*0.137*1.2, 1*0.206*1.2, 1*0.137*1.2},
     PreDroCoiAir=PreDroCoiAir,
     PreDroMixingBoxAir=PreDroMixingBoxAir,
-    PreDroCooWat=PreDroCooWat/2,
+    PreDroCooWat=PreDroCooWat,
     TemEcoHig=TemEcoHig,
     TemEcoLow=TemEcoLow,
     MixingBoxDamMin=MixingBoxDamMin,

--- a/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/BaseClasses/HVACSide/BaseClasses/AirSide.mo
+++ b/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/BaseClasses/HVACSide/BaseClasses/AirSide.mo
@@ -181,7 +181,7 @@ model Airside "Air side system"
       MixingBox_Ti=600,
       Fan_k=0.001,
       Fan_Ti=600,
-      booleanExpression(y=if floor1.duaFanAirHanUni.TOut < 253.15 then floor1.duaFanAirHanUni.occ
+      booleanExpression(y=if floor1.duaFanAirHanUni.TOut < 253.15 then floor1.duaFanAirHanUni.onFanOcc
              else true)),
     fivZonVAV(vol(each V=200000)),
     redeclare package MediumAir = MediumAir,
@@ -257,7 +257,7 @@ model Airside "Air side system"
       MixingBox_Ti=600,
       Fan_k=0.001,
       Fan_Ti=600,
-      booleanExpression(y=if floor2.duaFanAirHanUni.TOut < 253.15 then floor2.duaFanAirHanUni.occ
+      booleanExpression(y=if floor2.duaFanAirHanUni.TOut < 253.15 then floor2.duaFanAirHanUni.onFanOcc
              else true)),
     fivZonVAV(vol(each V=200000)),
     redeclare package MediumAir = MediumAir,
@@ -333,7 +333,7 @@ model Airside "Air side system"
       MixingBox_Ti=600,
       Fan_k=0.001,
       Fan_Ti=600,
-      booleanExpression(y=if floor3.duaFanAirHanUni.TOut < 253.15 then floor3.duaFanAirHanUni.occ
+      booleanExpression(y=if floor3.duaFanAirHanUni.TOut < 253.15 then floor3.duaFanAirHanUni.onFanOcc
              else true)),
     fivZonVAV(vol(each V=200000)),
     redeclare package MediumAir = MediumAir,
@@ -439,8 +439,8 @@ equation
                                         color={0,0,127}));
   connect(TSupAirSet[1].y, floor1.disTSet) annotation (Line(points={{-39,70},{
           108,70},{108,48},{112.438,48}}, color={0,0,127}));
-  connect(reaToBooOcc.y, floor1.occ) annotation (Line(points={{-39,100},{-36,
-          100},{-36,86},{106,86},{106,27},{112.438,27}}, color={255,0,255}));
+  connect(reaToBooOcc.y, floor1.onFanOcc) annotation (Line(points={{-39,100},{
+          -36,100},{-36,86},{106,86},{106,27},{112.438,27}}, color={255,0,255}));
   connect(floor1.onZon, onZon[1].y) annotation (Line(points={{112.438,21.75},{
           104,21.75},{104,76},{61,76}},               color={255,0,255}));
 
@@ -465,7 +465,7 @@ equation
   connect(floor2.port_Fre_Air, sou[2].ports[2]);
   connect(dpStaSet[2].y, floor2.pSet);
   connect(TSupAirSet[2].y, floor2.disTSet);
-  connect(reaToBooOcc.y, floor2.occ);
+  connect(reaToBooOcc.y, floor2.onFanOcc);
   connect(floor2.onZon, onZon[2].y);
 
    for j in 1:5 loop
@@ -481,7 +481,7 @@ equation
   connect(floor3.port_Fre_Air, sou[3].ports[2]);
   connect(dpStaSet[3].y, floor3.pSet);
   connect(TSupAirSet[3].y, floor3.disTSet);
-  connect(reaToBooOcc.y, floor3.occ);
+  connect(reaToBooOcc.y, floor3.onFanOcc);
   connect(floor3.onZon, onZon[3].y);
 
    for j in 1:5 loop

--- a/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/BaseClasses/HVACSide/BaseClasses/AirSide.mo
+++ b/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/BaseClasses/HVACSide/BaseClasses/AirSide.mo
@@ -1,5 +1,6 @@
 within MultizoneOfficeComplexAir.BaseClasses.HVACSide.BaseClasses;
 model Airside "Air side system"
+  parameter Real alpha = 1  "Sizing factor for overall system design capacity and mass flow rate";
   parameter Integer n =  3  "Number of floors";
   parameter Modelica.Units.SI.Pressure PreDroCoiAir=50
     "Pressure drop in the air side";
@@ -31,8 +32,8 @@ model Airside "Air side system"
       mAirFloRat5[3])/1.2*2}} "Volume flow rate curve";
   parameter Real HydEff[n,:] = {{0.93*0.65,0.93*0.7,0.93,0.93*0.6} for i in linspace(1,n,n)} "Hydraulic efficiency";
   parameter Real MotEff[n,:] = {{0.6045*0.65,0.6045*0.7,0.6045,0.6045*0.6} for i in linspace(1,n,n)} "Motor efficiency";
-  parameter Modelica.Units.SI.Pressure SupPreCur[n,:]={{1400*beta,1000*beta,700*beta,700*0.5*beta} for i in linspace(1,n,n)} "Pressure curve";
-  parameter Modelica.Units.SI.Pressure RetPreCur[n,:]={{600*beta,400*beta,200*beta,100*beta} for i in linspace(1,n,n)} "Pressure curve";
+  parameter Modelica.Units.SI.Pressure SupPreCur[n,:]={{2800,2000,1400,700} for i in linspace(1,n,n)} "Pressure curve";
+  parameter Modelica.Units.SI.Pressure RetPreCur[n,:]={{1200,800,400,200} for i in linspace(1,n,n)} "Pressure curve";
   parameter Modelica.Units.SI.Pressure PreAirDroMai1=140
     "Pressure drop 1 across the duct";
   parameter Modelica.Units.SI.Pressure PreAirDroMai2=140
@@ -94,11 +95,11 @@ model Airside "Air side system"
   parameter Modelica.Units.SI.MassFlowRate mWatFloRat5[n]={mAirFloRat5[1]*0.3*(
       35 - 12.88)/4.2/20,mAirFloRat5[2]*0.3*(35 - 12.88)/4.2/20,mAirFloRat5[3]*
       0.3*(35 - 12.88)/4.2/20} "mass flow rate for vav 5";
-  parameter Modelica.Units.SI.MassFlowRate mWatFloRatBot=26.7
+  parameter Modelica.Units.SI.MassFlowRate mWatFloRatBot=26.7*alpha
     "mass flow rate for cooling coil chilled water in floor 1";
-  parameter Modelica.Units.SI.MassFlowRate mWatFloRatMid=267
+  parameter Modelica.Units.SI.MassFlowRate mWatFloRatMid=267*alpha
     "mass flow rate for cooling coil chilled water in floor 2";
-  parameter Modelica.Units.SI.MassFlowRate mWatFloRatTop=26.7
+  parameter Modelica.Units.SI.MassFlowRate mWatFloRatTop=26.7*alpha
     "mass flow rate for cooling coil chilled water in floor 3";
   parameter Modelica.Units.SI.Pressure PreDroAir1=200
     "Pressure drop in the air side of vav 1";
@@ -130,8 +131,6 @@ model Airside "Air side system"
     "Pressure drop in the water side of vav 1";
   parameter Modelica.Units.SI.Efficiency eps5(max=1) = 0.8
     "Heat exchanger effectiveness of vav 1";
-  final parameter Real alpha = 0.8  "Sizing factor";
-  final parameter Real beta = 2  "Sizing factor for AHU fan pressure";
 
   //package MediumAir = Buildings.Media.Air "Medium model for air";
   package MediumAir = Buildings.Media.Air(extraPropertiesNames={"CO2"}) "Buildings library air media package with CO2";

--- a/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/BaseClasses/HVACSide/BaseClasses/AirSide.mo
+++ b/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/BaseClasses/HVACSide/BaseClasses/AirSide.mo
@@ -181,12 +181,15 @@ model Airside "Air side system"
       MixingBox_Ti=600,
       Fan_k=0.001,
       Fan_Ti=600,
-      booleanExpression(y=if floor1.duaFanAirHanUni.TOut < 253.15 then floor1.duaFanAirHanUni.On else true)),
+      booleanExpression(y=if floor1.duaFanAirHanUni.TOut < 253.15 then floor1.duaFanAirHanUni.occ
+             else true)),
     fivZonVAV(vol(each V=200000)),
     redeclare package MediumAir = MediumAir,
     redeclare package MediumHeaWat = MediumHeaWat,
-    C_start=fill(400e-6*Modelica.Media.IdealGases.Common.SingleGasesData.CO2.MM/Modelica.Media.IdealGases.Common.SingleGasesData.Air.MM, MediumAir.nC),
-    m_flow_lea={1*0.206*1.2, 1*0.137*1.2, 1*0.206*1.2, 1*0.137*1.2},
+    C_start=fill(400e-6*Modelica.Media.IdealGases.Common.SingleGasesData.CO2.MM
+        /Modelica.Media.IdealGases.Common.SingleGasesData.Air.MM, MediumAir.nC),
+
+    m_flow_lea={1*0.206*1.2,1*0.137*1.2,1*0.206*1.2,1*0.137*1.2},
     PreDroCoiAir=PreDroCoiAir,
     PreDroMixingBoxAir=PreDroMixingBoxAir,
     PreDroCooWat=PreDroCooWat/2,
@@ -254,13 +257,15 @@ model Airside "Air side system"
       MixingBox_Ti=600,
       Fan_k=0.001,
       Fan_Ti=600,
-      booleanExpression(y=if floor2.duaFanAirHanUni.TOut < 253.15 then floor2.duaFanAirHanUni.On
+      booleanExpression(y=if floor2.duaFanAirHanUni.TOut < 253.15 then floor2.duaFanAirHanUni.occ
              else true)),
     fivZonVAV(vol(each V=200000)),
     redeclare package MediumAir = MediumAir,
     redeclare package MediumHeaWat = MediumHeaWat,
-    C_start=fill(400e-6*Modelica.Media.IdealGases.Common.SingleGasesData.CO2.MM/Modelica.Media.IdealGases.Common.SingleGasesData.Air.MM, MediumAir.nC),
-    m_flow_lea={10*0.206*1.2, 10*0.137*1.2, 10*0.206*1.2, 10*0.137*1.2},
+    C_start=fill(400e-6*Modelica.Media.IdealGases.Common.SingleGasesData.CO2.MM
+        /Modelica.Media.IdealGases.Common.SingleGasesData.Air.MM, MediumAir.nC),
+
+    m_flow_lea={10*0.206*1.2,10*0.137*1.2,10*0.206*1.2,10*0.137*1.2},
     PreDroCoiAir=PreDroCoiAir,
     PreDroMixingBoxAir=PreDroMixingBoxAir,
     PreDroCooWat=PreDroCooWat/2,
@@ -328,13 +333,15 @@ model Airside "Air side system"
       MixingBox_Ti=600,
       Fan_k=0.001,
       Fan_Ti=600,
-      booleanExpression(y=if floor3.duaFanAirHanUni.TOut < 253.15 then floor3.duaFanAirHanUni.On
+      booleanExpression(y=if floor3.duaFanAirHanUni.TOut < 253.15 then floor3.duaFanAirHanUni.occ
              else true)),
     fivZonVAV(vol(each V=200000)),
     redeclare package MediumAir = MediumAir,
     redeclare package MediumHeaWat = MediumHeaWat,
-    C_start=fill(400e-6*Modelica.Media.IdealGases.Common.SingleGasesData.CO2.MM/Modelica.Media.IdealGases.Common.SingleGasesData.Air.MM, MediumAir.nC),
-    m_flow_lea={1*0.206*1.2, 1*0.137*1.2, 1*0.206*1.2, 1*0.137*1.2},
+    C_start=fill(400e-6*Modelica.Media.IdealGases.Common.SingleGasesData.CO2.MM
+        /Modelica.Media.IdealGases.Common.SingleGasesData.Air.MM, MediumAir.nC),
+
+    m_flow_lea={1*0.206*1.2,1*0.137*1.2,1*0.206*1.2,1*0.137*1.2},
     PreDroCoiAir=PreDroCoiAir,
     PreDroMixingBoxAir=PreDroMixingBoxAir,
     PreDroCooWat=PreDroCooWat,
@@ -391,7 +398,7 @@ model Airside "Air side system"
     PreDroWat5=PreDroWat5,
     eps5=eps5,
     redeclare package MediumCooWat = MediumCHW,
-    mWatFloRat=mWatFloRatTop)                      "Top Floor"
+    mWatFloRat=mWatFloRatTop) "Top Floor"
     annotation (Placement(transformation(extent={{114,20},{164,62}})));
 
   MultizoneOfficeComplexAir.BaseClasses.HVACSide.BaseClasses.Component.AirSide.AirHandlingUnit.BaseClasses.ZoneSetpoint
@@ -432,10 +439,9 @@ equation
                                         color={0,0,127}));
   connect(TSupAirSet[1].y, floor1.disTSet) annotation (Line(points={{-39,70},{
           108,70},{108,48},{112.438,48}}, color={0,0,127}));
-  connect(reaToBooOcc.y, floor1.OnFan) annotation (Line(points={{-39,100},{-36,
-          100},{-36,86},{106,86},{106,27},{112.438,27}},
-                                                      color={255,0,255}));
-  connect(floor1.OnZon, onZon[1].y) annotation (Line(points={{112.438,21.75},{
+  connect(reaToBooOcc.y, floor1.occ) annotation (Line(points={{-39,100},{-36,
+          100},{-36,86},{106,86},{106,27},{112.438,27}}, color={255,0,255}));
+  connect(floor1.onZon, onZon[1].y) annotation (Line(points={{112.438,21.75},{
           104,21.75},{104,76},{61,76}},               color={255,0,255}));
 
    for j in 1:5 loop
@@ -459,8 +465,8 @@ equation
   connect(floor2.port_Fre_Air, sou[2].ports[2]);
   connect(dpStaSet[2].y, floor2.pSet);
   connect(TSupAirSet[2].y, floor2.disTSet);
-  connect(reaToBooOcc.y, floor2.OnFan);
-  connect(floor2.OnZon, onZon[2].y);
+  connect(reaToBooOcc.y, floor2.occ);
+  connect(floor2.onZon, onZon[2].y);
 
    for j in 1:5 loop
     connect(loaMulMidFlo[j].y, floor2.Q_flow[j]) annotation (Line(points={{-81.4,
@@ -475,8 +481,8 @@ equation
   connect(floor3.port_Fre_Air, sou[3].ports[2]);
   connect(dpStaSet[3].y, floor3.pSet);
   connect(TSupAirSet[3].y, floor3.disTSet);
-  connect(reaToBooOcc.y, floor3.OnFan);
-  connect(floor3.OnZon, onZon[3].y);
+  connect(reaToBooOcc.y, floor3.occ);
+  connect(floor3.onZon, onZon[3].y);
 
    for j in 1:5 loop
     connect(loa[(3 - 1)*5 + j], floor3.Q_flow[j]);

--- a/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/BaseClasses/HVACSide/BaseClasses/AirsideFloor.mo
+++ b/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/BaseClasses/HVACSide/BaseClasses/AirsideFloor.mo
@@ -268,39 +268,41 @@ model AirsideFloor "Thermal zones and corresponding air side HVAC systems"
     PreDroWat5=PreDroWat5,
     eps5=eps5)
     annotation (Placement(transformation(extent={{30,-18},{66,-46}})));
-  Modelica.Fluid.Interfaces.FluidPort_b port_b_CooWat(redeclare package Medium =
-        MediumCooWat)
+  Modelica.Fluid.Interfaces.FluidPort_b port_b_CooWat(redeclare package Medium
+      = MediumCooWat)
     "Fluid connector b (positive design flow direction is from port_a to port_b)"
     annotation (Placement(transformation(extent={{-70,-110},{-50,-90}}),
         iconTransformation(extent={{-70,-110},{-50,-90}})));
-  Modelica.Fluid.Interfaces.FluidPort_a port_a_CooWat(redeclare package Medium =
-        MediumCooWat)
+  Modelica.Fluid.Interfaces.FluidPort_a port_a_CooWat(redeclare package Medium
+      = MediumCooWat)
     "Fluid connector a (positive design flow direction is from port_a to port_b)"
     annotation (Placement(transformation(extent={{-40,-110},{-20,-90}}),
         iconTransformation(extent={{-40,-110},{-20,-90}})));
-  Modelica.Fluid.Interfaces.FluidPort_a port_a_HeaWat(redeclare package Medium =
-        MediumHeaWat)
+  Modelica.Fluid.Interfaces.FluidPort_a port_a_HeaWat(redeclare package Medium
+      = MediumHeaWat)
     "Second port, typically outlet"
     annotation (Placement(transformation(extent={{30,-110},{50,-90}}),
         iconTransformation(extent={{30,-110},{50,-90}})));
-  Modelica.Fluid.Interfaces.FluidPort_b port_b_HeaWat(redeclare package Medium =
-        MediumHeaWat)
+  Modelica.Fluid.Interfaces.FluidPort_b port_b_HeaWat(redeclare package Medium
+      = MediumHeaWat)
     "Second port, typically outlet"
     annotation (Placement(transformation(extent={{60,-110},{80,-90}}),
         iconTransformation(extent={{60,-110},{80,-90}})));
-  Modelica.Fluid.Interfaces.FluidPort_b port_Exh_Air(redeclare package Medium = MediumAir)
+  Modelica.Fluid.Interfaces.FluidPort_b port_Exh_Air(redeclare package Medium
+      =                                                                         MediumAir)
     "Fluid connector b (positive design flow direction is from port_a to port_b)"
     annotation (Placement(transformation(extent={{-174,-50},{-154,-30}})));
-  Modelica.Fluid.Interfaces.FluidPort_a port_Fre_Air(redeclare package Medium = MediumAir)
+  Modelica.Fluid.Interfaces.FluidPort_a port_Fre_Air(redeclare package Medium
+      =                                                                         MediumAir)
     "Fluid connector b (positive design flow direction is from port_a to port_b)"
     annotation (Placement(transformation(extent={{-170,30},{-150,50}})));
   Modelica.Blocks.Routing.BooleanReplicator booleanReplicator(nout=5)
     annotation (Placement(transformation(extent={{-140,-96},{-126,-84}})));
-  Modelica.Blocks.Interfaces.BooleanInput OnFan
-    "Connector of Boolean input signal"
-    annotation (Placement(transformation(extent={{-180,-70},{-160,-50}}),
-        iconTransformation(extent={{-180,-70},{-160,-50}})));
-  Modelica.Blocks.Interfaces.BooleanInput OnZon
+  Modelica.Blocks.Interfaces.BooleanInput occ
+    "Connector of Boolean input signal" annotation (Placement(transformation(
+          extent={{-180,-70},{-160,-50}}), iconTransformation(extent={{-180,-70},
+            {-160,-50}})));
+  Modelica.Blocks.Interfaces.BooleanInput onZon
     "Connector of Boolean input signal"
     annotation (Placement(transformation(extent={{-180,-100},{-160,-80}}),
         iconTransformation(extent={{-180,-100},{-160,-80}})));
@@ -422,7 +424,7 @@ equation
       points={{-78,-7.27273},{-114,-7.27273},{-114,40},{-160,40}},
       color={0,140,72},
       thickness=0.5));
-  connect(booleanReplicator.y, fivZonVAV.On) annotation (Line(
+  connect(booleanReplicator.y,fivZonVAV.on)  annotation (Line(
       points={{-125.3,-90},{4,-90},{4,-31.7455},{28.8,-31.7455}},
       color={255,0,255}));
   connect(fivZonVAV.p, duaFanAirHanUni.pMea) annotation (Line(points={{55.2,
@@ -434,10 +436,9 @@ equation
           4.54545}},
         color={0,0,127}));
 
-  connect(OnFan, duaFanAirHanUni.On) annotation (Line(points={{-170,-60},{-108,
-          -60},{-108,11.6364},{-79.4,11.6364}},
-                                      color={255,0,255}));
-  connect(booleanReplicator.u, OnZon) annotation (Line(
+  connect(occ, duaFanAirHanUni.occ) annotation (Line(points={{-170,-60},{-108,
+          -60},{-108,11.6364},{-79.4,11.6364}}, color={255,0,255}));
+  connect(booleanReplicator.u,onZon)  annotation (Line(
       points={{-141.4,-90},{-170,-90}},
       color={255,0,255}));
   connect(fivZonVAV.Q_flow, Q_flow) annotation (Line(
@@ -450,8 +451,8 @@ equation
   connect(port_a_CooWat, port_a_CooWat) annotation (Line(points={{-30,-100},
           {-30,-100}},     color={0,127,255}));
 
-  connect(OnFan, reaAhu.occ_in) annotation (Line(points={{-170,-60},{-112,-60},
-          {-112,62},{26,62},{26,62.8}},    color={255,0,255}));
+  connect(occ, reaAhu.occ_in) annotation (Line(points={{-170,-60},{-112,-60},{-112,
+          62},{26,62},{26,62.8}}, color={255,0,255}));
   connect(duaFanAirHanUni.TSupAir, reaAhu.TSup_in) annotation (Line(
       points={{-48.6,-4.90909},{-34,-4.90909},{-34,56.1538},{26,56.1538}},
       color={0,0,127},

--- a/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/BaseClasses/HVACSide/BaseClasses/AirsideFloor.mo
+++ b/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/BaseClasses/HVACSide/BaseClasses/AirsideFloor.mo
@@ -298,8 +298,8 @@ model AirsideFloor "Thermal zones and corresponding air side HVAC systems"
     annotation (Placement(transformation(extent={{-170,30},{-150,50}})));
   Modelica.Blocks.Routing.BooleanReplicator booleanReplicator(nout=5)
     annotation (Placement(transformation(extent={{-140,-96},{-126,-84}})));
-  Modelica.Blocks.Interfaces.BooleanInput occ
-    "Connector of Boolean input signal" annotation (Placement(transformation(
+  Modelica.Blocks.Interfaces.BooleanInput onFanOcc
+    "Fan On signal during occupied period" annotation (Placement(transformation(
           extent={{-180,-70},{-160,-50}}), iconTransformation(extent={{-180,-70},
             {-160,-50}})));
   Modelica.Blocks.Interfaces.BooleanInput onZon
@@ -436,8 +436,8 @@ equation
           4.54545}},
         color={0,0,127}));
 
-  connect(occ, duaFanAirHanUni.occ) annotation (Line(points={{-170,-60},{-108,
-          -60},{-108,11.6364},{-79.4,11.6364}}, color={255,0,255}));
+  connect(onFanOcc, duaFanAirHanUni.onFanOcc) annotation (Line(points={{-170,
+          -60},{-108,-60},{-108,11.6364},{-79.4,11.6364}}, color={255,0,255}));
   connect(booleanReplicator.u,onZon)  annotation (Line(
       points={{-141.4,-90},{-170,-90}},
       color={255,0,255}));
@@ -451,8 +451,8 @@ equation
   connect(port_a_CooWat, port_a_CooWat) annotation (Line(points={{-30,-100},
           {-30,-100}},     color={0,127,255}));
 
-  connect(occ, reaAhu.occ_in) annotation (Line(points={{-170,-60},{-112,-60},{-112,
-          62},{26,62},{26,62.8}}, color={255,0,255}));
+  connect(onFanOcc, reaAhu.occ_in) annotation (Line(points={{-170,-60},{-112,-60},
+          {-112,62},{26,62},{26,62.8}}, color={255,0,255}));
   connect(duaFanAirHanUni.TSupAir, reaAhu.TSup_in) annotation (Line(
       points={{-48.6,-4.90909},{-34,-4.90909},{-34,56.1538},{26,56.1538}},
       color={0,0,127},

--- a/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/BaseClasses/HVACSide/BaseClasses/AirsideFloor.mo
+++ b/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/BaseClasses/HVACSide/BaseClasses/AirsideFloor.mo
@@ -359,7 +359,7 @@ model AirsideFloor "Thermal zones and corresponding air side HVAC systems"
     zonVAVCon[5](
     each MinFlowRateSetPoi=0.3,
     each HeatingFlowRateSetPoi=0.5,
-    heaCon(Ti=60, yMin=0.),
+    heaCon(Ti=60, yMin=0.005),
     cooCon(k=11, Ti=60))
     "Zone terminal VAV controller (airflow rate, reheat valve)l "
     annotation (Placement(transformation(extent={{-14,118},{6,138}})));
@@ -855,6 +855,8 @@ MultizoneOfficeComplexAir.BaseClasses.HVACSide.BaseClasses.Component.AirSide.Zon
 MultizoneOfficeComplexAir.BaseClasses.HVACSide.BaseClasses.Component.AirSide.ZoneTerminal.Controls.ZonCon</a> for a description of the zone terminal VAV controller. </p>
 </html>", revisions = "<html>
 <ul>
+<li> August 8, 2024, by Guowen Li, Xing Lu, Yan Chen: </li>
+<p> Added CO2 and air infiltration features; Adjusted system equipment sizing; Reduced nonlinear system warnings.</p>
 <li> August 17, 2023, by Xing Lu, Sen Huang, Lingzhe Wang:
 <p> First implementation.</p>
 </ul>

--- a/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/BaseClasses/HVACSide/BaseClasses/BoilerPlant.mo
+++ b/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/BaseClasses/HVACSide/BaseClasses/BoilerPlant.mo
@@ -206,6 +206,8 @@ MultizoneOfficeComplexAir.BaseClasses.HVACSide.BaseClasses.Component.WaterSide.B
 MultizoneOfficeComplexAir.BaseClasses.HVACSide.BaseClasses.Component.WaterSide.Control.PlantStageN</a> for a description of the boiler stage control. </p>
 </html>", revisions = "<html>
 <ul>
+<li>August 8, 2024, by Guowen Li, Xing Lu, Yan Chen: </li>
+<p>Adjusted system equipment sizing; Reduced nonlinear system warnings.</p>
 <li> August 17, 2023, by Xing Lu, Sen Huang, Lingzhe Wang:
 <p> First implementation.</p>
 </ul>

--- a/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/BaseClasses/HVACSide/BaseClasses/BoilerPlant.mo
+++ b/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/BaseClasses/HVACSide/BaseClasses/BoilerPlant.mo
@@ -3,14 +3,15 @@ model BoilerPlant "Boiler hot water plant"
   replaceable package MediumHW =
      Modelica.Media.Interfaces.PartialMedium
     "Medium in the hot water side";
+  parameter Real alpha = 1  "Sizing factor for overall system design capacity and mass flow rate";
   parameter Integer n=2
     "Number of boilers";
   parameter Integer m=2
     "Number of pumps";
   parameter Real thrhol[:]= {0.95}
     "Threshold for boiler staging";
-  parameter Real Cap[:] = {4191000/n for i in linspace(1, n, n)} "Rated Plant Capacity";
-  parameter Modelica.Units.SI.MassFlowRate mHW_flow_nominal[:]={4191000/n/20
+  parameter Real Cap[:] = {4191000*alpha/n for i in linspace(1, n, n)} "Rated Plant Capacity";
+  parameter Modelica.Units.SI.MassFlowRate mHW_flow_nominal[:]={4191000*alpha/n/20
       /4200 for i in linspace(
       1,
       n,

--- a/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/BaseClasses/HVACSide/BaseClasses/BoilerPlant.mo
+++ b/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/BaseClasses/HVACSide/BaseClasses/BoilerPlant.mo
@@ -9,8 +9,8 @@ model BoilerPlant "Boiler hot water plant"
     "Number of pumps";
   parameter Real thrhol[:]= {0.95}
     "Threshold for boiler staging";
-  parameter Real Cap[:] = {2762738.20/n for i in linspace(1, n, n)} "Rated Plant Capacity";
-  parameter Modelica.Units.SI.MassFlowRate mHW_flow_nominal[:]={2762738.20/n/20
+  parameter Real Cap[:] = {4191000/n for i in linspace(1, n, n)} "Rated Plant Capacity";
+  parameter Modelica.Units.SI.MassFlowRate mHW_flow_nominal[:]={4191000/n/20
       /4200 for i in linspace(
       1,
       n,

--- a/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/BaseClasses/HVACSide/BaseClasses/ChillerPlant.mo
+++ b/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/BaseClasses/HVACSide/BaseClasses/ChillerPlant.mo
@@ -19,7 +19,7 @@ model ChillerPlant
   parameter Modelica.Units.SI.Power PTow_nominal[:]={-datChi[1].QEva_flow_nominal*(COP_nominal + 1)/COP_nominal*0.015 for i in linspace(
       1,
       n,
-      n)} "Nominal cooling tower power (assume specific fan power is 0.015kW per 1kW of CT heat rejected)";
+      n)} "Nominal cooling tower power based on CT capacity Q_cond (assume specific fan power is 0.015kW per 1kW of CT heat rejected)";
   parameter Modelica.Units.SI.TemperatureDifference dTCHW_nominal=5.56
     "Temperature difference at chilled water side";
   parameter Modelica.Units.SI.TemperatureDifference dTCW_nominal=5.18

--- a/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/BaseClasses/HVACSide/BaseClasses/ChillerPlant.mo
+++ b/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/BaseClasses/HVACSide/BaseClasses/ChillerPlant.mo
@@ -16,10 +16,10 @@ model ChillerPlant
   parameter Real tWai = 900 "Waiting time";
   parameter Modelica.Units.SI.TemperatureDifference dT=0.5
     "Temperature difference for stage control";
-  parameter Modelica.Units.SI.Power PTow_nominal[:]={10E3 for i in linspace(
+  parameter Modelica.Units.SI.Power PTow_nominal[:]={-datChi[1].QEva_flow_nominal*(COP_nominal + 1)/COP_nominal*0.015 for i in linspace(
       1,
       n,
-      n)} "Nominal cooling tower power (at y=1)";
+      n)} "Nominal cooling tower power (assume specific fan power is 0.015kW per 1kW of CT heat rejected)";
   parameter Modelica.Units.SI.TemperatureDifference dTCHW_nominal=5.56
     "Temperature difference at chilled water side";
   parameter Modelica.Units.SI.TemperatureDifference dTCW_nominal=5.18
@@ -40,12 +40,12 @@ model ChillerPlant
     "Approach temperature for controlling cooling towers";
   parameter Real COP_nominal = datChi[1].COP_nominal "Chiller COP";
   parameter Modelica.Units.SI.MassFlowRate mCHW_flow_nominal[:]={-datChi[1].QEva_flow_nominal
-      /4200/5.56 for i in linspace(
+      /4200/dTCHW_nominal for i in linspace(
       1,
       n,
       n)} "Nominal mass flow rate at chilled water side";
   parameter Modelica.Units.SI.MassFlowRate mCW_flow_nominal[:]={
-      mCHW_flow_nominal[1]*(datChi[1].COP_nominal + 1)/datChi[1].COP_nominal
+      -datChi[1].QEva_flow_nominal*(COP_nominal + 1)/COP_nominal/4200/dTCW_nominal
       for i in linspace(
       1,
       n,
@@ -164,7 +164,7 @@ model ChillerPlant
         1,
         n,
         n)},
-    dp_nominal=dPCW_nominal*10)
+    dp_nominal=dPCW_nominal + dP_nominal + dPByp_nominal)
     annotation (Placement(transformation(extent={{-144,-102},{-116,-76}})));
   Buildings.Fluid.Storage.ExpansionVessel expVesCW(
       redeclare package Medium = MediumCW, V_start=1)

--- a/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/BaseClasses/HVACSide/BaseClasses/ChillerPlant.mo
+++ b/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/BaseClasses/HVACSide/BaseClasses/ChillerPlant.mo
@@ -428,6 +428,8 @@ MultizoneOfficeComplexAir.BaseClasses.HVACSide.BaseClasses.Component.WaterSide.C
 MultizoneOfficeComplexAir.BaseClasses.HVACSide.BaseClasses.Component.FlowMover.Pump.Control.SecPumCon</a> for a description of the chilled water secondary pump control. </p>
 </html>", revisions = "<html>
 <ul>
+<li> August 8, 2024, by Guowen Li, Xing Lu, Yan Chen: </li>
+<p> Adjusted system equipment sizing; Reduced nonlinear system warnings.</p>
 <li> August 17, 2023, by Xing Lu, Sen Huang, Lingzhe Wang:
 <p> First implementation.</p>
 </ul>

--- a/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/BaseClasses/HVACSide/BaseClasses/Component/AirSide/AirHandlingUnit/DuaFanAirHanUnit.mo
+++ b/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/BaseClasses/HVACSide/BaseClasses/Component/AirSide/AirHandlingUnit/DuaFanAirHanUnit.mo
@@ -122,7 +122,8 @@ model DuaFanAirHanUnit "AHU with supply/return fans and cooling coil."
                 MediumAir)
     "Fluid connector a (positive design flow direction is from port_a to port_b)"
     annotation (Placement(transformation(extent={{90,-90},{110,-70}})));
-  Modelica.Blocks.Interfaces.BooleanInput occ "occupied boolean signal"
+  Modelica.Blocks.Interfaces.BooleanInput onFanOcc
+    "Fan On signal during occupied period"
     annotation (Placement(transformation(extent={{-120,-110},{-100,-90}})));
   Modelica.Blocks.Interfaces.RealInput disTSet
     "Connector of setpoint input signal" annotation (Placement(
@@ -333,10 +334,10 @@ equation
           {8,-50},{8,12},{-0.2,12}},      color={255,0,255}));
   connect(mixBox.TOut, TOut) annotation (Line(points={{-54,-12},{-54,-80},
           {-110,-80}}, color={0,0,127}));
-  connect(occ, mixBox.On) annotation (Line(points={{-110,-100},{-68,-100},{-68,
-          -12}}, color={255,0,255}));
-  connect(occ, supFan.occ) annotation (Line(points={{-110,-100},{4,-100},{4,6},
-          {16,6}}, color={255,0,255}));
+  connect(onFanOcc, mixBox.On) annotation (Line(points={{-110,-100},{-68,-100},
+          {-68,-12}}, color={255,0,255}));
+  connect(onFanOcc, supFan.onFanOcc) annotation (Line(points={{-110,-100},{4,-100},
+          {4,6},{16,6}}, color={255,0,255}));
   connect(senTDisAir.T, TSupAir) annotation (Line(points={{82,6.6},{82,40},
           {110,40}},     color={0,0,127},
       pattern=LinePattern.Dash));

--- a/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/BaseClasses/HVACSide/BaseClasses/Component/AirSide/AirHandlingUnit/DuaFanAirHanUnit.mo
+++ b/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/BaseClasses/HVACSide/BaseClasses/Component/AirSide/AirHandlingUnit/DuaFanAirHanUnit.mo
@@ -72,8 +72,8 @@ model DuaFanAirHanUnit "AHU with supply/return fans and cooling coil."
     VolFloCur=VolFloCur,
     PreCur=SupPreCur)
     annotation (Placement(transformation(extent={{18,-10},{38,10}})));
-  Modelica.Fluid.Interfaces.FluidPort_b port_b_Air(redeclare package
-      Medium = MediumAir)
+  Modelica.Fluid.Interfaces.FluidPort_b port_b_Air(redeclare package Medium =
+               MediumAir)
     "Fluid connector b (positive design flow direction is from port_a to port_b)"
     annotation (Placement(transformation(extent={{90,-10},{110,10}})));
   MultizoneOfficeComplexAir.BaseClasses.HVACSide.BaseClasses.Component.AirSide.Coil.CoolingCoil
@@ -102,27 +102,27 @@ model DuaFanAirHanUnit "AHU with supply/return fans and cooling coil."
         extent={{-10,-10},{10,10}},
         rotation=90,
         origin={-60,0})));
-  Modelica.Fluid.Interfaces.FluidPort_a port_a_Wat(redeclare package
-      Medium =  MediumWat)
+  Modelica.Fluid.Interfaces.FluidPort_a port_a_Wat(redeclare package Medium =
+                MediumWat)
     "Fluid connector a (positive design flow direction is from port_a to port_b)"
     annotation (Placement(transformation(extent={{10,90},{30,110}})));
-  Modelica.Fluid.Interfaces.FluidPort_b port_b_Wat(redeclare package
-      Medium = MediumWat)
+  Modelica.Fluid.Interfaces.FluidPort_b port_b_Wat(redeclare package Medium =
+               MediumWat)
     "Fluid connector b (positive design flow direction is from port_a to port_b)"
     annotation (Placement(transformation(extent={{-50,90},{-30,110}})));
-  Modelica.Fluid.Interfaces.FluidPort_b port_Exh_Air(redeclare package
-      Medium =  MediumAir)
+  Modelica.Fluid.Interfaces.FluidPort_b port_Exh_Air(redeclare package Medium
+      =         MediumAir)
     "Fluid connector b (positive design flow direction is from port_a to port_b)"
     annotation (Placement(transformation(extent={{-112,-10},{-92,10}})));
-  Modelica.Fluid.Interfaces.FluidPort_a port_Fre_Air(redeclare package
-      Medium = MediumAir)
+  Modelica.Fluid.Interfaces.FluidPort_a port_Fre_Air(redeclare package Medium
+      =        MediumAir)
     "Fluid connector b (positive design flow direction is from port_a to port_b)"
     annotation (Placement(transformation(extent={{-110,50},{-90,70}})));
-  Modelica.Fluid.Interfaces.FluidPort_a port_a_Air(redeclare package
-      Medium =  MediumAir)
+  Modelica.Fluid.Interfaces.FluidPort_a port_a_Air(redeclare package Medium =
+                MediumAir)
     "Fluid connector a (positive design flow direction is from port_a to port_b)"
     annotation (Placement(transformation(extent={{90,-90},{110,-70}})));
-  Modelica.Blocks.Interfaces.BooleanInput On
+  Modelica.Blocks.Interfaces.BooleanInput occ "occupied boolean signal"
     annotation (Placement(transformation(extent={{-120,-110},{-100,-90}})));
   Modelica.Blocks.Interfaces.RealInput disTSet
     "Connector of setpoint input signal" annotation (Placement(
@@ -241,7 +241,7 @@ model DuaFanAirHanUnit "AHU with supply/return fans and cooling coil."
       unit="1"))
     annotation (Placement(transformation(extent={{48,-56},{64,-40}})));
   Buildings.Fluid.Sensors.TraceSubstancesTwoPort senCO2RetAir(redeclare package
-              Medium = MediumAir, m_flow_nominal=mAirFloRat,
+      Medium =         MediumAir, m_flow_nominal=mAirFloRat,
     C_start=400e-6*Modelica.Media.IdealGases.Common.SingleGasesData.CO2.MM/
         Modelica.Media.IdealGases.Common.SingleGasesData.Air.MM)
     "Sensor at AHU return air"
@@ -257,7 +257,7 @@ model DuaFanAirHanUnit "AHU with supply/return fans and cooling coil."
         transformation(extent={{100,-110},{120,-90}}), iconTransformation(
           extent={{100,-110},{120,-90}})));
   Buildings.Fluid.Sensors.TraceSubstancesTwoPort senCO2FreAir(redeclare package
-              Medium = MediumAir,
+      Medium =         MediumAir,
     allowFlowReversal=false,      m_flow_nominal=mAirFloRat,
     C_start=400e-6*Modelica.Media.IdealGases.Common.SingleGasesData.CO2.MM/
         Modelica.Media.IdealGases.Common.SingleGasesData.Air.MM)
@@ -286,7 +286,7 @@ model DuaFanAirHanUnit "AHU with supply/return fans and cooling coil."
         transformation(extent={{100,-148},{120,-128}}),
         iconTransformation(extent={{100,-132},{120,-112}})));
   Buildings.Fluid.Sensors.TraceSubstancesTwoPort senCO2SupAir(redeclare package
-              Medium = MediumAir, m_flow_nominal=mAirFloRat,
+      Medium =         MediumAir, m_flow_nominal=mAirFloRat,
     C_start=400e-6*Modelica.Media.IdealGases.Common.SingleGasesData.CO2.MM/
         Modelica.Media.IdealGases.Common.SingleGasesData.Air.MM)
     "Sensor at AHU supply air" annotation (Placement(transformation(
@@ -333,10 +333,10 @@ equation
           {8,-50},{8,12},{-0.2,12}},      color={255,0,255}));
   connect(mixBox.TOut, TOut) annotation (Line(points={{-54,-12},{-54,-80},
           {-110,-80}}, color={0,0,127}));
-  connect(On, mixBox.On) annotation (Line(points={{-110,-100},{-68,-100},
-          {-68,-12}}, color={255,0,255}));
-  connect(On, supFan.On) annotation (Line(points={{-110,-100},{4,-100},{4,6},{16,
-          6}},     color={255,0,255}));
+  connect(occ, mixBox.On) annotation (Line(points={{-110,-100},{-68,-100},{-68,
+          -12}}, color={255,0,255}));
+  connect(occ, supFan.occ) annotation (Line(points={{-110,-100},{4,-100},{4,6},
+          {16,6}}, color={255,0,255}));
   connect(senTDisAir.T, TSupAir) annotation (Line(points={{82,6.6},{82,40},
           {110,40}},     color={0,0,127},
       pattern=LinePattern.Dash));

--- a/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/BaseClasses/HVACSide/BaseClasses/Component/AirSide/Coil/CoolingCoil.mo
+++ b/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/BaseClasses/HVACSide/BaseClasses/Component/AirSide/Coil/CoolingCoil.mo
@@ -3,7 +3,8 @@ model CoolingCoil "The model of the cooling coil"
   extends
     MultizoneOfficeComplexAir.BaseClasses.HVACSide.BaseClasses.Component.AirSide.Coil.BaseClasses.WatCoil(      val(
         dpValve_nominal=PreDroWat, y_start=0.1),
-                                    pI(reverseActing=false, conPID(y_reset=1)));
+                                    pI(
+      yMin=0.01,                       reverseActing=false, conPID(y_reset=1)));
   parameter Real UA "Rated heat exchange coefficients";
 
   MultizoneOfficeComplexAir.BaseClasses.HVACSide.BaseClasses.Component.AirSide.Coil.BaseClasses.WetCoil coi(

--- a/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/BaseClasses/HVACSide/BaseClasses/Component/AirSide/ZoneTerminal/Examples.mo
+++ b/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/BaseClasses/HVACSide/BaseClasses/Component/AirSide/ZoneTerminal/Examples.mo
@@ -255,7 +255,7 @@ package Examples
     connect(Q_flow.y, fivZonVAV.Q_flow) annotation (Line(points={{-79,-50},{-48,
             -50},{-48,-18.8},{-30.5333,-18.8}},
                                         color={0,0,127}));
-    connect(booleanExpression.y, fivZonVAV.On) annotation (Line(points={{-49,-4},
+    connect(booleanExpression.y,fivZonVAV.on)  annotation (Line(points={{-49,-4},
             {-38,-4},{-38,-6.4},{-30.5333,-6.4}},                                                                 color={255,0,255}));
     connect(yVal.y, fivZonVAV.yVal) annotation (Line(points={{-79,22},{-40,22},
             {-40,8},{-30.5333,8}},

--- a/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/BaseClasses/HVACSide/BaseClasses/Component/AirSide/ZoneTerminal/FiveZoneVAV.mo
+++ b/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/BaseClasses/HVACSide/BaseClasses/Component/AirSide/ZoneTerminal/FiveZoneVAV.mo
@@ -221,10 +221,11 @@ model FiveZoneVAV "Thermal zones, VAV terminals, and duct network"
   Modelica.Blocks.Interfaces.RealInput yVal[5]
     "Actuator position (0: closed, 1: open)"
     annotation (Placement(transformation(extent={{-120,50},{-100,70}})));
-  Modelica.Blocks.Interfaces.BooleanInput On[5]
+  Modelica.Blocks.Interfaces.BooleanInput on[5]
+    "Zonal On signal (not implemented)"
     annotation (Placement(transformation(extent={{-120,-22},{-100,-2}})));
-  Modelica.Fluid.Sensors.TemperatureTwoPort TZonSen[5](redeclare package Medium =
-               MediumAir)
+  Modelica.Fluid.Sensors.TemperatureTwoPort TZonSen[5](redeclare package Medium
+      =        MediumAir)
     annotation (Placement(transformation(extent={{138,-68},{118,-48}})));
   Modelica.Blocks.Interfaces.RealOutput p "Pressure at port" annotation (
       Placement(transformation(extent={{200,-22},{220,-2}}),
@@ -370,7 +371,7 @@ model FiveZoneVAV "Thermal zones, VAV terminals, and duct network"
   Modelica.Blocks.Sources.RealExpression m_flow_infAir[4](y=m_flow_lea)
     "Infiltration nominal air flow rate"
     annotation (Placement(transformation(extent={{-86,-114},{-66,-94}})));
-  Modelica.Blocks.Sources.RealExpression schFac_infAir[4](y={if On[1] == true
+  Modelica.Blocks.Sources.RealExpression schFac_infAir[4](y={if on[1] == true
          then 0.25 else 1.0 for i in 1:4})
     "Schedule factor for infiltration air (refer to E+)"
     annotation (Placement(transformation(extent={{-86,-134},{-66,-114}})));
@@ -442,18 +443,18 @@ equation
       points={{191,80},{210,80}},
       color={0,0,127},
       pattern=LinePattern.Dash));
-  connect(On[2], vAV2.On) annotation (Line(points={{-110,-14},{18,-14},{18,0},{29,
+  connect(on[2], vAV2.On) annotation (Line(points={{-110,-14},{18,-14},{18,0},{29,
           0}}, color={255,0,255}));
-  connect(On[3], vAV3.On) annotation (Line(points={{-110,-12},{-72,-12},{
+  connect(on[3], vAV3.On) annotation (Line(points={{-110,-12},{-72,-12},{
           -72,-8},{56,-8},{56,0},{71,0}},
                               color={255,0,255}));
-  connect(On[4], vAV4.On) annotation (Line(points={{-110,-10},{-72,-10},{-72,-10},
+  connect(on[4], vAV4.On) annotation (Line(points={{-110,-10},{-72,-10},{-72,-10},
           {100,-10},{100,0},{117,0}},
                                  color={255,0,255}));
-  connect(On[5], vAV5.On) annotation (Line(points={{-110,-8},{-72,-8},{-72,-10},
+  connect(on[5], vAV5.On) annotation (Line(points={{-110,-8},{-72,-8},{-72,-10},
           {148,-10},{148,0},{157,0}},
                                  color={255,0,255}));
-  connect(On[1], vAV1.On) annotation (Line(points={{-110,-16},{-72,-16},{-72,0},
+  connect(on[1], vAV1.On) annotation (Line(points={{-110,-16},{-72,-16},{-72,0},
           {-11,0}},
                color={255,0,255}));
   connect(yVal[1], vAV1.yVal) annotation (Line(points={{-110,56},{-34,56},{-34,12},

--- a/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/BaseClasses/HVACSide/BaseClasses/Component/FlowMover/BaseClasses/FlowMover.mo
+++ b/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/BaseClasses/HVACSide/BaseClasses/Component/FlowMover/BaseClasses/FlowMover.mo
@@ -15,12 +15,10 @@ partial model FlowMover
     PreCur=PreCur,
     TimCon=TimCon)
     annotation (Placement(transformation(extent={{-18,-10},{2,10}})));
-  Modelica.Fluid.Sensors.TemperatureTwoPort temEnt(redeclare package
-      Medium =
+  Modelica.Fluid.Sensors.TemperatureTwoPort temEnt(redeclare package Medium =
         Medium)
     annotation (Placement(transformation(extent={{-80,-10},{-60,10}})));
-  Modelica.Fluid.Sensors.TemperatureTwoPort temLea(redeclare package
-      Medium =
+  Modelica.Fluid.Sensors.TemperatureTwoPort temLea(redeclare package Medium =
         Medium)
     annotation (Placement(transformation(extent={{30,-10},{50,10}})));
   Modelica.Fluid.Sensors.MassFlowRate masFloRat(redeclare package Medium =
@@ -38,7 +36,8 @@ partial model FlowMover
     annotation (Placement(transformation(extent={{90,-10},{110,10}})));
   Modelica.Blocks.Interfaces.RealOutput P "Electrical power consumed"
     annotation (Placement(transformation(extent={{100,30},{120,50}})));
-  Modelica.Blocks.Interfaces.BooleanInput On "On-off signal" annotation (Placement(transformation(extent={{-140,40},{-100,80}})));
+  Modelica.Blocks.Interfaces.BooleanInput occ "On-off signal"
+    annotation (Placement(transformation(extent={{-140,40},{-100,80}})));
   Modelica.Blocks.Interfaces.RealOutput Rat
     "Actual normalised pump speed that is used for computations"
     annotation (Placement(transformation(extent={{100,-70},{120,-50}})));

--- a/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/BaseClasses/HVACSide/BaseClasses/Component/FlowMover/BaseClasses/FlowMover.mo
+++ b/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/BaseClasses/HVACSide/BaseClasses/Component/FlowMover/BaseClasses/FlowMover.mo
@@ -36,7 +36,7 @@ partial model FlowMover
     annotation (Placement(transformation(extent={{90,-10},{110,10}})));
   Modelica.Blocks.Interfaces.RealOutput P "Electrical power consumed"
     annotation (Placement(transformation(extent={{100,30},{120,50}})));
-  Modelica.Blocks.Interfaces.BooleanInput occ "On-off signal"
+  Modelica.Blocks.Interfaces.BooleanInput onFanOcc "On-off signal"
     annotation (Placement(transformation(extent={{-140,40},{-100,80}})));
   Modelica.Blocks.Interfaces.RealOutput Rat
     "Actual normalised pump speed that is used for computations"

--- a/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/BaseClasses/HVACSide/BaseClasses/Component/FlowMover/Control/VAVDualFanControl.mo
+++ b/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/BaseClasses/HVACSide/BaseClasses/Component/FlowMover/Control/VAVDualFanControl.mo
@@ -17,7 +17,8 @@ model VAVDualFanControl
     Ti=Ti,
     conPID(y_reset=1))
     annotation (Placement(transformation(extent={{-60,36},{-40,56}})));
-  Modelica.Blocks.Interfaces.BooleanInput occ
+  Modelica.Blocks.Interfaces.BooleanInput onFanOcc
+    "Fan On signal during occupied period"
     annotation (Placement(transformation(extent={{-140,40},{-100,80}})));
   Modelica.Blocks.Interfaces.RealInput SetPoi
     "Connector of setpoint input signal"
@@ -27,7 +28,8 @@ model VAVDualFanControl
     annotation (Placement(transformation(extent={{-140,-40},{-100,0}})));
   Modelica.Blocks.Interfaces.RealOutput ySup "Connector of Real output signal"
     annotation (Placement(transformation(extent={{100,-10},{120,10}})));
-  Modelica.Blocks.Interfaces.BooleanInput CyclingOn
+  Modelica.Blocks.Interfaces.BooleanInput onFanUnocc
+    "Fan On signal during unoccupied period"
     annotation (Placement(transformation(extent={{-140,-80},{-100,-40}})));
   Modelica.Blocks.Logical.Not not1
     annotation (Placement(transformation(extent={{-62,0},{-42,20}})));
@@ -41,16 +43,15 @@ model VAVDualFanControl
   Modelica.Blocks.Math.BooleanToReal booToRea
     annotation (Placement(transformation(extent={{-20,-40},{0,-20}})));
 equation
-  connect(variableSpeed.On, occ) annotation (Line(points={{-62,52},{-80,52},{-80,
-          60},{-120,60}}, color={255,0,255}));
+  connect(variableSpeed.On, onFanOcc) annotation (Line(points={{-62,52},{-80,52},
+          {-80,60},{-120,60}}, color={255,0,255}));
   connect(variableSpeed.mea, Mea) annotation (Line(
       points={{-62,40},{-70,40},{-70,-20},{-120,-20}},
       color={0,0,127}));
-  connect(cyclingOn.CyclingOn, CyclingOn) annotation (Line(
-      points={{-62,-30},{-80,-30},{-80,-60},{-120,-60}},
-      color={255,0,255}));
-  connect(not1.u, occ) annotation (Line(points={{-64,10},{-80,10},{-80,60},{-120,
-          60}}, color={255,0,255}));
+  connect(cyclingOn.CyclingOn, onFanUnocc) annotation (Line(points={{-62,-30},{
+          -80,-30},{-80,-60},{-120,-60}}, color={255,0,255}));
+  connect(not1.u, onFanOcc) annotation (Line(points={{-64,10},{-80,10},{-80,60},
+          {-120,60}}, color={255,0,255}));
   connect(not1.y, cyclingOn.OnSigIn) annotation (Line(
       points={{-41,10},{-24,10},{-24,-8},{-80,-8},{-80,-26},{-62,-26}},
       color={255,0,255}));
@@ -64,8 +65,8 @@ equation
           38},{34,38}}, color={0,0,127}));
   connect(SetPoi, variableSpeed.set) annotation (Line(points={{-120,20},
           {-74,20},{-74,46},{-62,46}}, color={0,0,127}));
-  connect(occ, swi.u2) annotation (Line(points={{-120,60},{-80,60},{-80,28},{-20,
-          28},{-20,38},{10,38}}, color={255,0,255}));
+  connect(onFanOcc, swi.u2) annotation (Line(points={{-120,60},{-80,60},{-80,28},
+          {-20,28},{-20,38},{10,38}}, color={255,0,255}));
   connect(cyclingOn.OnSigOut, booToRea.u)
     annotation (Line(points={{-39,-30},{-22,-30}}, color={255,0,255}));
   connect(booToRea.y, swi.u3) annotation (Line(points={{1,-30},{6,-30},{6,

--- a/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/BaseClasses/HVACSide/BaseClasses/Component/FlowMover/Control/VAVDualFanControl.mo
+++ b/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/BaseClasses/HVACSide/BaseClasses/Component/FlowMover/Control/VAVDualFanControl.mo
@@ -17,7 +17,7 @@ model VAVDualFanControl
     Ti=Ti,
     conPID(y_reset=1))
     annotation (Placement(transformation(extent={{-60,36},{-40,56}})));
-  Modelica.Blocks.Interfaces.BooleanInput On
+  Modelica.Blocks.Interfaces.BooleanInput occ
     annotation (Placement(transformation(extent={{-140,40},{-100,80}})));
   Modelica.Blocks.Interfaces.RealInput SetPoi
     "Connector of setpoint input signal"
@@ -41,18 +41,16 @@ model VAVDualFanControl
   Modelica.Blocks.Math.BooleanToReal booToRea
     annotation (Placement(transformation(extent={{-20,-40},{0,-20}})));
 equation
-  connect(variableSpeed.On, On) annotation (Line(
-      points={{-62,52},{-80,52},{-80,60},{-120,60}},
-      color={255,0,255}));
+  connect(variableSpeed.On, occ) annotation (Line(points={{-62,52},{-80,52},{-80,
+          60},{-120,60}}, color={255,0,255}));
   connect(variableSpeed.mea, Mea) annotation (Line(
       points={{-62,40},{-70,40},{-70,-20},{-120,-20}},
       color={0,0,127}));
   connect(cyclingOn.CyclingOn, CyclingOn) annotation (Line(
       points={{-62,-30},{-80,-30},{-80,-60},{-120,-60}},
       color={255,0,255}));
-  connect(not1.u, On) annotation (Line(
-      points={{-64,10},{-80,10},{-80,60},{-120,60}},
-      color={255,0,255}));
+  connect(not1.u, occ) annotation (Line(points={{-64,10},{-80,10},{-80,60},{-120,
+          60}}, color={255,0,255}));
   connect(not1.y, cyclingOn.OnSigIn) annotation (Line(
       points={{-41,10},{-24,10},{-24,-8},{-80,-8},{-80,-26},{-62,-26}},
       color={255,0,255}));
@@ -66,8 +64,8 @@ equation
           38},{34,38}}, color={0,0,127}));
   connect(SetPoi, variableSpeed.set) annotation (Line(points={{-120,20},
           {-74,20},{-74,46},{-62,46}}, color={0,0,127}));
-  connect(On, swi.u2) annotation (Line(points={{-120,60},{-80,60},{-80,
-          28},{-20,28},{-20,38},{10,38}}, color={255,0,255}));
+  connect(occ, swi.u2) annotation (Line(points={{-120,60},{-80,60},{-80,28},{-20,
+          28},{-20,38},{10,38}}, color={255,0,255}));
   connect(cyclingOn.OnSigOut, booToRea.u)
     annotation (Line(points={{-39,-30},{-22,-30}}, color={255,0,255}));
   connect(booToRea.y, swi.u3) annotation (Line(points={{1,-30},{6,-30},{6,

--- a/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/BaseClasses/HVACSide/BaseClasses/Component/FlowMover/Pump/PumpSystem.mo
+++ b/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/BaseClasses/HVACSide/BaseClasses/Component/FlowMover/Pump/PumpSystem.mo
@@ -72,5 +72,28 @@ equation
           extent={{-100,100},{100,-100}},
           lineColor={0,0,127},
           fillColor={255,255,255},
-          fillPattern=FillPattern.Solid)}));
+          fillPattern=FillPattern.Solid),
+        Line(
+          points={{-94,0},{-16,0}},
+          color={0,0,255},
+          smooth=Smooth.None),
+        Line(
+          points={{90,0},{14,0}},
+          color={0,0,255},
+          smooth=Smooth.None),
+        Ellipse(
+          extent={{-28,28},{32,-30}},
+          lineColor={0,0,255},
+          fillColor={255,255,255},
+          fillPattern=FillPattern.Solid),
+        Polygon(
+          points={{32,0},{-16,-24},{-16,22},{32,0}},
+          lineColor={0,0,255},
+          smooth=Smooth.None,
+          fillColor={0,0,255},
+          fillPattern=FillPattern.Solid),
+        Text(
+          extent={{40,86},{-36,46}},
+          textColor={28,108,200},
+          textString="[n]")}));
 end PumpSystem;

--- a/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/BaseClasses/HVACSide/BaseClasses/Component/FlowMover/VAVSupFan.mo
+++ b/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/BaseClasses/HVACSide/BaseClasses/Component/FlowMover/VAVSupFan.mo
@@ -24,8 +24,8 @@ model VAVSupFan
         transformation(extent={{-140,-120},{-100,-80}})));
   Modelica.Blocks.Interfaces.RealOutput yRet "Output signal connector"
     annotation (Placement(transformation(extent={{100,-92},{120,-72}})));
-  Control.TemperatureCheck onFan(numTemp=numTemp)
-    "Circulation fan ON signal based on zonal temperature and setpoints"
+  Control.TemperatureCheck onFanUnocc(numTemp=numTemp)
+    "Circulation fan ON signal based on zonal temperature and setpoints during unoccupied period"
     annotation (Placement(transformation(extent={{-92,-50},{-72,-30}})));
   Modelica.Blocks.Interfaces.RealInput T[numTemp]
     "Connector of setpoint input signal" annotation (Placement(
@@ -76,21 +76,21 @@ equation
   connect(withoutMotor.P, P) annotation (Line(
       points={{3,6},{12,6},{20,6},{20,40},{110,40}},
       color={0,0,127}));
-  connect(occ, varSpe.occ)
+  connect(onFanOcc, varSpe.onFanOcc)
     annotation (Line(points={{-120,60},{-62,60}}, color={255,0,255}));
   connect(varSpe.SetPoi, pSet) annotation (Line(points={{-62,56},{-80,56},
           {-80,20},{-120,20}}, color={0,0,127}));
   connect(varSpe.Mea, pMea) annotation (Line(points={{-62,52},{-66,52},{-66,
           16},{-56,16},{-56,-100},{-120,-100}}, color={0,0,127}));
-  connect(onFan.Temp, T) annotation (Line(points={{-94,-40},{-100,-40},{-100,-60},
-          {-120,-60}}, color={0,0,127}));
-  connect(onFan.On, varSpe.CyclingOn) annotation (Line(points={{-71,-40},{-68,-40},
-          {-68,48},{-62,48}}, color={255,0,255}));
-  connect(onFan.CooSetPoi, cooTSet) annotation (Line(points={{-94,-34},{-98,-34},
-          {-98,-20},{-120,-20}}, color={0,0,127}));
-  connect(onFan.HeaSetPoi, heaTSet) annotation (Line(points={{-94,-46},{-98,-46},
-          {-98,-60},{-60,-60},{-60,34},{-88,34},{-88,100},{-120,100}}, color={0,
-          0,127}));
+  connect(onFanUnocc.Temp, T) annotation (Line(points={{-94,-40},{-100,-40},{-100,
+          -60},{-120,-60}}, color={0,0,127}));
+  connect(onFanUnocc.On, varSpe.onFanUnocc) annotation (Line(points={{-71,-40},
+          {-68,-40},{-68,48},{-62,48}}, color={255,0,255}));
+  connect(onFanUnocc.CooSetPoi, cooTSet) annotation (Line(points={{-94,-34},{-98,
+          -34},{-98,-20},{-120,-20}}, color={0,0,127}));
+  connect(onFanUnocc.HeaSetPoi, heaTSet) annotation (Line(points={{-94,-46},{-98,
+          -46},{-98,-60},{-60,-60},{-60,34},{-88,34},{-88,100},{-120,100}},
+        color={0,0,127}));
   connect(varSpe.ySup, oveSpeSupFan.u)
     annotation (Line(points={{-39,54},{-28,54}}, color={0,0,127}));
   connect(oveSpeSupFan.y, withoutMotor.u) annotation (Line(points={{-5,54},

--- a/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/BaseClasses/HVACSide/BaseClasses/Component/FlowMover/VAVSupFan.mo
+++ b/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/BaseClasses/HVACSide/BaseClasses/Component/FlowMover/VAVSupFan.mo
@@ -24,7 +24,8 @@ model VAVSupFan
         transformation(extent={{-140,-120},{-100,-80}})));
   Modelica.Blocks.Interfaces.RealOutput yRet "Output signal connector"
     annotation (Placement(transformation(extent={{100,-92},{120,-72}})));
-  Control.TemperatureCheck TChe(numTemp=numTemp)
+  Control.TemperatureCheck onFan(numTemp=numTemp)
+    "Circulation fan ON signal based on zonal temperature and setpoints"
     annotation (Placement(transformation(extent={{-92,-50},{-72,-30}})));
   Modelica.Blocks.Interfaces.RealInput T[numTemp]
     "Connector of setpoint input signal" annotation (Placement(
@@ -75,21 +76,21 @@ equation
   connect(withoutMotor.P, P) annotation (Line(
       points={{3,6},{12,6},{20,6},{20,40},{110,40}},
       color={0,0,127}));
-  connect(On, varSpe.On)
+  connect(occ, varSpe.occ)
     annotation (Line(points={{-120,60},{-62,60}}, color={255,0,255}));
   connect(varSpe.SetPoi, pSet) annotation (Line(points={{-62,56},{-80,56},
           {-80,20},{-120,20}}, color={0,0,127}));
   connect(varSpe.Mea, pMea) annotation (Line(points={{-62,52},{-66,52},{-66,
           16},{-56,16},{-56,-100},{-120,-100}}, color={0,0,127}));
-  connect(TChe.Temp, T) annotation (Line(points={{-94,-40},{-100,-40},{-100,
-          -60},{-120,-60}}, color={0,0,127}));
-  connect(TChe.On, varSpe.CyclingOn) annotation (Line(points={{-71,-40},{
-          -68,-40},{-68,48},{-62,48}}, color={255,0,255}));
-  connect(TChe.CooSetPoi, cooTSet) annotation (Line(points={{-94,-34},{-98,
-          -34},{-98,-20},{-120,-20}}, color={0,0,127}));
-  connect(TChe.HeaSetPoi, heaTSet) annotation (Line(points={{-94,-46},{-98,
-          -46},{-98,-60},{-60,-60},{-60,34},{-88,34},{-88,100},{-120,100}},
-        color={0,0,127}));
+  connect(onFan.Temp, T) annotation (Line(points={{-94,-40},{-100,-40},{-100,-60},
+          {-120,-60}}, color={0,0,127}));
+  connect(onFan.On, varSpe.CyclingOn) annotation (Line(points={{-71,-40},{-68,-40},
+          {-68,48},{-62,48}}, color={255,0,255}));
+  connect(onFan.CooSetPoi, cooTSet) annotation (Line(points={{-94,-34},{-98,-34},
+          {-98,-20},{-120,-20}}, color={0,0,127}));
+  connect(onFan.HeaSetPoi, heaTSet) annotation (Line(points={{-94,-46},{-98,-46},
+          {-98,-60},{-60,-60},{-60,34},{-88,34},{-88,100},{-120,100}}, color={0,
+          0,127}));
   connect(varSpe.ySup, oveSpeSupFan.u)
     annotation (Line(points={{-39,54},{-28,54}}, color={0,0,127}));
   connect(oveSpeSupFan.y, withoutMotor.u) annotation (Line(points={{-5,54},

--- a/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/BaseClasses/HVACSide/BaseClasses/Component/FlowMover/VariableSpeedMover.mo
+++ b/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/BaseClasses/HVACSide/BaseClasses/Component/FlowMover/VariableSpeedMover.mo
@@ -51,9 +51,8 @@ equation
   connect(variableSpeed.y, withoutMotor.u) annotation (Line(
       points={{-39,54},{-30,54},{-30,6},{-19,6}},
       color={0,0,127}));
-  connect(On, variableSpeed.On) annotation (Line(
-      points={{-120,60},{-62,60}},
-      color={255,0,255}));
+  connect(occ, variableSpeed.On)
+    annotation (Line(points={{-120,60},{-62,60}}, color={255,0,255}));
   connect(variableSpeed.set, SetPoi) annotation (Line(
       points={{-62,54},{-78,54},{-78,20},{-120,20}},
       color={0,0,127}));

--- a/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/BaseClasses/HVACSide/BaseClasses/Component/FlowMover/VariableSpeedMover.mo
+++ b/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/BaseClasses/HVACSide/BaseClasses/Component/FlowMover/VariableSpeedMover.mo
@@ -51,7 +51,7 @@ equation
   connect(variableSpeed.y, withoutMotor.u) annotation (Line(
       points={{-39,54},{-30,54},{-30,6},{-19,6}},
       color={0,0,127}));
-  connect(occ, variableSpeed.On)
+  connect(onFanOcc, variableSpeed.On)
     annotation (Line(points={{-120,60},{-62,60}}, color={255,0,255}));
   connect(variableSpeed.set, SetPoi) annotation (Line(
       points={{-62,54},{-78,54},{-78,20},{-120,20}},

--- a/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/BaseClasses/HVACSide/BaseClasses/Examples/AirsideFloor.mo
+++ b/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/BaseClasses/HVACSide/BaseClasses/Examples/AirsideFloor.mo
@@ -289,7 +289,7 @@ equation
       points={{-79,-96},{-34,-96},{-34,-18.25},{-25.5625,-18.25}},
       color={255,0,255},
       pattern=LinePattern.Dash));
-  connect(airsideFloor.occ, airsideFloor.onZon) annotation (Line(
+  connect(airsideFloor.onFanOcc, airsideFloor.onZon) annotation (Line(
       points={{-25.5625,-13},{-34,-13},{-34,-18.25},{-25.5625,-18.25}},
       color={255,0,255},
       pattern=LinePattern.Dash));

--- a/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/BaseClasses/HVACSide/BaseClasses/Examples/AirsideFloor.mo
+++ b/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/BaseClasses/HVACSide/BaseClasses/Examples/AirsideFloor.mo
@@ -285,11 +285,11 @@ equation
       points={{19,-50},{3.5,-50},{3.5,-21.75}},
       color={0,0,127},
       pattern=LinePattern.Dash));
-  connect(booleanExpression.y, airsideFloor.OnZon) annotation (Line(
+  connect(booleanExpression.y,airsideFloor.onZon)  annotation (Line(
       points={{-79,-96},{-34,-96},{-34,-18.25},{-25.5625,-18.25}},
       color={255,0,255},
       pattern=LinePattern.Dash));
-  connect(airsideFloor.OnFan, airsideFloor.OnZon) annotation (Line(
+  connect(airsideFloor.occ, airsideFloor.onZon) annotation (Line(
       points={{-25.5625,-13},{-34,-13},{-34,-18.25},{-25.5625,-18.25}},
       color={255,0,255},
       pattern=LinePattern.Dash));

--- a/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/BaseClasses/HVACSide/HVAC.mo
+++ b/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/BaseClasses/HVACSide/HVAC.mo
@@ -122,7 +122,8 @@ model HVAC "Full HVAC system that contains the air side and water side systems"
   Modelica.Blocks.Sources.Constant TCHWSupSet(k=273.15 + 5.56)
     "Chilled water supply temperature setpoint"
     annotation (Placement(transformation(extent={{-82,-30},{-62,-10}})));
-  Modelica.Blocks.Sources.RealExpression PHWPum(y=sum(boiWatPla.pumSecHW.P))
+  Modelica.Blocks.Sources.RealExpression PHWPum(y=max(0, boiWatPla.pumSecHW.P[1])
+         + max(0, boiWatPla.pumSecHW.P[2]))
     "Hot water pump power consumption"
     annotation (Placement(transformation(extent={{114,-54},{134,-34}})));
   Modelica.Blocks.Sources.RealExpression PBoi(y=boiWatPla.mulBoi.boi[1].boi.QFue_flow

--- a/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/BaseClasses/HVACSide/HVAC.mo
+++ b/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/BaseClasses/HVACSide/HVAC.mo
@@ -350,6 +350,8 @@ See the model <a href=\"modelica://MultizoneOfficeComplexAir.BaseClasses.HVACSid
 <p>The water side system controls include the chiller plant staging control, chilled water supply temperature control, secondary chilled water pump staging control, secondary chilled water loop static pressure control, cooling tower supply water temperature control, minimum condenser supply water temperature control, boiler staging control, boiler water temperature control, and boiler hot water loop static pressure control.</p>
 </html>", revisions = "<html>
 <ul>
+<li>August 8, 2024, by Guowen Li, Xing Lu, Yan Chen: </li>
+<p>Added CO2 and air infiltration features; Adjusted system equipment sizing; Reduced nonlinear system warnings.</p>
 <li> August 17, 2023, by Xing Lu, Sen Huang, Lingzhe Wang, Yan Chen:
 <p> First implementation.</p>
 </ul>

--- a/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/BaseClasses/HVACSide/HVAC.mo
+++ b/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/BaseClasses/HVACSide/HVAC.mo
@@ -41,16 +41,16 @@ model HVAC "Full HVAC system that contains the air side and water side systems"
 
   parameter Modelica.Units.SI.MassFlowRate mFloRat1=-datChi[1].QEva_flow_nominal
       /4200/chiWatPla.dTCHW_nominal*chiWatPla.n/12
-    "mass flow rate for floor 1 (bottom floor)";
+    "CHW mass flow rate for floor 1 (bottom floor)";
   parameter Modelica.Units.SI.MassFlowRate mFloRat2=-datChi[1].QEva_flow_nominal
       /4200/chiWatPla.dTCHW_nominal*chiWatPla.n/12*10
-    "mass flow rate for floor 2 (middle floor)";
+    "CHW mass flow rate for floor 2 (middle floor)";
   parameter Modelica.Units.SI.MassFlowRate mFloRat3=-datChi[1].QEva_flow_nominal
       /4200/chiWatPla.dTCHW_nominal*chiWatPla.n/12
-    "mass flow rate for floor 3 (top floor)";
+    "CHW mass flow rate for floor 3 (top floor)";
 
   parameter Modelica.Units.SI.MassFlowRate mCHW_flow_nominal[:]={-datChi[1].QEva_flow_nominal
-      /4200/5.56 for i in linspace(
+      /4200/chiWatPla.dTCHW_nominal for i in linspace(
       1,
       3,
       3)} "Nominal mass flow rate at chilled water side";
@@ -109,7 +109,8 @@ model HVAC "Full HVAC system that contains the air side and water side systems"
                              "Chilled water plant distribution network"
     annotation (Placement(transformation(extent={{20,-88},{40,-108}})));
   Buildings.Fluid.Chillers.Data.ElectricEIR.ElectricEIRChiller_Trane_CVHE_1442kW_6_61COP_VSD
-    datChi[3](each QEva_flow_nominal=-2500000) "Chiller data record"
+    datChi[3](each QEva_flow_nominal=-5500000/3)
+                                               "Chiller data record"
                                                annotation (Placement(transformation(extent={{-52,
             -106},{-32,-86}})));
 

--- a/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/BaseClasses/HVACSide/HVAC.mo
+++ b/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/BaseClasses/HVACSide/HVAC.mo
@@ -76,7 +76,7 @@ model HVAC "Full HVAC system that contains the air side and water side systems"
     PreDroBra2(displayUnit="Pa") = 0,
     PreDroBra3(displayUnit="Pa") = 0,
     PreDroMai1(displayUnit="Pa") = (79712/4),
-    PreDroMai2(displayUnit="Pa") = (79712/4),
+    PreDroMai2(displayUnit="Pa") = (79712/4/2),
     mFloRat1=boiWatPla.Cap[1]/4190/boiWatPla.dTHW_nominal*boiWatPla.n/12,
     mFloRat2=boiWatPla.Cap[1]/4190/boiWatPla.dTHW_nominal*boiWatPla.n/12*10,
     mFloRat3=boiWatPla.Cap[1]/4190/boiWatPla.dTHW_nominal*boiWatPla.n/12,
@@ -101,11 +101,11 @@ model HVAC "Full HVAC system that contains the air side and water side systems"
     mFloRat1=mFloRat1,
     mFloRat2=mFloRat2,
     mFloRat3=mFloRat3,
-    PreDroBra1(displayUnit="Pa") = 0,
+    PreDroBra1(displayUnit="Pa") = PreDroCooWat,
     PreDroBra2(displayUnit="Pa") = 0,
     PreDroBra3(displayUnit="Pa") = 0,
-    PreDroMai1=PreDroCooWat*2,
-    PreDroMai2(displayUnit="Pa") = 0)
+    PreDroMai1=PreDroCooWat,
+    PreDroMai2(displayUnit="Pa") = PreDroCooWat/2)
                              "Chilled water plant distribution network"
     annotation (Placement(transformation(extent={{20,-88},{40,-108}})));
   Buildings.Fluid.Chillers.Data.ElectricEIR.ElectricEIRChiller_Trane_CVHE_1442kW_6_61COP_VSD

--- a/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/BaseClasses/HVACSide/HVAC.mo
+++ b/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/BaseClasses/HVACSide/HVAC.mo
@@ -68,7 +68,9 @@ model HVAC "Full HVAC system that contains the air side and water side systems"
     "Medium model";
 
   MultizoneOfficeComplexAir.BaseClasses.HVACSide.BaseClasses.BoilerPlant
-    boiWatPla(secPumCon(conPI(k=0.001)), redeclare package MediumHW =
+    boiWatPla(
+    mHW_flow_nominal={62/2*alpha for i in linspace(1, n, n)},
+              secPumCon(conPI(k=0.001)), redeclare package MediumHW =
         MediumHeaWat,
         alpha=alpha) "Boiler hot water plant"
     annotation (Placement(transformation(extent={{116,-110},{136,-90}})));
@@ -79,9 +81,12 @@ model HVAC "Full HVAC system that contains the air side and water side systems"
     PreDroBra3(displayUnit="Pa") = 0,
     PreDroMai1(displayUnit="Pa") = (79712/4),
     PreDroMai2(displayUnit="Pa") = (79712/4/2),
-    mFloRat1=boiWatPla.Cap[1]/4190/boiWatPla.dTHW_nominal*boiWatPla.n/12,
-    mFloRat2=boiWatPla.Cap[1]/4190/boiWatPla.dTHW_nominal*boiWatPla.n/12*10,
-    mFloRat3=boiWatPla.Cap[1]/4190/boiWatPla.dTHW_nominal*boiWatPla.n/12,
+    mFloRat1=floor1.mWatFloRat1 + floor1.mWatFloRat2 + floor1.mWatFloRat3 +
+        floor1.mWatFloRat4 + floor1.mWatFloRat5,
+    mFloRat2=floor2.mWatFloRat1 + floor2.mWatFloRat2 + floor2.mWatFloRat3 +
+        floor2.mWatFloRat4 + floor2.mWatFloRat5,
+    mFloRat3=floor3.mWatFloRat1 + floor3.mWatFloRat2 + floor3.mWatFloRat3 +
+        floor3.mWatFloRat4 + floor3.mWatFloRat5,
     redeclare package Medium = MediumHeaWat,
     PreDroBra1(displayUnit="Pa") = (79712/4))
     "Hot water plant distribution network"

--- a/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/BaseClasses/HVACSide/HVAC.mo
+++ b/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/BaseClasses/HVACSide/HVAC.mo
@@ -69,7 +69,8 @@ model HVAC "Full HVAC system that contains the air side and water side systems"
 
   MultizoneOfficeComplexAir.BaseClasses.HVACSide.BaseClasses.BoilerPlant
     boiWatPla(secPumCon(conPI(k=0.001)), redeclare package MediumHW =
-        MediumHeaWat) "Boiler hot water plant"
+        MediumHeaWat,
+        alpha=alpha) "Boiler hot water plant"
     annotation (Placement(transformation(extent={{116,-110},{136,-90}})));
 
   MultizoneOfficeComplexAir.BaseClasses.HVACSide.BaseClasses.Component.WaterSide.Network.PipeNetwork

--- a/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/BaseClasses/HVACSide/HVAC.mo
+++ b/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/BaseClasses/HVACSide/HVAC.mo
@@ -1,6 +1,7 @@
 within MultizoneOfficeComplexAir.BaseClasses.HVACSide;
 model HVAC "Full HVAC system that contains the air side and water side systems"
   extends MultizoneOfficeComplexAir.BaseClasses.HVACSide.BaseClasses.Airside(
+      alpha=alpha,
       sou(nPorts=3),
       floor1(
       reaZonCor(zone="bot_floor_cor"),
@@ -38,6 +39,8 @@ model HVAC "Full HVAC system that contains the air side and water side systems"
       oveZonNor(zone="top_floor_nor"),
       oveZonWes(zone="top_floor_wes"),
       final mWatFloRat=mFloRat3));
+
+  parameter Real alpha = 1  "Sizing factor for overall system design capacity and mass flow rate";
 
   parameter Modelica.Units.SI.MassFlowRate mFloRat1=-datChi[1].QEva_flow_nominal
       /4200/chiWatPla.dTCHW_nominal*chiWatPla.n/12
@@ -109,7 +112,7 @@ model HVAC "Full HVAC system that contains the air side and water side systems"
                              "Chilled water plant distribution network"
     annotation (Placement(transformation(extent={{20,-88},{40,-108}})));
   Buildings.Fluid.Chillers.Data.ElectricEIR.ElectricEIRChiller_Trane_CVHE_1442kW_6_61COP_VSD
-    datChi[3](each QEva_flow_nominal=-5500000/3)
+    datChi[3](each QEva_flow_nominal=-5500000/3*alpha)
                                                "Chiller data record"
                                                annotation (Placement(transformation(extent={{-52,
             -106},{-32,-86}})));

--- a/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/BaseClasses/HVACSide/HVAC.mo
+++ b/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/BaseClasses/HVACSide/HVAC.mo
@@ -1,7 +1,7 @@
 within MultizoneOfficeComplexAir.BaseClasses.HVACSide;
 model HVAC "Full HVAC system that contains the air side and water side systems"
   extends MultizoneOfficeComplexAir.BaseClasses.HVACSide.BaseClasses.Airside(
-      alpha=alpha,
+      alpha=1,
       sou(nPorts=3),
       floor1(
       reaZonCor(zone="bot_floor_cor"),
@@ -39,8 +39,6 @@ model HVAC "Full HVAC system that contains the air side and water side systems"
       oveZonNor(zone="top_floor_nor"),
       oveZonWes(zone="top_floor_wes"),
       final mWatFloRat=mFloRat3));
-
-  parameter Real alpha = 1  "Sizing factor for overall system design capacity and mass flow rate";
 
   parameter Modelica.Units.SI.MassFlowRate mFloRat1=-datChi[1].QEva_flow_nominal
       /4200/chiWatPla.dTCHW_nominal*chiWatPla.n/12

--- a/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/BaseClasses/LoadSide/LoadWrapper.mo
+++ b/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/BaseClasses/LoadSide/LoadWrapper.mo
@@ -170,9 +170,12 @@ equation
     Documentation(info="<html>
 <p>This is an EnergyPlus (V9.6) wrapper model that calculates the building&rsquo;s thermal loads with the boundary conditions. The inputs are the zone air temperatures from Modelica that is responsible for the airflow calculation (e.g., building infiltration) and HVAC system and controls.</p>
 <p>See the model <a href=\"modelica://MultizoneOfficeComplexAir.BaseClasses.LoadSide.BaseClasses.WholeBuildingEnergyPlus\">MultizoneOfficeComplexAir.BaseClasses.LoadSide.BaseClasses.WholeBuildingEnergyPlus</a> for the EnergyPlus model.</p>
-</html>", revisions = "<html>
+</html>", revisions="<html>
 <ul>
-<li> August 17, 2023, by Xing Lu, Sen Huang, Lingzhe Wang, Yan Chen:
-<p> First implementation.</p>
-</ul>"));
+<li>August 8, 2024, by Guowen Li, Xing Lu, Yan Chen: </li>
+<p>Added weather bus.</p>
+<li>August 17, 2023, by Xing Lu, Sen Huang, Lingzhe Wang, Yan Chen: </li>
+<p>First implementation.</p>
+</ul>
+</html>"));
 end LoadWrapper;

--- a/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/TestCases/TestCase.mo
+++ b/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/TestCases/TestCase.mo
@@ -66,10 +66,12 @@ equation
 <p><span style=\"font-family: MS Shell Dlg 2;\">See the model <a href=\"modelica://MultizoneOfficeComplexAir.BaseClasses.HVACSide.HVAC\">MultizoneOfficeComplexAir.BaseClasses.HVACSide.HVAC</a> for a description of the HVAC system, and see the model <a href=\"modelica://MultizoneOfficeComplexAir.BaseClasses.LoadSide.LoadWrapper\">MultizoneOfficeComplexAir.BaseClasses.LoadSide.LoadWrapper</a> for a description of the building thermal load calculated by EnergyPlus. </span></p>
 <h4>Spawn Version</h4>
 <p>Please use version <i>spawn-0.3.0-8d93151657</i> for BOPTEST environment; and use version <i>spawn-0.3.0-0fa49be497</i> for running testcases with Modlelica Buildings library.</p>
-</html>", revisions = "<html>
+</html>", revisions="<html>
 <ul>
-<li> August 17, 2023, by Xing Lu, Sen Huang, Lingzhe Wang, Yan Chen:
-<p> First implementation.</p>
+<li>August 8, 2024, by Guowen Li, Xing Lu, Yan Chen: </li>
+<p>Added CO2 and air infiltration features; Adjusted system equipment sizing; Reduced nonlinear system warnings.</p>
+<li>August 17, 2023, by Xing Lu, Sen Huang, Lingzhe Wang, Yan Chen: </li>
+<p>First implementation.</p>
 </ul>
 </html>"),
     __Dymola_Commands(file="Resources/script/Testcase.mos"

--- a/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/TestCases/TestCase.mo
+++ b/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/TestCases/TestCase.mo
@@ -6,8 +6,8 @@ model TestCase "Complex office building model that includes air side systems, wa
     floor1(duaFanAirHanUni(
         mixBox(mixBox(
             valRet(riseTime=15, y_start=1),
-            valExh(riseTime=15, y_start=0),
-            valFre(riseTime=15, y_start=0))),
+            valExh(riseTime=15, y_start=1),
+            valFre(riseTime=15, y_start=1))),
         retFan(varSpeFloMov(use_inputFilter=true, y_start=0)),
         supFan(varSpe(variableSpeed(zerSpe(k=0))), withoutMotor(varSpeFloMov(
                 use_inputFilter=true, y_start=0))),
@@ -15,8 +15,8 @@ model TestCase "Complex office building model that includes air side systems, wa
     floor2(duaFanAirHanUni(
         mixBox(mixBox(
             valRet(riseTime=15, y_start=1),
-            valExh(riseTime=15, y_start=0),
-            valFre(riseTime=15, y_start=0))),
+            valExh(riseTime=15, y_start=1),
+            valFre(riseTime=15, y_start=1))),
         retFan(varSpeFloMov(use_inputFilter=true, y_start=0)),
         supFan(varSpe(variableSpeed(zerSpe(k=0))), withoutMotor(varSpeFloMov(
                 use_inputFilter=true, y_start=0))),
@@ -24,8 +24,8 @@ model TestCase "Complex office building model that includes air side systems, wa
     floor3(duaFanAirHanUni(
         mixBox(mixBox(
             valRet(riseTime=15, y_start=1),
-            valExh(riseTime=15, y_start=0),
-            valFre(riseTime=15, y_start=0))),
+            valExh(riseTime=15, y_start=1),
+            valFre(riseTime=15, y_start=1))),
         retFan(varSpeFloMov(use_inputFilter=true, y_start=0)),
         supFan(varSpe(variableSpeed(zerSpe(k=0))), withoutMotor(varSpeFloMov(
                 use_inputFilter=true, y_start=0))),
@@ -58,7 +58,7 @@ equation
         coordinateSystem(preserveAspectRatio=false)),
     experiment(
       StopTime=31536000,
-      Interval=3600,
+      Interval=60,
       Tolerance=1e-06,
       __Dymola_Algorithm="Cvode"),
     Documentation(info="<html>


### PR DESCRIPTION
Main changes:
1. Resized system equipment based on peak thermal loads:
- Boiler capacity = Peak heating load (4191kW) / Number of boiler (2)
- AHU fan pressure rise: to cover the maximum air system pressure drop (1.734 kPa)
- Chiller capacity = Peak cooling load (5500kW) / Number of chiller (3)
- Cooling tower (CT) is resized using the following procedure:
> Q_cond = Q_eva*(COP_nominal+1)/COP_nominal where Q_eva is chiller capacity and Q_cond is cooling tower capacity
> m_CW = Q_cond/cp/dTCW_nominal
> P_CT_fan = 0.015*Q_cond which assumes the specific fan power (SFP) is 0.015kW per 1kW of CT heat rejected

- Resized designed nominal water mass flow rates of CHW, CW, and HW.
- Added a top-level sizing factor (alpha) of the overall system design capacity.

2. To avoid initialization failure, set initial economizer damper positions as open.
3. To avoid confusion, separated fan ON signals by occupied (always on) and unoccupied (conditional on).
4. Bounded the HW pump power output to non-negative values.

Simulation results are shown below:

- Annual out door air dry bulb temperature:

![TDryBul_annual](https://github.com/user-attachments/assets/9a56f15d-bab3-42c8-be42-4716b8bcf845)

- Heating month (day 0 - 30):

![Heating_month_day0-30](https://github.com/user-attachments/assets/4d9ad9b9-f956-423e-8be5-931ea2274671)

- Shoulder month (day 60 - 90):

![Shoulder_month_day60-90](https://github.com/user-attachments/assets/2d5b79d4-9f27-4fbb-bffe-1b984656ec70)

- Cooling month (day 190 - 220):

![Cooling_month_day190-220](https://github.com/user-attachments/assets/3e0fe427-8d6f-432f-8910-08434dabdf63)

- One-year simulation:

![Annual_simulation_0](https://github.com/user-attachments/assets/3a095e3f-2dd9-4bbe-b7f8-05417740130a)
The associated files of one-year simulation are attached.
[dsin.txt](https://github.com/user-attachments/files/16564992/dsin.txt)
[dslog.txt](https://github.com/user-attachments/files/16565027/dslog.txt)
[dsfinal.txt](https://github.com/user-attachments/files/16565816/dsfinal.txt)


