### PR TITLE
Add scripts of training data generation & Update sizing information & Add more measurements in read blocks

### DIFF
--- a/examples/python/controllers/perturb_multizone_office_complex_air.py
+++ b/examples/python/controllers/perturb_multizone_office_complex_air.py
@@ -1,0 +1,107 @@
+# -*- coding: utf-8 -*-
+"""
+This module implements a simple P controller of heater power control specifically
+for testcase1.
+
+"""
+import numpy.random as random
+
+# Set the global random seed
+random.seed(42)
+
+# excite signal: - generator for exciting signals
+def uniform_real(a,b):
+    return (b-a)*random.random_sample()+a
+
+def uniform_int(a,b):
+    return random.randint(a,b)
+
+def compute_control(y, forecasts=None):
+    """Compute the control input from the measurement.
+
+    Parameters
+    ----------
+    y : dict
+        Contains the current values of the measurements.
+        {<measurement_name>:<measurement_value>}
+    forecasts : structure depends on controller, optional
+        Forecasts used to calculate control.
+        Default is None.
+
+    Returns
+    -------
+    u : dict
+        Defines the control input to be used for the next step.
+        {<input_name> : <input_value>}
+
+    """
+    TzonCooSet = uniform_int(13,30) # Celsius
+    u = {
+        'hva_floor1_TSupAirSet_u': 273.15 + uniform_int(12,20), # or uniform_real(12,20)
+        'hva_floor1_TSupAirSet_activate': 1,
+        'hva_floor1_oveZonCor_TZonCooSet_u': 273.15 + TzonCooSet,
+        'hva_floor1_oveZonCor_TZonCooSet_activate': 1,
+        'hva_floor1_oveZonCor_TZonHeaSet_u': 273.15 + uniform_int(12,TzonCooSet), # ensure Heating setpoint is lower than Cooling setpoint
+        'hva_floor1_oveZonCor_TZonHeaSet_activate': 1,
+        #'hva_floor1_fivZonVAV_vAV1_oveZonLoc_yDam_u': uniform_real(0.3,1),
+        #'hva_floor1_fivZonVAV_vAV1_oveZonLoc_yDam_activate': 1,
+        #'hva_floor1_fivZonVAV_vAV1_oveZonLoc_yReaHea_u': uniform_real(0.005,1),
+        #'hva_floor1_fivZonVAV_vAV1_oveZonLoc_yReaHea_activate': 1,
+        'hva_floor2_TSupAirSet_u': 273.15 + uniform_int(12,20),
+        'hva_floor2_TSupAirSet_activate': 1,
+        'hva_floor2_oveZonCor_TZonCooSet_u': 273.15 + TzonCooSet,
+        'hva_floor2_oveZonCor_TZonCooSet_activate': 1,
+        'hva_floor2_oveZonCor_TZonHeaSet_u': 273.15 + uniform_int(12,TzonCooSet),
+        'hva_floor2_oveZonCor_TZonHeaSet_activate': 1,
+        'hva_floor3_TSupAirSet_u': 273.15 + uniform_int(12,20),
+        'hva_floor3_TSupAirSet_activate': 1,
+        'hva_floor3_oveZonCor_TZonCooSet_u': 273.15 + TzonCooSet,
+        'hva_floor3_oveZonCor_TZonCooSet_activate': 1,
+        'hva_floor3_oveZonCor_TZonHeaSet_u': 273.15 + uniform_int(12,TzonCooSet),
+        'hva_floor3_oveZonCor_TZonHeaSet_activate': 1,
+    }
+
+    return u
+
+
+def initialize():
+    """Initialize the control input u.
+
+    Parameters
+    ----------
+    None
+
+    Returns
+    -------
+    u : dict
+        Defines the control input to be used for the next step.
+        {<input_name> : <input_value>}
+
+    """
+
+    u = {
+        'hva_floor1_TSupAirSet_u': 273.15 + 12,
+        'hva_floor1_TSupAirSet_activate': 1,
+        'hva_floor1_oveZonCor_TZonCooSet_u': 273.15 + 24,
+        'hva_floor1_oveZonCor_TZonCooSet_activate': 1,
+        'hva_floor1_oveZonCor_TZonHeaSet_u': 273.15 + 20,
+        'hva_floor1_oveZonCor_TZonHeaSet_activate': 1,
+        #'hva_floor1_fivZonVAV_vAV1_oveZonLoc_yDam_u': 1.0,
+        #'hva_floor1_fivZonVAV_vAV1_oveZonLoc_yDam_activate': 1,
+        #'hva_floor1_fivZonVAV_vAV1_oveZonLoc_yReaHea_u': 0.01,
+        #'hva_floor1_fivZonVAV_vAV1_oveZonLoc_yReaHea_activate': 1,
+        'hva_floor2_TSupAirSet_u': 273.15 + 12,
+        'hva_floor2_TSupAirSet_activate': 1,
+        'hva_floor2_oveZonCor_TZonCooSet_u': 273.15 + 24,
+        'hva_floor2_oveZonCor_TZonCooSet_activate': 1,
+        'hva_floor2_oveZonCor_TZonHeaSet_u': 273.15 + 20,
+        'hva_floor2_oveZonCor_TZonHeaSet_activate': 1,  
+        'hva_floor3_TSupAirSet_u': 273.15 + 12,
+        'hva_floor3_TSupAirSet_activate': 1,
+        'hva_floor3_oveZonCor_TZonCooSet_u': 273.15 + 24,
+        'hva_floor3_oveZonCor_TZonCooSet_activate': 1,
+        'hva_floor3_oveZonCor_TZonHeaSet_u': 273.15 + 20,
+        'hva_floor3_oveZonCor_TZonHeaSet_activate': 1,              
+    }
+
+    return u

--- a/examples/python/controllers/perturb_multizone_office_complex_air.py
+++ b/examples/python/controllers/perturb_multizone_office_complex_air.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-This module implements a simple P controller of heater power control specifically
-for testcase1.
+This module implements a signal generator specifically for `multizone_office_complex_air`.
 
 """
 import numpy.random as random
@@ -35,29 +34,31 @@ def compute_control(y, forecasts=None):
         {<input_name> : <input_value>}
 
     """
+    TSupSet = uniform_int(12,20) # or uniform_real(12,20)
     TzonCooSet = uniform_int(13,30) # Celsius
+    TzonHeaSet = uniform_int(12,TzonCooSet) # ensure Heating setpoint is lower than Cooling setpoint
     u = {
-        'hva_floor1_TSupAirSet_u': 273.15 + uniform_int(12,20), # or uniform_real(12,20)
+        'hva_floor1_TSupAirSet_u': 273.15 + TSupSet, 
         'hva_floor1_TSupAirSet_activate': 1,
         'hva_floor1_oveZonCor_TZonCooSet_u': 273.15 + TzonCooSet,
         'hva_floor1_oveZonCor_TZonCooSet_activate': 1,
-        'hva_floor1_oveZonCor_TZonHeaSet_u': 273.15 + uniform_int(12,TzonCooSet), # ensure Heating setpoint is lower than Cooling setpoint
+        'hva_floor1_oveZonCor_TZonHeaSet_u': 273.15 + TzonHeaSet, 
         'hva_floor1_oveZonCor_TZonHeaSet_activate': 1,
         #'hva_floor1_fivZonVAV_vAV1_oveZonLoc_yDam_u': uniform_real(0.3,1),
         #'hva_floor1_fivZonVAV_vAV1_oveZonLoc_yDam_activate': 1,
         #'hva_floor1_fivZonVAV_vAV1_oveZonLoc_yReaHea_u': uniform_real(0.005,1),
         #'hva_floor1_fivZonVAV_vAV1_oveZonLoc_yReaHea_activate': 1,
-        'hva_floor2_TSupAirSet_u': 273.15 + uniform_int(12,20),
+        'hva_floor2_TSupAirSet_u': 273.15 + TSupSet,
         'hva_floor2_TSupAirSet_activate': 1,
         'hva_floor2_oveZonCor_TZonCooSet_u': 273.15 + TzonCooSet,
         'hva_floor2_oveZonCor_TZonCooSet_activate': 1,
-        'hva_floor2_oveZonCor_TZonHeaSet_u': 273.15 + uniform_int(12,TzonCooSet),
+        'hva_floor2_oveZonCor_TZonHeaSet_u': 273.15 + TzonHeaSet,
         'hva_floor2_oveZonCor_TZonHeaSet_activate': 1,
-        'hva_floor3_TSupAirSet_u': 273.15 + uniform_int(12,20),
+        'hva_floor3_TSupAirSet_u': 273.15 + TSupSet,
         'hva_floor3_TSupAirSet_activate': 1,
         'hva_floor3_oveZonCor_TZonCooSet_u': 273.15 + TzonCooSet,
         'hva_floor3_oveZonCor_TZonCooSet_activate': 1,
-        'hva_floor3_oveZonCor_TZonHeaSet_u': 273.15 + uniform_int(12,TzonCooSet),
+        'hva_floor3_oveZonCor_TZonHeaSet_u': 273.15 + TzonHeaSet,
         'hva_floor3_oveZonCor_TZonHeaSet_activate': 1,
     }
 

--- a/examples/python/interface.py
+++ b/examples/python/interface.py
@@ -142,7 +142,7 @@ def control_test(control_module='', start_time=0, warmup_period=0, length=24*360
         # Record test simulation start time
         start_time = int(res['time'])
         # Set final time and total time steps to be very large since scenario defines length
-        final_time = np.inf
+        final_time = 1e308 # using np.inf may cause InvalidJSONError: Out of range float values are not JSON compliant
         total_time_steps = int((365 * 24 * 3600)/step)
     else:
         # Initialize test with a specified start time and warmup period

--- a/examples/python/multizone_office_complex_air_excitations.py
+++ b/examples/python/multizone_office_complex_air_excitations.py
@@ -1,0 +1,147 @@
+# -*- coding: utf-8 -*-
+"""
+This script demonstrates a minimalistic example of testing a feedback controller
+using the scenario options with the prototype test case called "testcase1".
+
+"""
+"""
+This script demonstrates a minimalistic example of testing a feedback controller
+with the prototype test case called "testcase1".  It uses the testing
+interface implemented in interface.py and the concrete controller implemented
+in controllers/pid.py.
+
+"""
+
+# GENERAL PACKAGE IMPORT
+# ----------------------
+import sys
+import os
+sys.path.insert(0, os.path.sep.join(os.path.dirname(os.path.abspath(__file__)).split(os.path.sep)[:-2]))
+from examples.python.interface import control_test
+
+
+def run(plot=False):
+    """Run test case.
+    Parameters
+    ----------
+    plot : bool, optional
+        True to plot timeseries results.
+        Default is False.
+
+    Returns
+    -------
+    kpi : dict
+        Dictionary of core KPI names and values.
+        {kpi_name : value}
+    res : dict
+        Dictionary of trajectories of inputs and outputs.
+    custom_kpi_result: dict
+        Dictionary of tracked custom KPI calculations.
+        Empty if no customized KPI calculations defined.
+
+    """
+
+    # RUN THE CONTROL TEST
+    # --------------------
+    control_module = 'examples.python.controllers.perturb_multizone_office_complex_air'
+
+    # ---------------------------------------
+
+    # RUN THE CONTROL TEST
+    # --------------------
+    kpi, df_res, custom_kpi_result, forecasts = control_test(control_module,
+                                                             start_time=0,
+                                                             warmup_period=0,
+                                                             length=7*24*3600,
+                                                             step=60*60)
+
+    # POST-PROCESS RESULTS
+    # --------------------
+    time = df_res.index.values / 3600  # convert s --> hr
+    # Floor data processing function
+    def process_floor_data(floor):
+        zone_temperature_core = df_res[f'hva_{floor}_reaZonCor_TZon_y'].values - 273.15  # convert K --> C
+        zone_temperature_south = df_res[f'hva_{floor}_reaZonSou_TZon_y'].values - 273.15
+        zone_temperature_east = df_res[f'hva_{floor}_reaZonEas_TZon_y'].values - 273.15
+        zone_temperature_north = df_res[f'hva_{floor}_reaZonNor_TZon_y'].values - 273.15
+        zone_temperature_west = df_res[f'hva_{floor}_reaZonWes_TZon_y'].values - 273.15
+        zone_temperature_cooSet = df_res[f'hva_{floor}_reaZonCor_TRoo_Coo_set_y'].values - 273.15
+        zone_temperature_heaSet = df_res[f'hva_{floor}_reaZonCor_TRoo_Hea_set_y'].values - 273.15
+        return (zone_temperature_core, zone_temperature_south, zone_temperature_east,
+                zone_temperature_north, zone_temperature_west, zone_temperature_cooSet, zone_temperature_heaSet)
+    # Process data for each floor
+    floor1_data = process_floor_data('floor1')
+    floor2_data = process_floor_data('floor2')
+    floor3_data = process_floor_data('floor3')
+    # Plot results
+    if plot:
+        try:
+            from matplotlib import pyplot as plt
+            plt.figure(figsize=(14, 10))
+
+            # Plot for Floor 1
+            plt.subplot(3, 1, 1)
+            plt.title('Zone Temperature - Floor 1')
+            plt.plot(time, floor1_data[0], color='red', label='Core')
+            plt.plot(time, floor1_data[1], color='blue', label='South')
+            plt.plot(time, floor1_data[2], color='green', label='East')
+            plt.plot(time, floor1_data[3], color='darkcyan', label='North')
+            plt.plot(time, floor1_data[4], color='magenta', label='West')
+            plt.plot(time, floor1_data[5], '--', color='black', label='Cooling Setpoint')
+            plt.plot(time, floor1_data[6], '--', color='gray', label='Heating Setpoint')
+            plt.ylabel('Temperature [C]')
+            plt.legend(loc='upper right', fontsize='small')
+
+            # Plot for Floor 2
+            plt.subplot(3, 1, 2)
+            plt.title('Zone Temperature - Floor 2')
+            plt.plot(time, floor2_data[0], color='red', label='Core')
+            plt.plot(time, floor2_data[1], color='blue', label='South')
+            plt.plot(time, floor2_data[2], color='green', label='East')
+            plt.plot(time, floor2_data[3], color='darkcyan', label='North')
+            plt.plot(time, floor2_data[4], color='magenta', label='West')
+            plt.plot(time, floor2_data[5], '--', color='black', label='Cooling Setpoint')
+            plt.plot(time, floor2_data[6], '--', color='gray', label='Heating Setpoint')
+            plt.ylabel('Temperature [C]')
+            plt.legend(loc='upper right', fontsize='small')
+
+            # Plot for Floor 3
+            plt.subplot(3, 1, 3)
+            plt.title('Zone Temperature - Floor 3')
+            plt.plot(time, floor3_data[0], color='red', label='Core')
+            plt.plot(time, floor3_data[1], color='blue', label='South')
+            plt.plot(time, floor3_data[2], color='green', label='East')
+            plt.plot(time, floor3_data[3], color='darkcyan', label='North')
+            plt.plot(time, floor3_data[4], color='magenta', label='West')
+            plt.plot(time, floor3_data[5], '--', color='black', label='Cooling Setpoint')
+            plt.plot(time, floor3_data[6], '--', color='gray', label='Heating Setpoint')
+            plt.ylabel('Temperature [C]')
+            plt.xlabel('Time [hr]')
+            plt.legend(loc='upper right', fontsize='small')
+
+            plt.tight_layout()
+            plt.show()
+        except ImportError:
+            print("Cannot import numpy or matplotlib for plot generation")
+
+    return kpi, df_res, custom_kpi_result
+
+
+if __name__ == "__main__":
+    kpi, df_res, custom_kpi_result = run(plot=True)
+    
+    # SAVE TRAINING DATASET
+    # --------------------
+    outfilename = 'training.csv'
+    if os.path.exists(outfilename):
+        overwrite = input(f"The file {outfilename} already exists. Overwrite? (y/n): ")
+        if overwrite.lower() == 'y':
+            df_res.to_csv(outfilename, index=True)
+            print(f'File overwritten as {outfilename}')
+        else:
+            new_outfilename = input("Enter a new filename (with .csv extension): ")
+            df_res.to_csv(new_outfilename, index=True)
+            print(f'File saved as {new_outfilename}')
+    else:
+        df_res.to_csv(outfilename, index=True)
+        print(f'File saved as {outfilename}')

--- a/examples/python/multizone_office_complex_air_excitations.py
+++ b/examples/python/multizone_office_complex_air_excitations.py
@@ -67,8 +67,9 @@ def run(plot=False):
         zone_temperature_west = df_res[f'hva_{floor}_reaZonWes_TZon_y'].values - 273.15
         zone_temperature_cooSet = df_res[f'hva_{floor}_reaZonCor_TRoo_Coo_set_y'].values - 273.15
         zone_temperature_heaSet = df_res[f'hva_{floor}_reaZonCor_TRoo_Hea_set_y'].values - 273.15
-        return (zone_temperature_core, zone_temperature_south, zone_temperature_east,
-                zone_temperature_north, zone_temperature_west, zone_temperature_cooSet, zone_temperature_heaSet)
+        ahu_temperature_supSet = df_res[f'hva_{floor}_reaAhu_TSup_set_y'].values - 273.15
+        return (zone_temperature_core, zone_temperature_south, zone_temperature_east, zone_temperature_north, 
+                zone_temperature_west, zone_temperature_cooSet, zone_temperature_heaSet, ahu_temperature_supSet)
     # Process data for each floor
     floor1_data = process_floor_data('floor1')
     floor2_data = process_floor_data('floor2')
@@ -89,6 +90,7 @@ def run(plot=False):
             plt.plot(time, floor1_data[4], color='magenta', label='West')
             plt.plot(time, floor1_data[5], '--', color='black', label='Cooling Setpoint')
             plt.plot(time, floor1_data[6], '--', color='gray', label='Heating Setpoint')
+            plt.plot(time, floor1_data[7], '--', color='red', label='AHU Supply Setpoint')
             plt.ylabel('Temperature [C]')
             plt.legend(loc='upper right', fontsize='small')
 
@@ -102,6 +104,7 @@ def run(plot=False):
             plt.plot(time, floor2_data[4], color='magenta', label='West')
             plt.plot(time, floor2_data[5], '--', color='black', label='Cooling Setpoint')
             plt.plot(time, floor2_data[6], '--', color='gray', label='Heating Setpoint')
+            plt.plot(time, floor2_data[7], '--', color='red', label='AHU Supply Setpoint')
             plt.ylabel('Temperature [C]')
             plt.legend(loc='upper right', fontsize='small')
 
@@ -115,6 +118,7 @@ def run(plot=False):
             plt.plot(time, floor3_data[4], color='magenta', label='West')
             plt.plot(time, floor3_data[5], '--', color='black', label='Cooling Setpoint')
             plt.plot(time, floor3_data[6], '--', color='gray', label='Heating Setpoint')
+            plt.plot(time, floor3_data[7], '--', color='red', label='AHU Supply Setpoint')
             plt.ylabel('Temperature [C]')
             plt.xlabel('Time [hr]')
             plt.legend(loc='upper right', fontsize='small')

--- a/examples/python/testcase1_scenario.py
+++ b/examples/python/testcase1_scenario.py
@@ -16,7 +16,7 @@ in controllers/pid.py.
 # ----------------------
 import sys
 import os
-sys.path.insert(0, '/'.join((os.path.dirname(os.path.abspath(__file__))).split('/')[:-2]))
+sys.path.insert(0, os.path.sep.join(os.path.dirname(os.path.abspath(__file__)).split(os.path.sep)[:-2]))
 from examples.python.interface import control_test
 
 

--- a/testcases/multizone_office_complex_air/doc/index.html
+++ b/testcases/multizone_office_complex_air/doc/index.html
@@ -336,19 +336,19 @@
       <tr>
         <td>Bot Floor Cooling Coil</td>
         <td>458,333</td>
-        <td>26.7</td>
+        <td>19.6</td>
         <td>65.844</td>
       </tr>
       <tr>
         <td>Mid Floor Cooling Coil</td>
         <td>4,583,333</td>
-        <td>267</td>
+        <td>196</td>
         <td>658.44</td>
       </tr>
       <tr>
         <td>Top Floor Cooling Coil</td>
         <td>458,333</td>
-        <td>26.7</td>
+        <td>19.6</td>
         <td>65.844</td>
       </tr>
     </tbody>
@@ -432,19 +432,19 @@
               <tr>
                 <td>CHW Primary Pumps 1-3</td>
                 <td>Constant speed</td>
-                <td>107</td>
+                <td>78.5</td>
                 <td>211,000</td>
                 <td>0.87</td>
-                <td>25,951</td>
+                <td>19,039</td>
               </tr>
         
               <tr>
                 <td>CHW Secondary Pumps 1-2</td>
                 <td>Variable speed</td>
-                <td>161</td>
+                <td>117</td>
                 <td>478,000</td>
                 <td>0.88</td>
-                <td>87,452</td>
+                <td>63,552</td>
               </tr>
 
 
@@ -452,10 +452,10 @@
               <tr>
                 <td>CW Pumps 1-3</td>
                 <td>Variable speed</td>
-                <td>123</td>
+                <td>90.3</td>
                 <td>571,100</td>
                 <td>0.87</td>
-                <td>80,742</td>
+                <td>59,276</td>
               </tr>
         
               <tr>
@@ -484,8 +484,8 @@
                 <tbody>
                   <tr>
                     <td>Chillers 1-3</td>
-                    <td>107</td>
-          <td>123</td>
+                    <td>78.5</td>
+          <td>90.3</td>
                     <td>1,834,000</td>
 
 
@@ -501,15 +501,15 @@
                     <thead>
                       <tr>
                         <th>Boilers</th>
-                        <th>Design Size Nominal Capacity [W]</th>
-                        <th>Design Size Design Water Mass Flow Rate [kg/s]</th>
+                        <th>Design Hot Water Mass Flow Rate [kg/s]</th>
+                        <th>Design Capacity [W]</th>
                       </tr>
                     </thead>
                     <tbody>
                       <tr>
                         <td>Boiler 1-2</td>
-                        <td>2,100,000</td>
                         <td>31.2</td>
+                        <td>2,100,000</td>
                       </tr>
 
 
@@ -522,15 +522,13 @@
                           <tr>
                             <th>Cooling Towers</th>
                             <th>Design Water Mass Flow Rate [kg/s]</th>
-              <th>Design Air Mass Flow Rate [kg/s]</th>
                             <th>Fan Power at Design Air Flow Rate [W]</th>
                           </tr>
                         </thead>
                         <tbody>
                           <tr>
                             <td>Cooling Towers 1-2</td>
-                            <td>123</td>
-              <td>220</td>
+                            <td>90.3</td>
                             <td>32,000</td>
                           </tr>
 

--- a/testcases/multizone_office_complex_air/doc/index.html
+++ b/testcases/multizone_office_complex_air/doc/index.html
@@ -798,268 +798,268 @@
     The model inputs are:
     <ul>
         <li>
-            <code>hvac_floor1_TSupAirSet_u</code> [K] [min=285.15, max=313.15]: Supply air temperature setpoint for AHU of floor 1
+            <code>hva_floor1_TSupAirSet_u</code> [K] [min=285.15, max=313.15]: Supply air temperature setpoint for AHU of floor 1
             </li>
             <li>
-            <code>hvac_floor1_dpSet_u</code> [Pa] [min=50.0, max=410.0]: Supply duct pressure setpoint for AHU of floor 1
+            <code>hva_floor1_dpSet_u</code> [Pa] [min=50.0, max=410.0]: Supply duct pressure setpoint for AHU of floor 1
             </li>
             <li>
-            <code>hvac_floor1_duaFanAirHanUnit_cooCoil_yCoo_u</code> [1] [min=0.0, max=1.0]: Cooling coil valve control signal for AHU of floor 1 
+            <code>hva_floor1_duaFanAirHanUnit_cooCoil_yCoo_u</code> [1] [min=0.0, max=1.0]: Cooling coil valve control signal for AHU of floor 1 
             </li>
             <li>
-            <code>hvac_floor1_duaFanAirHanUnit_mixingBox_mixBox_yEA_u</code> [1] [min=0.0, max=1.0]: Exhaust air damper position setpoint for AHU of floor 1
+            <code>hva_floor1_duaFanAirHanUnit_mixingBox_mixBox_yEA_u</code> [1] [min=0.0, max=1.0]: Exhaust air damper position setpoint for AHU of floor 1
             </li>
             <li>
-            <code>hvac_floor1_duaFanAirHanUnit_mixingBox_mixBox_yOA_u</code> [1] [min=0.0, max=1.0]: Outside air damper position setpoint for AHU of floor 1
+            <code>hva_floor1_duaFanAirHanUnit_mixingBox_mixBox_yOA_u</code> [1] [min=0.0, max=1.0]: Outside air damper position setpoint for AHU of floor 1
             </li>
             <li>
-            <code>hvac_floor1_duaFanAirHanUnit_mixingBox_mixBox_yRet_u</code> [1] [min=0.0, max=1.0]: Return air damper position setpoint for AHU of floor 1
+            <code>hva_floor1_duaFanAirHanUnit_mixingBox_mixBox_yRet_u</code> [1] [min=0.0, max=1.0]: Return air damper position setpoint for AHU of floor 1
             </li>
             <li>
-            <code>hvac_floor1_duaFanAirHanUnit_oveSpeRetFan_u</code> [1] [min=0.0, max=1.0]: Return fan speed control signal for AHU of floor 1
+            <code>hva_floor1_duaFanAirHanUnit_oveSpeRetFan_u</code> [1] [min=0.0, max=1.0]: Return fan speed control signal for AHU of floor 1
             </li>
             <li>
-            <code>hvac_floor1_duaFanAirHanUnit_supFan_oveSpeSupFan_u</code> [1] [min=0.0, max=1.0]: Supply fan speed control signal for AHU of floor 1
+            <code>hva_floor1_duaFanAirHanUnit_supFan_oveSpeSupFan_u</code> [1] [min=0.0, max=1.0]: Supply fan speed control signal for AHU of floor 1
             </li>
             <li>
-            <code>hvac_floor1_fivZonVAV_vAV1_oveZonLoc_yDam_u</code> [1] [min=0.0, max=1.0]: Damper position setpoint for zone cor of floor 1
+            <code>hva_floor1_fivZonVAV_vAV1_oveZonLoc_yDam_u</code> [1] [min=0.0, max=1.0]: Damper position setpoint for zone cor of floor 1
             </li>
             <li>
-            <code>hvac_floor1_fivZonVAV_vAV1_oveZonLoc_yReaHea_u</code> [1] [min=0.0, max=1.0]: Reheat control signal for zone cor of floor 1
+            <code>hva_floor1_fivZonVAV_vAV1_oveZonLoc_yReaHea_u</code> [1] [min=0.0, max=1.0]: Reheat control signal for zone cor of floor 1
             </li>
             <li>
-            <code>hvac_floor1_fivZonVAV_vAV2_oveZonLoc_yDam_u</code> [1] [min=0.0, max=1.0]: Damper position setpoint for zone sou of floor 1
+            <code>hva_floor1_fivZonVAV_vAV2_oveZonLoc_yDam_u</code> [1] [min=0.0, max=1.0]: Damper position setpoint for zone sou of floor 1
             </li>
             <li>
-            <code>hvac_floor1_fivZonVAV_vAV2_oveZonLoc_yReaHea_u</code> [1] [min=0.0, max=1.0]: Reheat control signal for zone sou of floor 1
+            <code>hva_floor1_fivZonVAV_vAV2_oveZonLoc_yReaHea_u</code> [1] [min=0.0, max=1.0]: Reheat control signal for zone sou of floor 1
             </li>
             <li>
-            <code>hvac_floor1_fivZonVAV_vAV3_oveZonLoc_yDam_u</code> [1] [min=0.0, max=1.0]: Damper position setpoint for zone eas of floor 1
+            <code>hva_floor1_fivZonVAV_vAV3_oveZonLoc_yDam_u</code> [1] [min=0.0, max=1.0]: Damper position setpoint for zone eas of floor 1
             </li>
             <li>
-            <code>hvac_floor1_fivZonVAV_vAV3_oveZonLoc_yReaHea_u</code> [1] [min=0.0, max=1.0]: Reheat control signal for zone eas of floor 1
+            <code>hva_floor1_fivZonVAV_vAV3_oveZonLoc_yReaHea_u</code> [1] [min=0.0, max=1.0]: Reheat control signal for zone eas of floor 1
             </li>
             <li>
-            <code>hvac_floor1_fivZonVAV_vAV4_oveZonLoc_yDam_u</code> [1] [min=0.0, max=1.0]: Damper position setpoint for zone nor of floor 1
+            <code>hva_floor1_fivZonVAV_vAV4_oveZonLoc_yDam_u</code> [1] [min=0.0, max=1.0]: Damper position setpoint for zone nor of floor 1
             </li>
             <li>
-            <code>hvac_floor1_fivZonVAV_vAV4_oveZonLoc_yReaHea_u</code> [1] [min=0.0, max=1.0]: Reheat control signal for zone nor of floor 1
+            <code>hva_floor1_fivZonVAV_vAV4_oveZonLoc_yReaHea_u</code> [1] [min=0.0, max=1.0]: Reheat control signal for zone nor of floor 1
             </li>
             <li>
-            <code>hvac_floor1_fivZonVAV_vAV5_oveZonLoc_yDam_u</code> [1] [min=0.0, max=1.0]: Damper position setpoint for zone wes of floor 1
+            <code>hva_floor1_fivZonVAV_vAV5_oveZonLoc_yDam_u</code> [1] [min=0.0, max=1.0]: Damper position setpoint for zone wes of floor 1
             </li>
             <li>
-            <code>hvac_floor1_fivZonVAV_vAV5_oveZonLoc_yReaHea_u</code> [1] [min=0.0, max=1.0]: Reheat control signal for zone wes of floor 1
+            <code>hva_floor1_fivZonVAV_vAV5_oveZonLoc_yReaHea_u</code> [1] [min=0.0, max=1.0]: Reheat control signal for zone wes of floor 1
             </li>
             <li>
-            <code>hvac_floor1_oveZonCor_TZonCooSet_u</code> [K] [min=285.15, max=313.15]: Zone air temperature cooling setpoint for zone cor of floor 1
+            <code>hva_floor1_oveZonCor_TZonCooSet_u</code> [K] [min=285.15, max=313.15]: Zone air temperature cooling setpoint for zone cor of floor 1
             </li>
             <li>
-            <code>hvac_floor1_oveZonCor_TZonHeaSet_u</code> [K] [min=285.15, max=313.15]: Zone air temperature heating setpoint for zone cor of floor 1
+            <code>hva_floor1_oveZonCor_TZonHeaSet_u</code> [K] [min=285.15, max=313.15]: Zone air temperature heating setpoint for zone cor of floor 1
             </li>
             <li>
-            <code>hvac_floor1_oveZonEas_TZonCooSet_u</code> [K] [min=285.15, max=313.15]: Zone air temperature cooling setpoint for zone eas of floor 1
+            <code>hva_floor1_oveZonEas_TZonCooSet_u</code> [K] [min=285.15, max=313.15]: Zone air temperature cooling setpoint for zone eas of floor 1
             </li>
             <li>
-            <code>hvac_floor1_oveZonEas_TZonHeaSet_u</code> [K] [min=285.15, max=313.15]: Zone air temperature heating setpoint for zone eas of floor 1
+            <code>hva_floor1_oveZonEas_TZonHeaSet_u</code> [K] [min=285.15, max=313.15]: Zone air temperature heating setpoint for zone eas of floor 1
             </li>
             <li>
-            <code>hvac_floor1_oveZonNor_TZonCooSet_u</code> [K] [min=285.15, max=313.15]: Zone air temperature cooling setpoint for zone nor of floor 1
+            <code>hva_floor1_oveZonNor_TZonCooSet_u</code> [K] [min=285.15, max=313.15]: Zone air temperature cooling setpoint for zone nor of floor 1
             </li>
             <li>
-            <code>hvac_floor1_oveZonNor_TZonHeaSet_u</code> [K] [min=285.15, max=313.15]: Zone air temperature heating setpoint for zone nor of floor 1
+            <code>hva_floor1_oveZonNor_TZonHeaSet_u</code> [K] [min=285.15, max=313.15]: Zone air temperature heating setpoint for zone nor of floor 1
             </li>
             <li>
-            <code>hvac_floor1_oveZonSou_TZonCooSet_u</code> [K] [min=285.15, max=313.15]: Zone air temperature cooling setpoint for zone sou of floor 1
+            <code>hva_floor1_oveZonSou_TZonCooSet_u</code> [K] [min=285.15, max=313.15]: Zone air temperature cooling setpoint for zone sou of floor 1
             </li>
             <li>
-            <code>hvac_floor1_oveZonSou_TZonHeaSet_u</code> [K] [min=285.15, max=313.15]: Zone air temperature heating setpoint for zone sou of floor 1
+            <code>hva_floor1_oveZonSou_TZonHeaSet_u</code> [K] [min=285.15, max=313.15]: Zone air temperature heating setpoint for zone sou of floor 1
             </li>
             <li>
-            <code>hvac_floor1_oveZonWes_TZonCooSet_u</code> [K] [min=285.15, max=313.15]: Zone air temperature cooling setpoint for zone wes of floor 1
+            <code>hva_floor1_oveZonWes_TZonCooSet_u</code> [K] [min=285.15, max=313.15]: Zone air temperature cooling setpoint for zone wes of floor 1
             </li>
             <li>
-            <code>hvac_floor1_oveZonWes_TZonHeaSet_u</code> [K] [min=285.15, max=313.15]: Zone air temperature heating setpoint for zone wes of floor 1
+            <code>hva_floor1_oveZonWes_TZonHeaSet_u</code> [K] [min=285.15, max=313.15]: Zone air temperature heating setpoint for zone wes of floor 1
             </li>
             <li>
-            <code>hvac_floor2_TSupAirSet_u</code> [K] [min=285.15, max=313.15]: Supply air temperature setpoint for AHU of floor 2
+            <code>hva_floor2_TSupAirSet_u</code> [K] [min=285.15, max=313.15]: Supply air temperature setpoint for AHU of floor 2
             </li>
             <li>
-            <code>hvac_floor2_dpSet_u</code> [Pa] [min=50.0, max=410.0]: Supply duct pressure setpoint for AHU of floor 2
+            <code>hva_floor2_dpSet_u</code> [Pa] [min=50.0, max=410.0]: Supply duct pressure setpoint for AHU of floor 2
             </li>
             <li>
-            <code>hvac_floor2_duaFanAirHanUnit_cooCoil_yCoo_u</code> [1] [min=0.0, max=1.0]: Cooling coil valve control signal for AHU of floor 2
+            <code>hva_floor2_duaFanAirHanUnit_cooCoil_yCoo_u</code> [1] [min=0.0, max=1.0]: Cooling coil valve control signal for AHU of floor 2
             </li>
             <li>
-            <code>hvac_floor2_duaFanAirHanUnit_mixingBox_mixBox_yEA_u</code> [1] [min=0.0, max=1.0]: Exhaust air damper position setpoint for AHU of floor 2
+            <code>hva_floor2_duaFanAirHanUnit_mixingBox_mixBox_yEA_u</code> [1] [min=0.0, max=1.0]: Exhaust air damper position setpoint for AHU of floor 2
             </li>
             <li>
-            <code>hvac_floor2_duaFanAirHanUnit_mixingBox_mixBox_yOA_u</code> [1] [min=0.0, max=1.0]: Outside air damper position setpoint for AHU of floor 2
+            <code>hva_floor2_duaFanAirHanUnit_mixingBox_mixBox_yOA_u</code> [1] [min=0.0, max=1.0]: Outside air damper position setpoint for AHU of floor 2
             </li>
             <li>
-            <code>hvac_floor2_duaFanAirHanUnit_mixingBox_mixBox_yRet_u</code> [1] [min=0.0, max=1.0]: Return air damper position setpoint for AHU of floor 2
+            <code>hva_floor2_duaFanAirHanUnit_mixingBox_mixBox_yRet_u</code> [1] [min=0.0, max=1.0]: Return air damper position setpoint for AHU of floor 2
             </li>
             <li>
-            <code>hvac_floor2_duaFanAirHanUnit_oveSpeRetFan_u</code> [1] [min=0.0, max=1.0]: AHU return fan speed control signal of floor 2
+            <code>hva_floor2_duaFanAirHanUnit_oveSpeRetFan_u</code> [1] [min=0.0, max=1.0]: AHU return fan speed control signal of floor 2
             </li>
             <li>
-            <code>hvac_floor2_duaFanAirHanUnit_supFan_oveSpeSupFan_u</code> [1] [min=0.0, max=1.0]: AHU supply fan speed control signal of floor 2
+            <code>hva_floor2_duaFanAirHanUnit_supFan_oveSpeSupFan_u</code> [1] [min=0.0, max=1.0]: AHU supply fan speed control signal of floor 2
             </li>
             <li>
-            <code>hvac_floor2_fivZonVAV_vAV1_oveZonLoc_yDam_u</code> [1] [min=0.0, max=1.0]: Damper position setpoint for zone cor of floor 2
+            <code>hva_floor2_fivZonVAV_vAV1_oveZonLoc_yDam_u</code> [1] [min=0.0, max=1.0]: Damper position setpoint for zone cor of floor 2
             </li>
             <li>
-            <code>hvac_floor2_fivZonVAV_vAV1_oveZonLoc_yReaHea_u</code> [1] [min=0.0, max=1.0]: Reheat control signal for zone cor of floor 2
+            <code>hva_floor2_fivZonVAV_vAV1_oveZonLoc_yReaHea_u</code> [1] [min=0.0, max=1.0]: Reheat control signal for zone cor of floor 2
             </li>
             <li>
-            <code>hvac_floor2_fivZonVAV_vAV2_oveZonLoc_yDam_u</code> [1] [min=0.0, max=1.0]: Damper position setpoint for zone sou of floor 2
+            <code>hva_floor2_fivZonVAV_vAV2_oveZonLoc_yDam_u</code> [1] [min=0.0, max=1.0]: Damper position setpoint for zone sou of floor 2
             </li>
             <li>
-            <code>hvac_floor2_fivZonVAV_vAV2_oveZonLoc_yReaHea_u</code> [1] [min=0.0, max=1.0]: Reheat control signal for zone sou of floor 2
+            <code>hva_floor2_fivZonVAV_vAV2_oveZonLoc_yReaHea_u</code> [1] [min=0.0, max=1.0]: Reheat control signal for zone sou of floor 2
             </li>
             <li>
-            <code>hvac_floor2_fivZonVAV_vAV3_oveZonLoc_yDam_u</code> [1] [min=0.0, max=1.0]: Damper position setpoint for zone eas of floor 2
+            <code>hva_floor2_fivZonVAV_vAV3_oveZonLoc_yDam_u</code> [1] [min=0.0, max=1.0]: Damper position setpoint for zone eas of floor 2
             </li>
             <li>
-            <code>hvac_floor2_fivZonVAV_vAV3_oveZonLoc_yReaHea_u</code> [1] [min=0.0, max=1.0]: Reheat control signal for zone eas of floor 2
+            <code>hva_floor2_fivZonVAV_vAV3_oveZonLoc_yReaHea_u</code> [1] [min=0.0, max=1.0]: Reheat control signal for zone eas of floor 2
             </li>
             <li>
-            <code>hvac_floor2_fivZonVAV_vAV4_oveZonLoc_yDam_u</code> [1] [min=0.0, max=1.0]: Damper position setpoint for zone nor of floor 2
+            <code>hva_floor2_fivZonVAV_vAV4_oveZonLoc_yDam_u</code> [1] [min=0.0, max=1.0]: Damper position setpoint for zone nor of floor 2
             </li>
             <li>
-            <code>hvac_floor2_fivZonVAV_vAV4_oveZonLoc_yReaHea_u</code> [1] [min=0.0, max=1.0]: Reheat control signal for zone nor of floor 2
+            <code>hva_floor2_fivZonVAV_vAV4_oveZonLoc_yReaHea_u</code> [1] [min=0.0, max=1.0]: Reheat control signal for zone nor of floor 2
             </li>
             <li>
-            <code>hvac_floor2_fivZonVAV_vAV5_oveZonLoc_yDam_u</code> [1] [min=0.0, max=1.0]: Damper position setpoint for zone wes of floor 2
+            <code>hva_floor2_fivZonVAV_vAV5_oveZonLoc_yDam_u</code> [1] [min=0.0, max=1.0]: Damper position setpoint for zone wes of floor 2
             </li>
             <li>
-            <code>hvac_floor2_fivZonVAV_vAV5_oveZonLoc_yReaHea_u</code> [1] [min=0.0, max=1.0]: Reheat control signal for zone wes of floor 2
+            <code>hva_floor2_fivZonVAV_vAV5_oveZonLoc_yReaHea_u</code> [1] [min=0.0, max=1.0]: Reheat control signal for zone wes of floor 2
             </li>
             <li>
-            <code>hvac_floor2_oveZonCor_TZonCooSet_u</code> [K] [min=285.15, max=313.15]: Zone air temperature cooling setpoint for zone cor of floor 2
+            <code>hva_floor2_oveZonCor_TZonCooSet_u</code> [K] [min=285.15, max=313.15]: Zone air temperature cooling setpoint for zone cor of floor 2
             </li>
             <li>
-            <code>hvac_floor2_oveZonCor_TZonHeaSet_u</code> [K] [min=285.15, max=313.15]: Zone air temperature heating setpoint for zone cor of floor 2
+            <code>hva_floor2_oveZonCor_TZonHeaSet_u</code> [K] [min=285.15, max=313.15]: Zone air temperature heating setpoint for zone cor of floor 2
             </li>
             <li>
-            <code>hvac_floor2_oveZonEas_TZonCooSet_u</code> [K] [min=285.15, max=313.15]: Zone air temperature cooling setpoint for zone eas of floor 2
+            <code>hva_floor2_oveZonEas_TZonCooSet_u</code> [K] [min=285.15, max=313.15]: Zone air temperature cooling setpoint for zone eas of floor 2
             </li>
             <li>
-            <code>hvac_floor2_oveZonEas_TZonHeaSet_u</code> [K] [min=285.15, max=313.15]: Zone air temperature heating setpoint for zone eas of floor 2
+            <code>hva_floor2_oveZonEas_TZonHeaSet_u</code> [K] [min=285.15, max=313.15]: Zone air temperature heating setpoint for zone eas of floor 2
             </li>
             <li>
-            <code>hvac_floor2_oveZonNor_TZonCooSet_u</code> [K] [min=285.15, max=313.15]: Zone air temperature cooling setpoint for zone nor of floor 2
+            <code>hva_floor2_oveZonNor_TZonCooSet_u</code> [K] [min=285.15, max=313.15]: Zone air temperature cooling setpoint for zone nor of floor 2
             </li>
             <li>
-            <code>hvac_floor2_oveZonNor_TZonHeaSet_u</code> [K] [min=285.15, max=313.15]: Zone air temperature heating setpoint for zone nor of floor 2
+            <code>hva_floor2_oveZonNor_TZonHeaSet_u</code> [K] [min=285.15, max=313.15]: Zone air temperature heating setpoint for zone nor of floor 2
             </li>
             <li>
-            <code>hvac_floor2_oveZonSou_TZonCooSet_u</code> [K] [min=285.15, max=313.15]: Zone air temperature cooling setpoint for zone sou of floor 2
+            <code>hva_floor2_oveZonSou_TZonCooSet_u</code> [K] [min=285.15, max=313.15]: Zone air temperature cooling setpoint for zone sou of floor 2
             </li>
             <li>
-            <code>hvac_floor2_oveZonSou_TZonHeaSet_u</code> [K] [min=285.15, max=313.15]: Zone air temperature heating setpoint for zone sou of floor 2
+            <code>hva_floor2_oveZonSou_TZonHeaSet_u</code> [K] [min=285.15, max=313.15]: Zone air temperature heating setpoint for zone sou of floor 2
             </li>
             <li>
-            <code>hvac_floor2_oveZonWes_TZonCooSet_u</code> [K] [min=285.15, max=313.15]: Zone air temperature cooling setpoint for zone wes of floor 2
+            <code>hva_floor2_oveZonWes_TZonCooSet_u</code> [K] [min=285.15, max=313.15]: Zone air temperature cooling setpoint for zone wes of floor 2
             </li>
             <li>
-            <code>hvac_floor2_oveZonWes_TZonHeaSet_u</code> [K] [min=285.15, max=313.15]: Zone air temperature heating setpoint for zone wes of floor 2
+            <code>hva_floor2_oveZonWes_TZonHeaSet_u</code> [K] [min=285.15, max=313.15]: Zone air temperature heating setpoint for zone wes of floor 2
             </li>
             <li>
-            <code>hvac_floor3_TSupAirSet_u</code> [K] [min=285.15, max=313.15]: Supply air temperature setpoint for AHU of floor 3
+            <code>hva_floor3_TSupAirSet_u</code> [K] [min=285.15, max=313.15]: Supply air temperature setpoint for AHU of floor 3
             </li>
             <li>
-            <code>hvac_floor3_dpSet_u</code> [Pa] [min=50.0, max=410.0]: Supply duct pressure setpoint for AHU of floor 3
+            <code>hva_floor3_dpSet_u</code> [Pa] [min=50.0, max=410.0]: Supply duct pressure setpoint for AHU of floor 3
             </li>
             <li>
-            <code>hvac_floor3_duaFanAirHanUnit_cooCoil_yCoo_u</code> [1] [min=0.0, max=1.0]: Cooling coil valve control signal for AHU of floor 3
+            <code>hva_floor3_duaFanAirHanUnit_cooCoil_yCoo_u</code> [1] [min=0.0, max=1.0]: Cooling coil valve control signal for AHU of floor 3
             </li>
             <li>
-            <code>hvac_floor3_duaFanAirHanUnit_mixingBox_mixBox_yEA_u</code> [1] [min=0.0, max=1.0]: Exhaust air damper position setpoint for AHU of floor 3
+            <code>hva_floor3_duaFanAirHanUnit_mixingBox_mixBox_yEA_u</code> [1] [min=0.0, max=1.0]: Exhaust air damper position setpoint for AHU of floor 3
             </li>
             <li>
-            <code>hvac_floor3_duaFanAirHanUnit_mixingBox_mixBox_yOA_u</code> [1] [min=0.0, max=1.0]: Outside air damper position setpoint for AHU of floor 3
+            <code>hva_floor3_duaFanAirHanUnit_mixingBox_mixBox_yOA_u</code> [1] [min=0.0, max=1.0]: Outside air damper position setpoint for AHU of floor 3
             </li>
             <li>
-            <code>hvac_floor3_duaFanAirHanUnit_mixingBox_mixBox_yRet_u</code> [1] [min=0.0, max=1.0]: Return air damper position setpoint for AHU of floor 3
+            <code>hva_floor3_duaFanAirHanUnit_mixingBox_mixBox_yRet_u</code> [1] [min=0.0, max=1.0]: Return air damper position setpoint for AHU of floor 3
             </li>
             <li>
-            <code>hvac_floor3_duaFanAirHanUnit_oveSpeRetFan_u</code> [1] [min=0.0, max=1.0]: AHU return fan speed control signal of floor 3
+            <code>hva_floor3_duaFanAirHanUnit_oveSpeRetFan_u</code> [1] [min=0.0, max=1.0]: AHU return fan speed control signal of floor 3
             </li>
             <li>
-            <code>hvac_floor3_duaFanAirHanUnit_supFan_oveSpeSupFan_u</code> [1] [min=0.0, max=1.0]: AHU supply fan speed control signal of floor 3
+            <code>hva_floor3_duaFanAirHanUnit_supFan_oveSpeSupFan_u</code> [1] [min=0.0, max=1.0]: AHU supply fan speed control signal of floor 3
             </li>
             <li>
-            <code>hvac_floor3_fivZonVAV_vAV1_oveZonLoc_yDam_u</code> [1] [min=0.0, max=1.0]: Damper position setpoint for zone cor of floor 3
+            <code>hva_floor3_fivZonVAV_vAV1_oveZonLoc_yDam_u</code> [1] [min=0.0, max=1.0]: Damper position setpoint for zone cor of floor 3
             </li>
             <li>
-            <code>hvac_floor3_fivZonVAV_vAV1_oveZonLoc_yReaHea_u</code> [1] [min=0.0, max=1.0]: Reheat control signal for zone cor of floor 3
+            <code>hva_floor3_fivZonVAV_vAV1_oveZonLoc_yReaHea_u</code> [1] [min=0.0, max=1.0]: Reheat control signal for zone cor of floor 3
             </li>
             <li>
-            <code>hvac_floor3_fivZonVAV_vAV2_oveZonLoc_yDam_u</code> [1] [min=0.0, max=1.0]: Damper position setpoint for zone sou of floor 3
+            <code>hva_floor3_fivZonVAV_vAV2_oveZonLoc_yDam_u</code> [1] [min=0.0, max=1.0]: Damper position setpoint for zone sou of floor 3
             </li>
             <li>
-            <code>hvac_floor3_fivZonVAV_vAV2_oveZonLoc_yReaHea_u</code> [1] [min=0.0, max=1.0]: Reheat control signal for zone sou of floor 3
+            <code>hva_floor3_fivZonVAV_vAV2_oveZonLoc_yReaHea_u</code> [1] [min=0.0, max=1.0]: Reheat control signal for zone sou of floor 3
             </li>
             <li>
-            <code>hvac_floor3_fivZonVAV_vAV3_oveZonLoc_yDam_u</code> [1] [min=0.0, max=1.0]: Damper position setpoint for zone eas of floor 3
+            <code>hva_floor3_fivZonVAV_vAV3_oveZonLoc_yDam_u</code> [1] [min=0.0, max=1.0]: Damper position setpoint for zone eas of floor 3
             </li>
             <li>
-            <code>hvac_floor3_fivZonVAV_vAV3_oveZonLoc_yReaHea_u</code> [1] [min=0.0, max=1.0]: Reheat control signal for zone eas of floor 3
+            <code>hva_floor3_fivZonVAV_vAV3_oveZonLoc_yReaHea_u</code> [1] [min=0.0, max=1.0]: Reheat control signal for zone eas of floor 3
             </li>
             <li>
-            <code>hvac_floor3_fivZonVAV_vAV4_oveZonLoc_yDam_u</code> [1] [min=0.0, max=1.0]: Damper position setpoint for zone nor of floor 3
+            <code>hva_floor3_fivZonVAV_vAV4_oveZonLoc_yDam_u</code> [1] [min=0.0, max=1.0]: Damper position setpoint for zone nor of floor 3
             </li>
             <li>
-            <code>hvac_floor3_fivZonVAV_vAV4_oveZonLoc_yReaHea_u</code> [1] [min=0.0, max=1.0]: Reheat control signal for zone nor of floor 3
+            <code>hva_floor3_fivZonVAV_vAV4_oveZonLoc_yReaHea_u</code> [1] [min=0.0, max=1.0]: Reheat control signal for zone nor of floor 3
             </li>
             <li>
-            <code>hvac_floor3_fivZonVAV_vAV5_oveZonLoc_yDam_u</code> [1] [min=0.0, max=1.0]: Damper position setpoint for zone wes of floor 3
+            <code>hva_floor3_fivZonVAV_vAV5_oveZonLoc_yDam_u</code> [1] [min=0.0, max=1.0]: Damper position setpoint for zone wes of floor 3
             </li>
             <li>
-            <code>hvac_floor3_fivZonVAV_vAV5_oveZonLoc_yReaHea_u</code> [1] [min=0.0, max=1.0]: Reheat control signal for zone wes of floor 3
+            <code>hva_floor3_fivZonVAV_vAV5_oveZonLoc_yReaHea_u</code> [1] [min=0.0, max=1.0]: Reheat control signal for zone wes of floor 3
             </li>
             <li>
-            <code>hvac_floor3_oveZonCor_TZonCooSet_u</code> [K] [min=285.15, max=313.15]: Zone air temperature cooling setpoint for zone cor of floor 3
+            <code>hva_floor3_oveZonCor_TZonCooSet_u</code> [K] [min=285.15, max=313.15]: Zone air temperature cooling setpoint for zone cor of floor 3
             </li>
             <li>
-            <code>hvac_floor3_oveZonCor_TZonHeaSet_u</code> [K] [min=285.15, max=313.15]: Zone air temperature heating setpoint for zone cor of floor 3
+            <code>hva_floor3_oveZonCor_TZonHeaSet_u</code> [K] [min=285.15, max=313.15]: Zone air temperature heating setpoint for zone cor of floor 3
             </li>
             <li>
-            <code>hvac_floor3_oveZonEas_TZonCooSet_u</code> [K] [min=285.15, max=313.15]: Zone air temperature cooling setpoint for zone eas of floor 3
+            <code>hva_floor3_oveZonEas_TZonCooSet_u</code> [K] [min=285.15, max=313.15]: Zone air temperature cooling setpoint for zone eas of floor 3
             </li>
             <li>
-            <code>hvac_floor3_oveZonEas_TZonHeaSet_u</code> [K] [min=285.15, max=313.15]: Zone air temperature heating setpoint for zone eas of floor 3
+            <code>hva_floor3_oveZonEas_TZonHeaSet_u</code> [K] [min=285.15, max=313.15]: Zone air temperature heating setpoint for zone eas of floor 3
             </li>
             <li>
-            <code>hvac_floor3_oveZonNor_TZonCooSet_u</code> [K] [min=285.15, max=313.15]: Zone air temperature cooling setpoint for zone nor of floor 3
+            <code>hva_floor3_oveZonNor_TZonCooSet_u</code> [K] [min=285.15, max=313.15]: Zone air temperature cooling setpoint for zone nor of floor 3
             </li>
             <li>
-            <code>hvac_floor3_oveZonNor_TZonHeaSet_u</code> [K] [min=285.15, max=313.15]: Zone air temperature heating setpoint for zone nor of floor 3
+            <code>hva_floor3_oveZonNor_TZonHeaSet_u</code> [K] [min=285.15, max=313.15]: Zone air temperature heating setpoint for zone nor of floor 3
             </li>
             <li>
-            <code>hvac_floor3_oveZonSou_TZonCooSet_u</code> [K] [min=285.15, max=313.15]: Zone air temperature cooling setpoint for zone sou of floor 3
+            <code>hva_floor3_oveZonSou_TZonCooSet_u</code> [K] [min=285.15, max=313.15]: Zone air temperature cooling setpoint for zone sou of floor 3
             </li>
             <li>
-            <code>hvac_floor3_oveZonSou_TZonHeaSet_u</code> [K] [min=285.15, max=313.15]: Zone air temperature heating setpoint for zone sou of floor 3
+            <code>hva_floor3_oveZonSou_TZonHeaSet_u</code> [K] [min=285.15, max=313.15]: Zone air temperature heating setpoint for zone sou of floor 3
             </li>
             <li>
-            <code>hvac_floor3_oveZonWes_TZonCooSet_u</code> [K] [min=285.15, max=313.15]: Zone air temperature cooling setpoint for zone wes of floor 3
+            <code>hva_floor3_oveZonWes_TZonCooSet_u</code> [K] [min=285.15, max=313.15]: Zone air temperature cooling setpoint for zone wes of floor 3
             </li>
             <li>
-            <code>hvac_floor3_oveZonWes_TZonHeaSet_u</code> [K] [min=285.15, max=313.15]: Zone air temperature heating setpoint for zone wes of floor 3
+            <code>hva_floor3_oveZonWes_TZonHeaSet_u</code> [K] [min=285.15, max=313.15]: Zone air temperature heating setpoint for zone wes of floor 3
             </li>
             <li>
-            <code>hvac_oveChiWatSys_TW_set_u</code> [K] [min=278.15, max=288.15]: Chilled/hot water supply setpoint
+            <code>hva_oveChiWatSys_TW_set_u</code> [K] [min=278.15, max=288.15]: Chilled/hot water supply setpoint
             </li>
             <li>
-            <code>hvac_oveChiWatSys_dp_set_u</code> [Pa] [min=0.0, max=19130000.0]: Differential pressure setpoint
+            <code>hva_oveChiWatSys_dp_set_u</code> [Pa] [min=0.0, max=19130000.0]: Differential pressure setpoint
             </li>
             <li>
-            <code>hvac_oveHotWatSys_TW_set_u</code> [K] [min=291.15, max=353.15]: Chilled/hot water supply setpoint
+            <code>hva_oveHotWatSys_TW_set_u</code> [K] [min=291.15, max=353.15]: Chilled/hot water supply setpoint
             </li>
             <li>
-            <code>hvac_oveHotWatSys_dp_set_u</code> [Pa] [min=0.0, max=19130000.0]: Differential pressure setpoint
+            <code>hva_oveHotWatSys_dp_set_u</code> [Pa] [min=0.0, max=19130000.0]: Differential pressure setpoint
             </li>
     </ul>
 </p>
@@ -1068,607 +1068,607 @@
     The model outputs are:
     <ul>
         <li>
-            <code>hvac_floor1_reaZonCor_TRoo_Coo_set_y</code> [K] [min=None, max=None]: Zone temperature cooling setpoint for zone cor of floor 1
+            <code>hva_floor1_reaZonCor_TRoo_Coo_set_y</code> [K] [min=None, max=None]: Zone temperature cooling setpoint for zone cor of floor 1
             </li>
             <li>
-            <code>hvac_floor1_reaZonCor_TRoo_Hea_set_y</code> [K] [min=None, max=None]: Zone temperature heating setpoint for zone cor of floor 1
+            <code>hva_floor1_reaZonCor_TRoo_Hea_set_y</code> [K] [min=None, max=None]: Zone temperature heating setpoint for zone cor of floor 1
             </li>
             <li>
-            <code>hvac_floor1_reaZonCor_TSup_y</code> [K] [min=None, max=None]: Discharge air temperature to zone measurement for zone cor of floor 1
+            <code>hva_floor1_reaZonCor_TSup_y</code> [K] [min=None, max=None]: Discharge air temperature to zone measurement for zone cor of floor 1
             </li>
             <li>
-            <code>hvac_floor1_reaZonCor_TZon_y</code> [K] [min=None, max=None]: Zone air temperature measurement for zone cor of floor 1
+            <code>hva_floor1_reaZonCor_TZon_y</code> [K] [min=None, max=None]: Zone air temperature measurement for zone cor of floor 1
             </li>
             <li>
-            <code>hvac_floor1_reaZonCor_V_flow_set_y</code> [m3/s] [min=None, max=None]: Airflow setpoint for zone cor of floor 1
+            <code>hva_floor1_reaZonCor_V_flow_set_y</code> [m3/s] [min=None, max=None]: Airflow setpoint for zone cor of floor 1
             </li>
             <li>
-            <code>hvac_floor1_reaZonCor_V_flow_y</code> [m3/s] [min=None, max=None]: Discharge air flowrate to zone measurement for zone cor of floor 1
+            <code>hva_floor1_reaZonCor_V_flow_y</code> [m3/s] [min=None, max=None]: Discharge air flowrate to zone measurement for zone cor of floor 1
             </li>
             <li>
-            <code>hvac_floor1_reaZonCor_yCoo_y</code> [1] [min=None, max=None]: Cooling PID signal measurement for zone cor of floor 1
+            <code>hva_floor1_reaZonCor_yCoo_y</code> [1] [min=None, max=None]: Cooling PID signal measurement for zone cor of floor 1
             </li>
             <li>
-            <code>hvac_floor1_reaZonCor_yDam_y</code> [1] [min=None, max=None]: Damper position measurement for zone cor of floor 1
+            <code>hva_floor1_reaZonCor_yDam_y</code> [1] [min=None, max=None]: Damper position measurement for zone cor of floor 1
             </li>
             <li>
-            <code>hvac_floor1_reaZonCor_yHea_y</code> [1] [min=None, max=None]: Heating PID signal measurement for zone cor of floor 1
+            <code>hva_floor1_reaZonCor_yHea_y</code> [1] [min=None, max=None]: Heating PID signal measurement for zone cor of floor 1
             </li>
             <li>
-            <code>hvac_floor1_reaZonCor_yReheaVal_y</code> [1] [min=None, max=None]: Reheat valve position measurement for zone cor of floor 1
+            <code>hva_floor1_reaZonCor_yReheaVal_y</code> [1] [min=None, max=None]: Reheat valve position measurement for zone cor of floor 1
             </li>
             <li>
-            <code>hvac_floor1_reaZonEas_TRoo_Coo_set_y</code> [K] [min=None, max=None]: Zone temperature cooling setpoint for zone eas of floor 1
+            <code>hva_floor1_reaZonEas_TRoo_Coo_set_y</code> [K] [min=None, max=None]: Zone temperature cooling setpoint for zone eas of floor 1
             </li>
             <li>
-            <code>hvac_floor1_reaZonEas_TRoo_Hea_set_y</code> [K] [min=None, max=None]: Zone temperature heating setpoint for zone eas of floor 1
+            <code>hva_floor1_reaZonEas_TRoo_Hea_set_y</code> [K] [min=None, max=None]: Zone temperature heating setpoint for zone eas of floor 1
             </li>
             <li>
-            <code>hvac_floor1_reaZonEas_TSup_y</code> [K] [min=None, max=None]: Discharge air temperature to zone measurement for zone eas of floor 1
+            <code>hva_floor1_reaZonEas_TSup_y</code> [K] [min=None, max=None]: Discharge air temperature to zone measurement for zone eas of floor 1
             </li>
             <li>
-            <code>hvac_floor1_reaZonEas_TZon_y</code> [K] [min=None, max=None]: Zone air temperature measurement for zone eas of floor 1
+            <code>hva_floor1_reaZonEas_TZon_y</code> [K] [min=None, max=None]: Zone air temperature measurement for zone eas of floor 1
             </li>
             <li>
-            <code>hvac_floor1_reaZonEas_V_flow_set_y</code> [m3/s] [min=None, max=None]: Airflow setpoint of zone eas of floor 1
+            <code>hva_floor1_reaZonEas_V_flow_set_y</code> [m3/s] [min=None, max=None]: Airflow setpoint of zone eas of floor 1
             </li>
             <li>
-            <code>hvac_floor1_reaZonEas_V_flow_y</code> [m3/s] [min=None, max=None]: Discharge air flowrate to zone measurement for zone eas of floor 1
+            <code>hva_floor1_reaZonEas_V_flow_y</code> [m3/s] [min=None, max=None]: Discharge air flowrate to zone measurement for zone eas of floor 1
             </li>
             <li>
-            <code>hvac_floor1_reaZonEas_yCoo_y</code> [1] [min=None, max=None]: Cooling PID signal measurement for zone eas of floor 1
+            <code>hva_floor1_reaZonEas_yCoo_y</code> [1] [min=None, max=None]: Cooling PID signal measurement for zone eas of floor 1
             </li>
             <li>
-            <code>hvac_floor1_reaZonEas_yDam_y</code> [1] [min=None, max=None]: Damper position measurement for zone eas of floor 1
+            <code>hva_floor1_reaZonEas_yDam_y</code> [1] [min=None, max=None]: Damper position measurement for zone eas of floor 1
             </li>
             <li>
-            <code>hvac_floor1_reaZonEas_yHea_y</code> [1] [min=None, max=None]: Heating PID signal measurement for zone eas of floor 1
+            <code>hva_floor1_reaZonEas_yHea_y</code> [1] [min=None, max=None]: Heating PID signal measurement for zone eas of floor 1
             </li>
             <li>
-            <code>hvac_floor1_reaZonEas_yReheaVal_y</code> [1] [min=None, max=None]: Reheat valve position measurement for zone eas of floor 1
+            <code>hva_floor1_reaZonEas_yReheaVal_y</code> [1] [min=None, max=None]: Reheat valve position measurement for zone eas of floor 1
             </li>
             <li>
-            <code>hvac_floor1_reaZonNor_TRoo_Coo_set_y</code> [K] [min=None, max=None]: Zone temperature cooling setpoint for zone nor of floor 1
+            <code>hva_floor1_reaZonNor_TRoo_Coo_set_y</code> [K] [min=None, max=None]: Zone temperature cooling setpoint for zone nor of floor 1
             </li>
             <li>
-            <code>hvac_floor1_reaZonNor_TRoo_Hea_set_y</code> [K] [min=None, max=None]: Zone temperature heating setpoint for zone nor of floor 1
+            <code>hva_floor1_reaZonNor_TRoo_Hea_set_y</code> [K] [min=None, max=None]: Zone temperature heating setpoint for zone nor of floor 1
             </li>
             <li>
-            <code>hvac_floor1_reaZonNor_TSup_y</code> [K] [min=None, max=None]: Discharge air temperature to zone measurement for zone nor of floor 1
+            <code>hva_floor1_reaZonNor_TSup_y</code> [K] [min=None, max=None]: Discharge air temperature to zone measurement for zone nor of floor 1
             </li>
             <li>
-            <code>hvac_floor1_reaZonNor_TZon_y</code> [K] [min=None, max=None]: Zone air temperature measurement for zone nor of floor 1
+            <code>hva_floor1_reaZonNor_TZon_y</code> [K] [min=None, max=None]: Zone air temperature measurement for zone nor of floor 1
             </li>
             <li>
-            <code>hvac_floor1_reaZonNor_V_flow_set_y</code> [m3/s] [min=None, max=None]: Airflow setpoint for zone nor of floor 1
+            <code>hva_floor1_reaZonNor_V_flow_set_y</code> [m3/s] [min=None, max=None]: Airflow setpoint for zone nor of floor 1
             </li>
             <li>
-            <code>hvac_floor1_reaZonNor_V_flow_y</code> [m3/s] [min=None, max=None]: Discharge air flowrate to zone measurement for zone nor of floor 1
+            <code>hva_floor1_reaZonNor_V_flow_y</code> [m3/s] [min=None, max=None]: Discharge air flowrate to zone measurement for zone nor of floor 1
             </li>
             <li>
-            <code>hvac_floor1_reaZonNor_yCoo_y</code> [1] [min=None, max=None]: Cooling PID signal measurement for zone nor of floor 1
+            <code>hva_floor1_reaZonNor_yCoo_y</code> [1] [min=None, max=None]: Cooling PID signal measurement for zone nor of floor 1
             </li>
             <li>
-            <code>hvac_floor1_reaZonNor_yDam_y</code> [1] [min=None, max=None]: Damper position measurement for zone nor of floor 1
+            <code>hva_floor1_reaZonNor_yDam_y</code> [1] [min=None, max=None]: Damper position measurement for zone nor of floor 1
             </li>
             <li>
-            <code>hvac_floor1_reaZonNor_yHea_y</code> [1] [min=None, max=None]: Heating PID signal measurement for zone nor of floor 1
+            <code>hva_floor1_reaZonNor_yHea_y</code> [1] [min=None, max=None]: Heating PID signal measurement for zone nor of floor 1
             </li>
             <li>
-            <code>hvac_floor1_reaZonNor_yReheaVal_y</code> [1] [min=None, max=None]: Reheat valve position measurement for zone nor of floor 1
+            <code>hva_floor1_reaZonNor_yReheaVal_y</code> [1] [min=None, max=None]: Reheat valve position measurement for zone nor of floor 1
             </li>
             <li>
-            <code>hvac_floor1_reaZonSou_TRoo_Coo_set_y</code> [K] [min=None, max=None]: Zone temperature cooling setpoint for zone sou of floor 1
+            <code>hva_floor1_reaZonSou_TRoo_Coo_set_y</code> [K] [min=None, max=None]: Zone temperature cooling setpoint for zone sou of floor 1
             </li>
             <li>
-            <code>hvac_floor1_reaZonSou_TRoo_Hea_set_y</code> [K] [min=None, max=None]: Zone temperature heating setpoint for zone sou of floor 1
+            <code>hva_floor1_reaZonSou_TRoo_Hea_set_y</code> [K] [min=None, max=None]: Zone temperature heating setpoint for zone sou of floor 1
             </li>
             <li>
-            <code>hvac_floor1_reaZonSou_TSup_y</code> [K] [min=None, max=None]: Discharge air temperature to zone measurement for zone sou of floor 1
+            <code>hva_floor1_reaZonSou_TSup_y</code> [K] [min=None, max=None]: Discharge air temperature to zone measurement for zone sou of floor 1
             </li>
             <li>
-            <code>hvac_floor1_reaZonSou_TZon_y</code> [K] [min=None, max=None]: Zone air temperature measurement for zone sou of floor 1
+            <code>hva_floor1_reaZonSou_TZon_y</code> [K] [min=None, max=None]: Zone air temperature measurement for zone sou of floor 1
             </li>
             <li>
-            <code>hvac_floor1_reaZonSou_V_flow_set_y</code> [m3/s] [min=None, max=None]: Airflow setpoint of zone sou of floor 1
+            <code>hva_floor1_reaZonSou_V_flow_set_y</code> [m3/s] [min=None, max=None]: Airflow setpoint of zone sou of floor 1
             </li>
             <li>
-            <code>hvac_floor1_reaZonSou_V_flow_y</code> [m3/s] [min=None, max=None]: Discharge air flowrate to zone measurement for zone sou of floor 1
+            <code>hva_floor1_reaZonSou_V_flow_y</code> [m3/s] [min=None, max=None]: Discharge air flowrate to zone measurement for zone sou of floor 1
             </li>
             <li>
-            <code>hvac_floor1_reaZonSou_yCoo_y</code> [1] [min=None, max=None]: Cooling PID signal measurement for zone sou of floor 1
+            <code>hva_floor1_reaZonSou_yCoo_y</code> [1] [min=None, max=None]: Cooling PID signal measurement for zone sou of floor 1
             </li>
             <li>
-            <code>hvac_floor1_reaZonSou_yDam_y</code> [1] [min=None, max=None]: Damper position measurement for zone sou of floor 1
+            <code>hva_floor1_reaZonSou_yDam_y</code> [1] [min=None, max=None]: Damper position measurement for zone sou of floor 1
             </li>
             <li>
-            <code>hvac_floor1_reaZonSou_yHea_y</code> [1] [min=None, max=None]: Heating PID signal measurement for zone sou of floor 1
+            <code>hva_floor1_reaZonSou_yHea_y</code> [1] [min=None, max=None]: Heating PID signal measurement for zone sou of floor 1
             </li>
             <li>
-            <code>hvac_floor1_reaZonSou_yReheaVal_y</code> [1] [min=None, max=None]: Reheat valve position measurement for zone sou of floor 1
+            <code>hva_floor1_reaZonSou_yReheaVal_y</code> [1] [min=None, max=None]: Reheat valve position measurement for zone sou of floor 1
             </li>
             <li>
-            <code>hvac_floor1_reaZonWes_TRoo_Coo_set_y</code> [K] [min=None, max=None]: Zone temperature cooling setpoint for zone wes of floor 1
+            <code>hva_floor1_reaZonWes_TRoo_Coo_set_y</code> [K] [min=None, max=None]: Zone temperature cooling setpoint for zone wes of floor 1
             </li>
             <li>
-            <code>hvac_floor1_reaZonWes_TRoo_Hea_set_y</code> [K] [min=None, max=None]: Zone temperature heating setpoint for zone wes of floor 1
+            <code>hva_floor1_reaZonWes_TRoo_Hea_set_y</code> [K] [min=None, max=None]: Zone temperature heating setpoint for zone wes of floor 1
             </li>
             <li>
-            <code>hvac_floor1_reaZonWes_TSup_y</code> [K] [min=None, max=None]: Discharge air temperature to zone measurement for zone wes of floor 1
+            <code>hva_floor1_reaZonWes_TSup_y</code> [K] [min=None, max=None]: Discharge air temperature to zone measurement for zone wes of floor 1
             </li>
             <li>
-            <code>hvac_floor1_reaZonWes_TZon_y</code> [K] [min=None, max=None]: Zone air temperature measurement for zone wes of floor 1
+            <code>hva_floor1_reaZonWes_TZon_y</code> [K] [min=None, max=None]: Zone air temperature measurement for zone wes of floor 1
             </li>
             <li>
-            <code>hvac_floor1_reaZonWes_V_flow_set_y</code> [m3/s] [min=None, max=None]: Airflow setpoint of zone wes of floor 1
+            <code>hva_floor1_reaZonWes_V_flow_set_y</code> [m3/s] [min=None, max=None]: Airflow setpoint of zone wes of floor 1
             </li>
             <li>
-            <code>hvac_floor1_reaZonWes_V_flow_y</code> [m3/s] [min=None, max=None]: Discharge air flowrate to zone measurement for zone wes of floor 1
+            <code>hva_floor1_reaZonWes_V_flow_y</code> [m3/s] [min=None, max=None]: Discharge air flowrate to zone measurement for zone wes of floor 1
             </li>
             <li>
-            <code>hvac_floor1_reaZonWes_yCoo_y</code> [1] [min=None, max=None]: Cooling PID signal measurement for zone wes of floor 1
+            <code>hva_floor1_reaZonWes_yCoo_y</code> [1] [min=None, max=None]: Cooling PID signal measurement for zone wes of floor 1
             </li>
             <li>
-            <code>hvac_floor1_reaZonWes_yDam_y</code> [1] [min=None, max=None]: Damper position measurement for zone wes of floor 1
+            <code>hva_floor1_reaZonWes_yDam_y</code> [1] [min=None, max=None]: Damper position measurement for zone wes of floor 1
             </li>
             <li>
-            <code>hvac_floor1_reaZonWes_yHea_y</code> [1] [min=None, max=None]: Heating PID signal measurement for zone wes of floor 1
+            <code>hva_floor1_reaZonWes_yHea_y</code> [1] [min=None, max=None]: Heating PID signal measurement for zone wes of floor 1
             </li>
             <li>
-            <code>hvac_floor1_reaZonWes_yReheaVal_y</code> [1] [min=None, max=None]: Reheat valve position measurement for zone wes of floor 1
+            <code>hva_floor1_reaZonWes_yReheaVal_y</code> [1] [min=None, max=None]: Reheat valve position measurement for zone wes of floor 1
             </li>
             <li>
-            <code>hvac_floor1_readAhu_PFanTot_y</code> [W] [min=None, max=None]: Total electrical power measurement of supply and return fans for AHU of floor 1
+            <code>hva_floor1_readAhu_PFanTot_y</code> [W] [min=None, max=None]: Total electrical power measurement of supply and return fans for AHU of floor 1
             </li>
             <li>
-            <code>hvac_floor1_readAhu_TCooCoiRet_y</code> [K] [min=None, max=None]: Cooling coil return water temperature measurement for AHU of floor 1
+            <code>hva_floor1_readAhu_TCooCoiRet_y</code> [K] [min=None, max=None]: Cooling coil return water temperature measurement for AHU of floor 1
             </li>
             <li>
-            <code>hvac_floor1_readAhu_TCooCoiSup_y</code> [K] [min=None, max=None]: Cooling coil supply water temperature measurement for AHU of floor 1
+            <code>hva_floor1_readAhu_TCooCoiSup_y</code> [K] [min=None, max=None]: Cooling coil supply water temperature measurement for AHU of floor 1
             </li>
             <li>
-            <code>hvac_floor1_readAhu_TMix_y</code> [K] [min=None, max=None]: Mixed air temperature measurement for AHU of floor 1
+            <code>hva_floor1_readAhu_TMix_y</code> [K] [min=None, max=None]: Mixed air temperature measurement for AHU of floor 1
             </li>
             <li>
-            <code>hvac_floor1_readAhu_TRet_y</code> [K] [min=None, max=None]: Return air temperature measurement for AHU of floor 1
+            <code>hva_floor1_readAhu_TRet_y</code> [K] [min=None, max=None]: Return air temperature measurement for AHU of floor 1
             </li>
             <li>
-            <code>hvac_floor1_readAhu_TSup_set_y</code> [K] [min=None, max=None]: Supply air temperature setpoint measurement for AHU of floor 1
+            <code>hva_floor1_readAhu_TSup_set_y</code> [K] [min=None, max=None]: Supply air temperature setpoint measurement for AHU of floor 1
             </li>
             <li>
-            <code>hvac_floor1_readAhu_TSup_y</code> [K] [min=None, max=None]: Supply air temperature measurement for AHU of floor 1
+            <code>hva_floor1_readAhu_TSup_y</code> [K] [min=None, max=None]: Supply air temperature measurement for AHU of floor 1
             </li>
             <li>
-            <code>hvac_floor1_readAhu_V_flow_OA_y</code> [m3/s] [min=None, max=None]: Supply outdoor airflow rate measurement for AHU of floor 1
+            <code>hva_floor1_readAhu_V_flow_OA_y</code> [m3/s] [min=None, max=None]: Supply outdoor airflow rate measurement for AHU of floor 1
             </li>
             <li>
-            <code>hvac_floor1_readAhu_V_flow_ret_y</code> [m3/s] [min=None, max=None]: Return air flowrate measurement for AHU of floor 1
+            <code>hva_floor1_readAhu_V_flow_ret_y</code> [m3/s] [min=None, max=None]: Return air flowrate measurement for AHU of floor 1
             </li>
             <li>
-            <code>hvac_floor1_readAhu_V_flow_sup_y</code> [m3/s] [min=None, max=None]: Supply air flowrate measurement for AHU of floor 1
+            <code>hva_floor1_readAhu_V_flow_sup_y</code> [m3/s] [min=None, max=None]: Supply air flowrate measurement for AHU of floor 1
             </li>
             <li>
-            <code>hvac_floor1_readAhu_dp_sup_y</code> [Pa] [min=None, max=None]: Discharge pressure of supply fan for AHU of floor 1
+            <code>hva_floor1_readAhu_dp_sup_y</code> [Pa] [min=None, max=None]: Discharge pressure of supply fan for AHU of floor 1
             </li>
             <li>
-            <code>hvac_floor1_readAhu_occ_y</code> [1] [min=None, max=None]: Occupancy status of floor 1 (1 occupied, 0 unoccupied)
+            <code>hva_floor1_readAhu_occ_y</code> [1] [min=None, max=None]: Occupancy status of floor 1 (1 occupied, 0 unoccupied)
             </li>
             <li>
-            <code>hvac_floor1_readAhu_yCooVal_y</code> [1] [min=None, max=None]: AHU cooling coil valve position measurement of floor 1
+            <code>hva_floor1_readAhu_yCooVal_y</code> [1] [min=None, max=None]: AHU cooling coil valve position measurement of floor 1
             </li>
             <li>
-            <code>hvac_floor1_readAhu_yOA_y</code> [1] [min=None, max=None]: AHU cooling coil valve position measurement of floor 1
+            <code>hva_floor1_readAhu_yOA_y</code> [1] [min=None, max=None]: AHU cooling coil valve position measurement of floor 1
             </li>
             <li>
-            <code>hvac_floor2_reaZonCor_TRoo_Coo_set_y</code> [K] [min=None, max=None]: Zone temperature cooling setpoint for zone cor of floor 2
+            <code>hva_floor2_reaZonCor_TRoo_Coo_set_y</code> [K] [min=None, max=None]: Zone temperature cooling setpoint for zone cor of floor 2
             </li>
             <li>
-            <code>hvac_floor2_reaZonCor_TRoo_Hea_set_y</code> [K] [min=None, max=None]: Zone temperature heating setpoint for zone cor of floor 2
+            <code>hva_floor2_reaZonCor_TRoo_Hea_set_y</code> [K] [min=None, max=None]: Zone temperature heating setpoint for zone cor of floor 2
             </li>
             <li>
-            <code>hvac_floor2_reaZonCor_TSup_y</code> [K] [min=None, max=None]: Discharge air temperature to zone measurement for zone cor of floor 2
+            <code>hva_floor2_reaZonCor_TSup_y</code> [K] [min=None, max=None]: Discharge air temperature to zone measurement for zone cor of floor 2
             </li>
             <li>
-            <code>hvac_floor2_reaZonCor_TZon_y</code> [K] [min=None, max=None]: Zone air temperature measurement for zone cor of floor 2
+            <code>hva_floor2_reaZonCor_TZon_y</code> [K] [min=None, max=None]: Zone air temperature measurement for zone cor of floor 2
             </li>
             <li>
-            <code>hvac_floor2_reaZonCor_V_flow_set_y</code> [m3/s] [min=None, max=None]: Airflow setpoint of zone cor of floor 2
+            <code>hva_floor2_reaZonCor_V_flow_set_y</code> [m3/s] [min=None, max=None]: Airflow setpoint of zone cor of floor 2
             </li>
             <li>
-            <code>hvac_floor2_reaZonCor_V_flow_y</code> [m3/s] [min=None, max=None]: Discharge air flowrate to zone measurement for zone cor of floor 2
+            <code>hva_floor2_reaZonCor_V_flow_y</code> [m3/s] [min=None, max=None]: Discharge air flowrate to zone measurement for zone cor of floor 2
             </li>
             <li>
-            <code>hvac_floor2_reaZonCor_yCoo_y</code> [1] [min=None, max=None]: Cooling PID signal measurement for zone cor of floor 2
+            <code>hva_floor2_reaZonCor_yCoo_y</code> [1] [min=None, max=None]: Cooling PID signal measurement for zone cor of floor 2
             </li>
             <li>
-            <code>hvac_floor2_reaZonCor_yDam_y</code> [1] [min=None, max=None]: Damper position measurement for zone cor of floor 2
+            <code>hva_floor2_reaZonCor_yDam_y</code> [1] [min=None, max=None]: Damper position measurement for zone cor of floor 2
             </li>
             <li>
-            <code>hvac_floor2_reaZonCor_yHea_y</code> [1] [min=None, max=None]: Heating PID signal measurement for zone cor of floor 2
+            <code>hva_floor2_reaZonCor_yHea_y</code> [1] [min=None, max=None]: Heating PID signal measurement for zone cor of floor 2
             </li>
             <li>
-            <code>hvac_floor2_reaZonCor_yReheaVal_y</code> [1] [min=None, max=None]: Reheat valve position measurement for zone cor of floor 2
+            <code>hva_floor2_reaZonCor_yReheaVal_y</code> [1] [min=None, max=None]: Reheat valve position measurement for zone cor of floor 2
             </li>
             <li>
-            <code>hvac_floor2_reaZonEas_TRoo_Coo_set_y</code> [K] [min=None, max=None]: Zone temperature cooling setpoint for zone eas of floor 2
+            <code>hva_floor2_reaZonEas_TRoo_Coo_set_y</code> [K] [min=None, max=None]: Zone temperature cooling setpoint for zone eas of floor 2
             </li>
             <li>
-            <code>hvac_floor2_reaZonEas_TRoo_Hea_set_y</code> [K] [min=None, max=None]: Zone temperature heating setpoint for zone eas of floor 2
+            <code>hva_floor2_reaZonEas_TRoo_Hea_set_y</code> [K] [min=None, max=None]: Zone temperature heating setpoint for zone eas of floor 2
             </li>
             <li>
-            <code>hvac_floor2_reaZonEas_TSup_y</code> [K] [min=None, max=None]: Discharge air temperature to zone measurement for zone eas of floor 2
+            <code>hva_floor2_reaZonEas_TSup_y</code> [K] [min=None, max=None]: Discharge air temperature to zone measurement for zone eas of floor 2
             </li>
             <li>
-            <code>hvac_floor2_reaZonEas_TZon_y</code> [K] [min=None, max=None]: Zone air temperature measurement for zone eas of floor 2
+            <code>hva_floor2_reaZonEas_TZon_y</code> [K] [min=None, max=None]: Zone air temperature measurement for zone eas of floor 2
             </li>
             <li>
-            <code>hvac_floor2_reaZonEas_V_flow_set_y</code> [m3/s] [min=None, max=None]: Airflow setpoint of zone eas of floor 2
+            <code>hva_floor2_reaZonEas_V_flow_set_y</code> [m3/s] [min=None, max=None]: Airflow setpoint of zone eas of floor 2
             </li>
             <li>
-            <code>hvac_floor2_reaZonEas_V_flow_y</code> [m3/s] [min=None, max=None]: Discharge air flowrate to zone measurement for zone eas of floor 2
+            <code>hva_floor2_reaZonEas_V_flow_y</code> [m3/s] [min=None, max=None]: Discharge air flowrate to zone measurement for zone eas of floor 2
             </li>
             <li>
-            <code>hvac_floor2_reaZonEas_yCoo_y</code> [1] [min=None, max=None]: Cooling PID signal measurement for zone eas of floor 2
+            <code>hva_floor2_reaZonEas_yCoo_y</code> [1] [min=None, max=None]: Cooling PID signal measurement for zone eas of floor 2
             </li>
             <li>
-            <code>hvac_floor2_reaZonEas_yDam_y</code> [1] [min=None, max=None]: Damper position measurement for zone eas of floor 2
+            <code>hva_floor2_reaZonEas_yDam_y</code> [1] [min=None, max=None]: Damper position measurement for zone eas of floor 2
             </li>
             <li>
-            <code>hvac_floor2_reaZonEas_yHea_y</code> [1] [min=None, max=None]: Heating PID signal measurement for zone eas of floor 2
+            <code>hva_floor2_reaZonEas_yHea_y</code> [1] [min=None, max=None]: Heating PID signal measurement for zone eas of floor 2
             </li>
             <li>
-            <code>hvac_floor2_reaZonEas_yReheaVal_y</code> [1] [min=None, max=None]: Reheat valve position measurement for zone eas of floor 2
+            <code>hva_floor2_reaZonEas_yReheaVal_y</code> [1] [min=None, max=None]: Reheat valve position measurement for zone eas of floor 2
             </li>
             <li>
-            <code>hvac_floor2_reaZonNor_TRoo_Coo_set_y</code> [K] [min=None, max=None]: Zone temperature cooling setpoint for zone nor of floor 2
+            <code>hva_floor2_reaZonNor_TRoo_Coo_set_y</code> [K] [min=None, max=None]: Zone temperature cooling setpoint for zone nor of floor 2
             </li>
             <li>
-            <code>hvac_floor2_reaZonNor_TRoo_Hea_set_y</code> [K] [min=None, max=None]: Zone temperature heating setpoint for zone nor of floor 2
+            <code>hva_floor2_reaZonNor_TRoo_Hea_set_y</code> [K] [min=None, max=None]: Zone temperature heating setpoint for zone nor of floor 2
             </li>
             <li>
-            <code>hvac_floor2_reaZonNor_TSup_y</code> [K] [min=None, max=None]: Discharge air temperature to zone measurement for zone nor of floor 2
+            <code>hva_floor2_reaZonNor_TSup_y</code> [K] [min=None, max=None]: Discharge air temperature to zone measurement for zone nor of floor 2
             </li>
             <li>
-            <code>hvac_floor2_reaZonNor_TZon_y</code> [K] [min=None, max=None]: Zone air temperature measurement for zone nor of floor 2
+            <code>hva_floor2_reaZonNor_TZon_y</code> [K] [min=None, max=None]: Zone air temperature measurement for zone nor of floor 2
             </li>
             <li>
-            <code>hvac_floor2_reaZonNor_V_flow_set_y</code> [m3/s] [min=None, max=None]: Airflow setpoint of zone nor of floor 2
+            <code>hva_floor2_reaZonNor_V_flow_set_y</code> [m3/s] [min=None, max=None]: Airflow setpoint of zone nor of floor 2
             </li>
             <li>
-            <code>hvac_floor2_reaZonNor_V_flow_y</code> [m3/s] [min=None, max=None]: Discharge air flowrate to zone measurement for zone nor of floor 2
+            <code>hva_floor2_reaZonNor_V_flow_y</code> [m3/s] [min=None, max=None]: Discharge air flowrate to zone measurement for zone nor of floor 2
             </li>
             <li>
-            <code>hvac_floor2_reaZonNor_yCoo_y</code> [1] [min=None, max=None]: Cooling PID signal measurement for zone nor of floor 2
+            <code>hva_floor2_reaZonNor_yCoo_y</code> [1] [min=None, max=None]: Cooling PID signal measurement for zone nor of floor 2
             </li>
             <li>
-            <code>hvac_floor2_reaZonNor_yDam_y</code> [1] [min=None, max=None]: Damper position measurement for zone nor of floor 2
+            <code>hva_floor2_reaZonNor_yDam_y</code> [1] [min=None, max=None]: Damper position measurement for zone nor of floor 2
             </li>
             <li>
-            <code>hvac_floor2_reaZonNor_yHea_y</code> [1] [min=None, max=None]: Heating PID signal measurement for zone nor of floor 2
+            <code>hva_floor2_reaZonNor_yHea_y</code> [1] [min=None, max=None]: Heating PID signal measurement for zone nor of floor 2
             </li>
             <li>
-            <code>hvac_floor2_reaZonNor_yReheaVal_y</code> [1] [min=None, max=None]: Reheat valve position measurement for zone nor of floor 2
+            <code>hva_floor2_reaZonNor_yReheaVal_y</code> [1] [min=None, max=None]: Reheat valve position measurement for zone nor of floor 2
             </li>
             <li>
-            <code>hvac_floor2_reaZonSou_TRoo_Coo_set_y</code> [K] [min=None, max=None]: Zone temperature cooling setpoint for zone sou of floor 2
+            <code>hva_floor2_reaZonSou_TRoo_Coo_set_y</code> [K] [min=None, max=None]: Zone temperature cooling setpoint for zone sou of floor 2
             </li>
             <li>
-            <code>hvac_floor2_reaZonSou_TRoo_Hea_set_y</code> [K] [min=None, max=None]: Zone temperature heating setpoint for zone sou of floor 2
+            <code>hva_floor2_reaZonSou_TRoo_Hea_set_y</code> [K] [min=None, max=None]: Zone temperature heating setpoint for zone sou of floor 2
             </li>
             <li>
-            <code>hvac_floor2_reaZonSou_TSup_y</code> [K] [min=None, max=None]: Discharge air temperature to zone measurement for zone sou of floor 2
+            <code>hva_floor2_reaZonSou_TSup_y</code> [K] [min=None, max=None]: Discharge air temperature to zone measurement for zone sou of floor 2
             </li>
             <li>
-            <code>hvac_floor2_reaZonSou_TZon_y</code> [K] [min=None, max=None]: Zone air temperature measurement for zone sou of floor 2
+            <code>hva_floor2_reaZonSou_TZon_y</code> [K] [min=None, max=None]: Zone air temperature measurement for zone sou of floor 2
             </li>
             <li>
-            <code>hvac_floor2_reaZonSou_V_flow_set_y</code> [m3/s] [min=None, max=None]: Airflow setpoint of zone sou of floor 2
+            <code>hva_floor2_reaZonSou_V_flow_set_y</code> [m3/s] [min=None, max=None]: Airflow setpoint of zone sou of floor 2
             </li>
             <li>
-            <code>hvac_floor2_reaZonSou_V_flow_y</code> [m3/s] [min=None, max=None]: Discharge air flowrate to zone measurement for zone sou of floor 2
+            <code>hva_floor2_reaZonSou_V_flow_y</code> [m3/s] [min=None, max=None]: Discharge air flowrate to zone measurement for zone sou of floor 2
             </li>
             <li>
-            <code>hvac_floor2_reaZonSou_yCoo_y</code> [1] [min=None, max=None]: Cooling PID signal measurement for zone sou of floor 2
+            <code>hva_floor2_reaZonSou_yCoo_y</code> [1] [min=None, max=None]: Cooling PID signal measurement for zone sou of floor 2
             </li>
             <li>
-            <code>hvac_floor2_reaZonSou_yDam_y</code> [1] [min=None, max=None]: Damper position measurement for zone sou of floor 2
+            <code>hva_floor2_reaZonSou_yDam_y</code> [1] [min=None, max=None]: Damper position measurement for zone sou of floor 2
             </li>
             <li>
-            <code>hvac_floor2_reaZonSou_yHea_y</code> [1] [min=None, max=None]: Heating PID signal measurement for zone sou of floor 2
+            <code>hva_floor2_reaZonSou_yHea_y</code> [1] [min=None, max=None]: Heating PID signal measurement for zone sou of floor 2
             </li>
             <li>
-            <code>hvac_floor2_reaZonSou_yReheaVal_y</code> [1] [min=None, max=None]: Reheat valve position measurement for zone sou of floor 2
+            <code>hva_floor2_reaZonSou_yReheaVal_y</code> [1] [min=None, max=None]: Reheat valve position measurement for zone sou of floor 2
             </li>
             <li>
-            <code>hvac_floor2_reaZonWes_TRoo_Coo_set_y</code> [K] [min=None, max=None]: Zone temperature cooling setpoint for zone wes of floor 2
+            <code>hva_floor2_reaZonWes_TRoo_Coo_set_y</code> [K] [min=None, max=None]: Zone temperature cooling setpoint for zone wes of floor 2
             </li>
             <li>
-            <code>hvac_floor2_reaZonWes_TRoo_Hea_set_y</code> [K] [min=None, max=None]: Zone temperature heating setpoint for zone wes of floor 2
+            <code>hva_floor2_reaZonWes_TRoo_Hea_set_y</code> [K] [min=None, max=None]: Zone temperature heating setpoint for zone wes of floor 2
             </li>
             <li>
-            <code>hvac_floor2_reaZonWes_TSup_y</code> [K] [min=None, max=None]: Discharge air temperature to zone measurement for zone wes of floor 2
+            <code>hva_floor2_reaZonWes_TSup_y</code> [K] [min=None, max=None]: Discharge air temperature to zone measurement for zone wes of floor 2
             </li>
             <li>
-            <code>hvac_floor2_reaZonWes_TZon_y</code> [K] [min=None, max=None]: Zone air temperature measurement for zone wes of floor 2
+            <code>hva_floor2_reaZonWes_TZon_y</code> [K] [min=None, max=None]: Zone air temperature measurement for zone wes of floor 2
             </li>
             <li>
-            <code>hvac_floor2_reaZonWes_V_flow_set_y</code> [m3/s] [min=None, max=None]: Airflow setpoint of zone wes of floor 2
+            <code>hva_floor2_reaZonWes_V_flow_set_y</code> [m3/s] [min=None, max=None]: Airflow setpoint of zone wes of floor 2
             </li>
             <li>
-            <code>hvac_floor2_reaZonWes_V_flow_y</code> [m3/s] [min=None, max=None]: Discharge air flowrate to zone measurement for zone wes of floor 2
+            <code>hva_floor2_reaZonWes_V_flow_y</code> [m3/s] [min=None, max=None]: Discharge air flowrate to zone measurement for zone wes of floor 2
             </li>
             <li>
-            <code>hvac_floor2_reaZonWes_yCoo_y</code> [1] [min=None, max=None]: Cooling PID signal measurement for zone wes of floor 2
+            <code>hva_floor2_reaZonWes_yCoo_y</code> [1] [min=None, max=None]: Cooling PID signal measurement for zone wes of floor 2
             </li>
             <li>
-            <code>hvac_floor2_reaZonWes_yDam_y</code> [1] [min=None, max=None]: Damper position measurement for zone wes of floor 2
+            <code>hva_floor2_reaZonWes_yDam_y</code> [1] [min=None, max=None]: Damper position measurement for zone wes of floor 2
             </li>
             <li>
-            <code>hvac_floor2_reaZonWes_yHea_y</code> [1] [min=None, max=None]: Heating PID signal measurement for zone wes of floor 2
+            <code>hva_floor2_reaZonWes_yHea_y</code> [1] [min=None, max=None]: Heating PID signal measurement for zone wes of floor 2
             </li>
             <li>
-            <code>hvac_floor2_reaZonWes_yReheaVal_y</code> [1] [min=None, max=None]: Reheat valve position measurement for zone wes of floor 2
+            <code>hva_floor2_reaZonWes_yReheaVal_y</code> [1] [min=None, max=None]: Reheat valve position measurement for zone wes of floor 2
             </li>
             <li>
-            <code>hvac_floor2_readAhu_PFanTot_y</code> [W] [min=None, max=None]: Total electrical power measurement of supply and return fans for AHU of floor 2
+            <code>hva_floor2_readAhu_PFanTot_y</code> [W] [min=None, max=None]: Total electrical power measurement of supply and return fans for AHU of floor 2
             </li>
             <li>
-            <code>hvac_floor2_readAhu_TCooCoiRet_y</code> [K] [min=None, max=None]: Cooling coil return water temperature measurement for AHU of floor 2
+            <code>hva_floor2_readAhu_TCooCoiRet_y</code> [K] [min=None, max=None]: Cooling coil return water temperature measurement for AHU of floor 2
             </li>
             <li>
-            <code>hvac_floor2_readAhu_TCooCoiSup_y</code> [K] [min=None, max=None]: Cooling coil supply water temperature measurement for AHU of floor 2
+            <code>hva_floor2_readAhu_TCooCoiSup_y</code> [K] [min=None, max=None]: Cooling coil supply water temperature measurement for AHU of floor 2
             </li>
             <li>
-            <code>hvac_floor2_readAhu_TMix_y</code> [K] [min=None, max=None]: Mixed air temperature measurement for AHU of floor 2
+            <code>hva_floor2_readAhu_TMix_y</code> [K] [min=None, max=None]: Mixed air temperature measurement for AHU of floor 2
             </li>
             <li>
-            <code>hvac_floor2_readAhu_TRet_y</code> [K] [min=None, max=None]: Return air temperature measurement for AHU of floor 2
+            <code>hva_floor2_readAhu_TRet_y</code> [K] [min=None, max=None]: Return air temperature measurement for AHU of floor 2
             </li>
             <li>
-            <code>hvac_floor2_readAhu_TSup_set_y</code> [K] [min=None, max=None]: Supply air temperature setpoint measurement for AHU of floor 2
+            <code>hva_floor2_readAhu_TSup_set_y</code> [K] [min=None, max=None]: Supply air temperature setpoint measurement for AHU of floor 2
             </li>
             <li>
-            <code>hvac_floor2_readAhu_TSup_y</code> [K] [min=None, max=None]: Supply air temperature measurement for AHU of floor 2
+            <code>hva_floor2_readAhu_TSup_y</code> [K] [min=None, max=None]: Supply air temperature measurement for AHU of floor 2
             </li>
             <li>
-            <code>hvac_floor2_readAhu_V_flow_OA_y</code> [m3/s] [min=None, max=None]: Supply outdoor airflow rate measurement for AHU of floor 2
+            <code>hva_floor2_readAhu_V_flow_OA_y</code> [m3/s] [min=None, max=None]: Supply outdoor airflow rate measurement for AHU of floor 2
             </li>
             <li>
-            <code>hvac_floor2_readAhu_V_flow_ret_y</code> [m3/s] [min=None, max=None]: Return air flowrate measurement for AHU of floor 2
+            <code>hva_floor2_readAhu_V_flow_ret_y</code> [m3/s] [min=None, max=None]: Return air flowrate measurement for AHU of floor 2
             </li>
             <li>
-            <code>hvac_floor2_readAhu_V_flow_sup_y</code> [m3/s] [min=None, max=None]: Supply air flowrate measurement for AHU of floor 2
+            <code>hva_floor2_readAhu_V_flow_sup_y</code> [m3/s] [min=None, max=None]: Supply air flowrate measurement for AHU of floor 2
             </li>
             <li>
-            <code>hvac_floor2_readAhu_dp_sup_y</code> [Pa] [min=None, max=None]: Discharge pressure of supply fan for AHU of floor 2
+            <code>hva_floor2_readAhu_dp_sup_y</code> [Pa] [min=None, max=None]: Discharge pressure of supply fan for AHU of floor 2
             </li>
             <li>
-            <code>hvac_floor2_readAhu_occ_y</code> [1] [min=None, max=None]: Occupancy status of floor 2 (1 occupied, 0 unoccupied)
+            <code>hva_floor2_readAhu_occ_y</code> [1] [min=None, max=None]: Occupancy status of floor 2 (1 occupied, 0 unoccupied)
             </li>
             <li>
-            <code>hvac_floor2_readAhu_yCooVal_y</code> [1] [min=None, max=None]: AHU cooling coil valve position measurement of floor 2
+            <code>hva_floor2_readAhu_yCooVal_y</code> [1] [min=None, max=None]: AHU cooling coil valve position measurement of floor 2
             </li>
             <li>
-            <code>hvac_floor2_readAhu_yOA_y</code> [1] [min=None, max=None]: AHU cooling coil valve position measurement of floor 2
+            <code>hva_floor2_readAhu_yOA_y</code> [1] [min=None, max=None]: AHU cooling coil valve position measurement of floor 2
             </li>
             <li>
-            <code>hvac_floor3_reaZonCor_TRoo_Coo_set_y</code> [K] [min=None, max=None]: Zone temperature cooling setpoint for zone cor of floor 3
+            <code>hva_floor3_reaZonCor_TRoo_Coo_set_y</code> [K] [min=None, max=None]: Zone temperature cooling setpoint for zone cor of floor 3
             </li>
             <li>
-            <code>hvac_floor3_reaZonCor_TRoo_Hea_set_y</code> [K] [min=None, max=None]: Zone temperature heating setpoint for zone cor of floor 3
+            <code>hva_floor3_reaZonCor_TRoo_Hea_set_y</code> [K] [min=None, max=None]: Zone temperature heating setpoint for zone cor of floor 3
             </li>
             <li>
-            <code>hvac_floor3_reaZonCor_TSup_y</code> [K] [min=None, max=None]: Discharge air temperature to zone measurement for zone cor of floor 3
+            <code>hva_floor3_reaZonCor_TSup_y</code> [K] [min=None, max=None]: Discharge air temperature to zone measurement for zone cor of floor 3
             </li>
             <li>
-            <code>hvac_floor3_reaZonCor_TZon_y</code> [K] [min=None, max=None]: Zone air temperature measurement for zone cor of floor 3
+            <code>hva_floor3_reaZonCor_TZon_y</code> [K] [min=None, max=None]: Zone air temperature measurement for zone cor of floor 3
             </li>
             <li>
-            <code>hvac_floor3_reaZonCor_V_flow_set_y</code> [m3/s] [min=None, max=None]: Airflow setpoint of zone cor of floor 3
+            <code>hva_floor3_reaZonCor_V_flow_set_y</code> [m3/s] [min=None, max=None]: Airflow setpoint of zone cor of floor 3
             </li>
             <li>
-            <code>hvac_floor3_reaZonCor_V_flow_y</code> [m3/s] [min=None, max=None]: Discharge air flowrate to zone measurement for zone cor of floor 3
+            <code>hva_floor3_reaZonCor_V_flow_y</code> [m3/s] [min=None, max=None]: Discharge air flowrate to zone measurement for zone cor of floor 3
             </li>
             <li>
-            <code>hvac_floor3_reaZonCor_yCoo_y</code> [1] [min=None, max=None]: Cooling PID signal measurement for zone cor of floor 3
+            <code>hva_floor3_reaZonCor_yCoo_y</code> [1] [min=None, max=None]: Cooling PID signal measurement for zone cor of floor 3
             </li>
             <li>
-            <code>hvac_floor3_reaZonCor_yDam_y</code> [1] [min=None, max=None]: Damper position measurement for zone cor of floor 3
+            <code>hva_floor3_reaZonCor_yDam_y</code> [1] [min=None, max=None]: Damper position measurement for zone cor of floor 3
             </li>
             <li>
-            <code>hvac_floor3_reaZonCor_yHea_y</code> [1] [min=None, max=None]: Heating PID signal measurement for zone cor of floor 3
+            <code>hva_floor3_reaZonCor_yHea_y</code> [1] [min=None, max=None]: Heating PID signal measurement for zone cor of floor 3
             </li>
             <li>
-            <code>hvac_floor3_reaZonCor_yReheaVal_y</code> [1] [min=None, max=None]: Reheat valve position measurement for zone cor of floor 3
+            <code>hva_floor3_reaZonCor_yReheaVal_y</code> [1] [min=None, max=None]: Reheat valve position measurement for zone cor of floor 3
             </li>
             <li>
-            <code>hvac_floor3_reaZonEas_TRoo_Coo_set_y</code> [K] [min=None, max=None]: Zone temperature cooling setpoint for zone eas of floor 3
+            <code>hva_floor3_reaZonEas_TRoo_Coo_set_y</code> [K] [min=None, max=None]: Zone temperature cooling setpoint for zone eas of floor 3
             </li>
             <li>
-            <code>hvac_floor3_reaZonEas_TRoo_Hea_set_y</code> [K] [min=None, max=None]: Zone temperature heating setpoint for zone eas of floor 3
+            <code>hva_floor3_reaZonEas_TRoo_Hea_set_y</code> [K] [min=None, max=None]: Zone temperature heating setpoint for zone eas of floor 3
             </li>
             <li>
-            <code>hvac_floor3_reaZonEas_TSup_y</code> [K] [min=None, max=None]: Discharge air temperature to zone measurement for zone eas of floor 3
+            <code>hva_floor3_reaZonEas_TSup_y</code> [K] [min=None, max=None]: Discharge air temperature to zone measurement for zone eas of floor 3
             </li>
             <li>
-            <code>hvac_floor3_reaZonEas_TZon_y</code> [K] [min=None, max=None]: Zone air temperature measurement for zone eas of floor 3
+            <code>hva_floor3_reaZonEas_TZon_y</code> [K] [min=None, max=None]: Zone air temperature measurement for zone eas of floor 3
             </li>
             <li>
-            <code>hvac_floor3_reaZonEas_V_flow_set_y</code> [m3/s] [min=None, max=None]: Airflow setpoint of zone eas of floor 3
+            <code>hva_floor3_reaZonEas_V_flow_set_y</code> [m3/s] [min=None, max=None]: Airflow setpoint of zone eas of floor 3
             </li>
             <li>
-            <code>hvac_floor3_reaZonEas_V_flow_y</code> [m3/s] [min=None, max=None]: Discharge air flowrate to zone measurement for zone eas of floor 3
+            <code>hva_floor3_reaZonEas_V_flow_y</code> [m3/s] [min=None, max=None]: Discharge air flowrate to zone measurement for zone eas of floor 3
             </li>
             <li>
-            <code>hvac_floor3_reaZonEas_yCoo_y</code> [1] [min=None, max=None]: Cooling PID signal measurement for zone eas of floor 3
+            <code>hva_floor3_reaZonEas_yCoo_y</code> [1] [min=None, max=None]: Cooling PID signal measurement for zone eas of floor 3
             </li>
             <li>
-            <code>hvac_floor3_reaZonEas_yDam_y</code> [1] [min=None, max=None]: Damper position measurement for zone eas of floor 3
+            <code>hva_floor3_reaZonEas_yDam_y</code> [1] [min=None, max=None]: Damper position measurement for zone eas of floor 3
             </li>
             <li>
-            <code>hvac_floor3_reaZonEas_yHea_y</code> [1] [min=None, max=None]: Heating PID signal measurement for zone eas of floor 3
+            <code>hva_floor3_reaZonEas_yHea_y</code> [1] [min=None, max=None]: Heating PID signal measurement for zone eas of floor 3
             </li>
             <li>
-            <code>hvac_floor3_reaZonEas_yReheaVal_y</code> [1] [min=None, max=None]: Reheat valve position measurement for zone eas of floor 3
+            <code>hva_floor3_reaZonEas_yReheaVal_y</code> [1] [min=None, max=None]: Reheat valve position measurement for zone eas of floor 3
             </li>
             <li>
-            <code>hvac_floor3_reaZonNor_TRoo_Coo_set_y</code> [K] [min=None, max=None]: Zone temperature cooling setpoint for zone nor of floor 3
+            <code>hva_floor3_reaZonNor_TRoo_Coo_set_y</code> [K] [min=None, max=None]: Zone temperature cooling setpoint for zone nor of floor 3
             </li>
             <li>
-            <code>hvac_floor3_reaZonNor_TRoo_Hea_set_y</code> [K] [min=None, max=None]: Zone temperature heating setpoint for zone nor of floor 3
+            <code>hva_floor3_reaZonNor_TRoo_Hea_set_y</code> [K] [min=None, max=None]: Zone temperature heating setpoint for zone nor of floor 3
             </li>
             <li>
-            <code>hvac_floor3_reaZonNor_TSup_y</code> [K] [min=None, max=None]: Discharge air temperature to zone measurement for zone nor of floor 3
+            <code>hva_floor3_reaZonNor_TSup_y</code> [K] [min=None, max=None]: Discharge air temperature to zone measurement for zone nor of floor 3
             </li>
             <li>
-            <code>hvac_floor3_reaZonNor_TZon_y</code> [K] [min=None, max=None]: Zone air temperature measurement for zone nor of floor 3
+            <code>hva_floor3_reaZonNor_TZon_y</code> [K] [min=None, max=None]: Zone air temperature measurement for zone nor of floor 3
             </li>
             <li>
-            <code>hvac_floor3_reaZonNor_V_flow_set_y</code> [m3/s] [min=None, max=None]: Airflow setpoint of zone nor of floor 3
+            <code>hva_floor3_reaZonNor_V_flow_set_y</code> [m3/s] [min=None, max=None]: Airflow setpoint of zone nor of floor 3
             </li>
             <li>
-            <code>hvac_floor3_reaZonNor_V_flow_y</code> [m3/s] [min=None, max=None]: Discharge air flowrate to zone measurement for zone nor of floor 3
+            <code>hva_floor3_reaZonNor_V_flow_y</code> [m3/s] [min=None, max=None]: Discharge air flowrate to zone measurement for zone nor of floor 3
             </li>
             <li>
-            <code>hvac_floor3_reaZonNor_yCoo_y</code> [1] [min=None, max=None]: Cooling PID signal measurement for zone nor of floor 3
+            <code>hva_floor3_reaZonNor_yCoo_y</code> [1] [min=None, max=None]: Cooling PID signal measurement for zone nor of floor 3
             </li>
             <li>
-            <code>hvac_floor3_reaZonNor_yDam_y</code> [1] [min=None, max=None]: Damper position measurement for zone nor of floor 3
+            <code>hva_floor3_reaZonNor_yDam_y</code> [1] [min=None, max=None]: Damper position measurement for zone nor of floor 3
             </li>
             <li>
-            <code>hvac_floor3_reaZonNor_yHea_y</code> [1] [min=None, max=None]: Heating PID signal measurement for zone nor of floor 3
+            <code>hva_floor3_reaZonNor_yHea_y</code> [1] [min=None, max=None]: Heating PID signal measurement for zone nor of floor 3
             </li>
             <li>
-            <code>hvac_floor3_reaZonNor_yReheaVal_y</code> [1] [min=None, max=None]: Reheat valve position measurement for zone nor of floor 3
+            <code>hva_floor3_reaZonNor_yReheaVal_y</code> [1] [min=None, max=None]: Reheat valve position measurement for zone nor of floor 3
             </li>
             <li>
-            <code>hvac_floor3_reaZonSou_TRoo_Coo_set_y</code> [K] [min=None, max=None]: Zone temperature cooling setpoint for zone sou of floor 3
+            <code>hva_floor3_reaZonSou_TRoo_Coo_set_y</code> [K] [min=None, max=None]: Zone temperature cooling setpoint for zone sou of floor 3
             </li>
             <li>
-            <code>hvac_floor3_reaZonSou_TRoo_Hea_set_y</code> [K] [min=None, max=None]: Zone temperature heating setpoint for zone sou of floor 3
+            <code>hva_floor3_reaZonSou_TRoo_Hea_set_y</code> [K] [min=None, max=None]: Zone temperature heating setpoint for zone sou of floor 3
             </li>
             <li>
-            <code>hvac_floor3_reaZonSou_TSup_y</code> [K] [min=None, max=None]: Discharge air temperature to zone measurement for zone sou of floor 3
+            <code>hva_floor3_reaZonSou_TSup_y</code> [K] [min=None, max=None]: Discharge air temperature to zone measurement for zone sou of floor 3
             </li>
             <li>
-            <code>hvac_floor3_reaZonSou_TZon_y</code> [K] [min=None, max=None]: Zone air temperature measurement for zone sou of floor 3
+            <code>hva_floor3_reaZonSou_TZon_y</code> [K] [min=None, max=None]: Zone air temperature measurement for zone sou of floor 3
             </li>
             <li>
-            <code>hvac_floor3_reaZonSou_V_flow_set_y</code> [m3/s] [min=None, max=None]: Airflow setpoint of zone sou of floor 3
+            <code>hva_floor3_reaZonSou_V_flow_set_y</code> [m3/s] [min=None, max=None]: Airflow setpoint of zone sou of floor 3
             </li>
             <li>
-            <code>hvac_floor3_reaZonSou_V_flow_y</code> [m3/s] [min=None, max=None]: Discharge air flowrate to zone measurement for zone sou of floor 3
+            <code>hva_floor3_reaZonSou_V_flow_y</code> [m3/s] [min=None, max=None]: Discharge air flowrate to zone measurement for zone sou of floor 3
             </li>
             <li>
-            <code>hvac_floor3_reaZonSou_yCoo_y</code> [1] [min=None, max=None]: Cooling PID signal measurement for zone sou of floor 3
+            <code>hva_floor3_reaZonSou_yCoo_y</code> [1] [min=None, max=None]: Cooling PID signal measurement for zone sou of floor 3
             </li>
             <li>
-            <code>hvac_floor3_reaZonSou_yDam_y</code> [1] [min=None, max=None]: Damper position measurement for zone sou of floor 3
+            <code>hva_floor3_reaZonSou_yDam_y</code> [1] [min=None, max=None]: Damper position measurement for zone sou of floor 3
             </li>
             <li>
-            <code>hvac_floor3_reaZonSou_yHea_y</code> [1] [min=None, max=None]: Heating PID signal measurement for zone sou of floor 3
+            <code>hva_floor3_reaZonSou_yHea_y</code> [1] [min=None, max=None]: Heating PID signal measurement for zone sou of floor 3
             </li>
             <li>
-            <code>hvac_floor3_reaZonSou_yReheaVal_y</code> [1] [min=None, max=None]: Reheat valve position measurement for zone sou of floor 3
+            <code>hva_floor3_reaZonSou_yReheaVal_y</code> [1] [min=None, max=None]: Reheat valve position measurement for zone sou of floor 3
             </li>
             <li>
-            <code>hvac_floor3_reaZonWes_TRoo_Coo_set_y</code> [K] [min=None, max=None]: Zone temperature cooling setpoint for zone wes of floor 3
+            <code>hva_floor3_reaZonWes_TRoo_Coo_set_y</code> [K] [min=None, max=None]: Zone temperature cooling setpoint for zone wes of floor 3
             </li>
             <li>
-            <code>hvac_floor3_reaZonWes_TRoo_Hea_set_y</code> [K] [min=None, max=None]: Zone temperature heating setpoint for zone wes of floor 3
+            <code>hva_floor3_reaZonWes_TRoo_Hea_set_y</code> [K] [min=None, max=None]: Zone temperature heating setpoint for zone wes of floor 3
             </li>
             <li>
-            <code>hvac_floor3_reaZonWes_TSup_y</code> [K] [min=None, max=None]: Discharge air temperature to zone measurement for zone wes of floor 3
+            <code>hva_floor3_reaZonWes_TSup_y</code> [K] [min=None, max=None]: Discharge air temperature to zone measurement for zone wes of floor 3
             </li>
             <li>
-            <code>hvac_floor3_reaZonWes_TZon_y</code> [K] [min=None, max=None]: Zone air temperature measurement for zone wes of floor 3
+            <code>hva_floor3_reaZonWes_TZon_y</code> [K] [min=None, max=None]: Zone air temperature measurement for zone wes of floor 3
             </li>
             <li>
-            <code>hvac_floor3_reaZonWes_V_flow_set_y</code> [m3/s] [min=None, max=None]: Airflow setpoint of zone wes of floor 3
+            <code>hva_floor3_reaZonWes_V_flow_set_y</code> [m3/s] [min=None, max=None]: Airflow setpoint of zone wes of floor 3
             </li>
             <li>
-            <code>hvac_floor3_reaZonWes_V_flow_y</code> [m3/s] [min=None, max=None]: Discharge air flowrate to zone measurement for zone wes of floor 3
+            <code>hva_floor3_reaZonWes_V_flow_y</code> [m3/s] [min=None, max=None]: Discharge air flowrate to zone measurement for zone wes of floor 3
             </li>
             <li>
-            <code>hvac_floor3_reaZonWes_yCoo_y</code> [1] [min=None, max=None]: Cooling PID signal measurement for zone wes of floor 3
+            <code>hva_floor3_reaZonWes_yCoo_y</code> [1] [min=None, max=None]: Cooling PID signal measurement for zone wes of floor 3
             </li>
             <li>
-            <code>hvac_floor3_reaZonWes_yDam_y</code> [1] [min=None, max=None]: Damper position measurement for zone wes of floor 3
+            <code>hva_floor3_reaZonWes_yDam_y</code> [1] [min=None, max=None]: Damper position measurement for zone wes of floor 3
             </li>
             <li>
-            <code>hvac_floor3_reaZonWes_yHea_y</code> [1] [min=None, max=None]: Heating PID signal measurement for zone wes of floor 3
+            <code>hva_floor3_reaZonWes_yHea_y</code> [1] [min=None, max=None]: Heating PID signal measurement for zone wes of floor 3
             </li>
             <li>
-            <code>hvac_floor3_reaZonWes_yReheaVal_y</code> [1] [min=None, max=None]: Reheat valve position measurement for zone wes of floor 3
+            <code>hva_floor3_reaZonWes_yReheaVal_y</code> [1] [min=None, max=None]: Reheat valve position measurement for zone wes of floor 3
             </li>
             <li>
-            <code>hvac_floor3_readAhu_PFanTot_y</code> [W] [min=None, max=None]: Total electrical power measurement of supply and return fans for AHU of floor 3
+            <code>hva_floor3_readAhu_PFanTot_y</code> [W] [min=None, max=None]: Total electrical power measurement of supply and return fans for AHU of floor 3
             </li>
             <li>
-            <code>hvac_floor3_readAhu_TCooCoiRet_y</code> [K] [min=None, max=None]: Cooling coil return water temperature measurement for AHU of floor 3
+            <code>hva_floor3_readAhu_TCooCoiRet_y</code> [K] [min=None, max=None]: Cooling coil return water temperature measurement for AHU of floor 3
             </li>
             <li>
-            <code>hvac_floor3_readAhu_TCooCoiSup_y</code> [K] [min=None, max=None]: Cooling coil supply water temperature measurement for AHU of floor 3
+            <code>hva_floor3_readAhu_TCooCoiSup_y</code> [K] [min=None, max=None]: Cooling coil supply water temperature measurement for AHU of floor 3
             </li>
             <li>
-            <code>hvac_floor3_readAhu_TMix_y</code> [K] [min=None, max=None]: Mixed air temperature measurement for AHU of floor 3
+            <code>hva_floor3_readAhu_TMix_y</code> [K] [min=None, max=None]: Mixed air temperature measurement for AHU of floor 3
             </li>
             <li>
-            <code>hvac_floor3_readAhu_TRet_y</code> [K] [min=None, max=None]: Return air temperature measurement for AHU of floor 3
+            <code>hva_floor3_readAhu_TRet_y</code> [K] [min=None, max=None]: Return air temperature measurement for AHU of floor 3
             </li>
             <li>
-            <code>hvac_floor3_readAhu_TSup_set_y</code> [K] [min=None, max=None]: Supply air temperature setpoint measurement for AHU of floor 3
+            <code>hva_floor3_readAhu_TSup_set_y</code> [K] [min=None, max=None]: Supply air temperature setpoint measurement for AHU of floor 3
             </li>
             <li>
-            <code>hvac_floor3_readAhu_TSup_y</code> [K] [min=None, max=None]: Supply air temperature measurement for AHU of floor 3
+            <code>hva_floor3_readAhu_TSup_y</code> [K] [min=None, max=None]: Supply air temperature measurement for AHU of floor 3
             </li>
             <li>
-            <code>hvac_floor3_readAhu_V_flow_OA_y</code> [m3/s] [min=None, max=None]: Supply outdoor airflow rate measurement for AHU of floor 3
+            <code>hva_floor3_readAhu_V_flow_OA_y</code> [m3/s] [min=None, max=None]: Supply outdoor airflow rate measurement for AHU of floor 3
             </li>
             <li>
-            <code>hvac_floor3_readAhu_V_flow_ret_y</code> [m3/s] [min=None, max=None]: Return air flowrate measurement for AHU of floor 3
+            <code>hva_floor3_readAhu_V_flow_ret_y</code> [m3/s] [min=None, max=None]: Return air flowrate measurement for AHU of floor 3
             </li>
             <li>
-            <code>hvac_floor3_readAhu_V_flow_sup_y</code> [m3/s] [min=None, max=None]: Supply air flowrate measurement for AHU of floor 3
+            <code>hva_floor3_readAhu_V_flow_sup_y</code> [m3/s] [min=None, max=None]: Supply air flowrate measurement for AHU of floor 3
             </li>
             <li>
-            <code>hvac_floor3_readAhu_dp_sup_y</code> [Pa] [min=None, max=None]: Discharge pressure of supply fan for AHU of floor 3
+            <code>hva_floor3_readAhu_dp_sup_y</code> [Pa] [min=None, max=None]: Discharge pressure of supply fan for AHU of floor 3
             </li>
             <li>
-            <code>hvac_floor3_readAhu_occ_y</code> [1] [min=None, max=None]: Occupancy status of floor 3 (1 occupied, 0 unoccupied)
+            <code>hva_floor3_readAhu_occ_y</code> [1] [min=None, max=None]: Occupancy status of floor 3 (1 occupied, 0 unoccupied)
             </li>
             <li>
-            <code>hvac_floor3_readAhu_yCooVal_y</code> [1] [min=None, max=None]: AHU cooling coil valve position measurement of floor 3
+            <code>hva_floor3_readAhu_yCooVal_y</code> [1] [min=None, max=None]: AHU cooling coil valve position measurement of floor 3
             </li>
             <li>
-            <code>hvac_floor3_readAhu_yOA_y</code> [1] [min=None, max=None]: AHU cooling coil valve position measurement of floor 3
+            <code>hva_floor3_readAhu_yOA_y</code> [1] [min=None, max=None]: AHU cooling coil valve position measurement of floor 3
             </li>
             <li>
-            <code>hvac_reaChiWatSys_TW_y</code> [K] [min=None, max=None]: Chilled water temperature measurement of floor 3
+            <code>hva_reaChiWatSys_TW_y</code> [K] [min=None, max=None]: Chilled water temperature measurement of floor 3
             </li>
             <li>
-            <code>hvac_reaChiWatSys_dp_y</code> [K] [min=None, max=None]: Differential pressure of chilled/hot water measurement
+            <code>hva_reaChiWatSys_dp_y</code> [K] [min=None, max=None]: Differential pressure of chilled/hot water measurement
             </li>
             <li>
-            <code>hvac_reaChiWatSys_reaPChi_y</code> [W] [min=None, max=None]: Multiple chiller power consumption
+            <code>hva_reaChiWatSys_reaPChi_y</code> [W] [min=None, max=None]: Multiple chiller power consumption
             </li>
             <li>
-            <code>hvac_reaChiWatSys_reaPCooTow_y</code> [W] [min=None, max=None]: Multiple cooling tower power consumption
+            <code>hva_reaChiWatSys_reaPCooTow_y</code> [W] [min=None, max=None]: Multiple cooling tower power consumption
             </li>
             <li>
-            <code>hvac_reaChiWatSys_reaPPum_y</code> [W] [min=None, max=None]: Chilled water plant pump power consumption
+            <code>hva_reaChiWatSys_reaPPum_y</code> [W] [min=None, max=None]: Chilled water plant pump power consumption
             </li>
             <li>
-            <code>hvac_reaHotWatSys_TW_y</code> [K] [min=None, max=None]: Chilled water temperature measurement
+            <code>hva_reaHotWatSys_TW_y</code> [K] [min=None, max=None]: Chilled water temperature measurement
             </li>
             <li>
-            <code>hvac_reaHotWatSys_dp_y</code> [K] [min=None, max=None]: Differential pressure of chilled/hot water measurement
+            <code>hva_reaHotWatSys_dp_y</code> [K] [min=None, max=None]: Differential pressure of chilled/hot water measurement
             </li>
             <li>
-            <code>hvac_reaHotWatSys_reaPBoi_y</code> [W] [min=None, max=None]: Multiple gas power consumption
+            <code>hva_reaHotWatSys_reaPBoi_y</code> [W] [min=None, max=None]: Multiple gas power consumption
             </li>
             <li>
-            <code>hvac_reaHotWatSys_reaPPum_y</code> [W] [min=None, max=None]: Chilled water plant pump power consumption
+            <code>hva_reaHotWatSys_reaPPum_y</code> [W] [min=None, max=None]: Chilled water plant pump power consumption
             </li>
             <li>
             <code>loaEPlus_weatherStation_reaWeaCeiHei_y</code> [m] [min=None, max=None]: Cloud cover ceiling height measurement

--- a/testcases/multizone_office_complex_air/doc/index.html
+++ b/testcases/multizone_office_complex_air/doc/index.html
@@ -1781,7 +1781,7 @@
 			<code>hva_reaChiWatSys_mCHW_tot_y</code> [kg/s] [min=None, max=None]: Chilled water total mass flow rate measurement
             </li>
             <li>
-            <code>hva_reaChiWatSys_dp_y</code> [K] [min=None, max=None]: Differential pressure of chilled/hot water measurement
+            <code>hva_reaChiWatSys_dp_y</code> [Pa] [min=None, max=None]: Differential pressure of chilled/hot water measurement
             </li>
             <li>
             <code>hva_reaChiWatSys_reaPChi_y</code> [W] [min=None, max=None]: Multiple chiller power consumption
@@ -1802,7 +1802,7 @@
 			<code>hva_reaHotWatSys_mHW_tot_y</code> [kg/s] [min=None, max=None]: Hot water total mass flow rate measurement
             </li>
             <li>
-            <code>hva_reaHotWatSys_dp_y</code> [K] [min=None, max=None]: Differential pressure of chilled/hot water measurement
+            <code>hva_reaHotWatSys_dp_y</code> [Pa] [min=None, max=None]: Differential pressure of chilled/hot water measurement
             </li>
             <li>
             <code>hva_reaHotWatSys_reaPBoi_y</code> [W] [min=None, max=None]: Multiple gas power consumption

--- a/testcases/multizone_office_complex_air/doc/index.html
+++ b/testcases/multizone_office_complex_air/doc/index.html
@@ -150,338 +150,394 @@
 
  <br>
 <table cellspacing=\"2\" cellpadding=\"0\" border=\"0\" summary=\"Layers\">
-    <thread>
-    <tr>
-      <th>VAV terminal with Reheat Coil</th>
-      <th>Design Air Mass Flow Rate [kg/s]</th>
-      <th>Minimum Damper Position</th>
-      <th>Design Reheat Coil Water Mass Flow Rate [kg/s]</th>
+    <thread>
+    <tr>
+      <th>VAV terminal with Reheat Coil</th>
+      <th>Design Air Mass Flow Rate [kg/s]</th>
+      <th>Minimum Damper Position</th>
+      <th>Design Reheat Coil Water Mass Flow Rate [kg/s]</th>
 
-    </tr>
+
+
+    </tr>
   </thead>
   <tbody>
-    <tr>
-      <td>Bot Floor Core Zone VAV</td>
-      <td>31.45</td>
-      <td>0.3</td>
-      <td>2.48</td>
+    <tr>
+      <td>Bot Floor Core Zone VAV</td>
+      <td>39.312</td>
+      <td>0.3</td>
+      <td>3.106</td>
 
 
-    </tr>
-    <tr>
-      <td>Mid Floor Core Zone VAV</td>
-      <td>314.5</td>
-      <td>0.3</td>
-      <td>24.8</td>
-
-    </tr>
-    <tr>
-      <td>Top Floor Core Zone VAV</td>
-      <td>31.45</td>
-      <td>0.3</td>
-      <td>2.48</td>
-
-    </tr>
-    <tr>
-      <td>Bot Floor South Zone VAV</td>
-      <td>6.48</td>
-      <td>0.3</td>
-      <td>0.51</td>
 
 
-    </tr>
-    <tr>
-      <td>Bot Floor East Zone VAV</td>
-      <td>4.29</td>
-      <td>0.3</td>
-      <td>0.34</td>
+
+    </tr>
+    <tr>
+      <td>Mid Floor Core Zone VAV</td>
+      <td>393.12</td>
+      <td>0.3</td>
+      <td>31.06</td>
 
 
-    </tr>
-    <tr>
-      <td>Bot Floor North Zone VAV</td>
-      <td>5.47</td>
-      <td>0.3</td>
-      <td>0.43</td>
 
-    </tr>
-    <tr>
-      <td>Bot Floor West Zone VAV</td>
-      <td>4.98</td>
-      <td>0.3</td>
-      <td>0.39</td>
+    </tr>
+    <tr>
+      <td>Top Floor Core Zone VAV</td>
+      <td>39.312</td>
+      <td>0.3</td>
+      <td>3.106</td>
 
 
-    </tr>
-    <tr>
-      <td>Mid Floor South Zone VAV</td>
-      <td>64.8</td>
-      <td>0.3</td>
-      <td>5.12</td>
+
+    </tr>
+    <tr>
+      <td>Bot Floor South Zone VAV</td>
+      <td>8.1</td>
+      <td>0.3</td>
+      <td>0.6399</td>
 
 
-    </tr>
-    <tr>
-      <td>Mid Floor East Zone VAV</td>
-      <td>42.9</td>
-      <td>0.3</td>
-      <td>3.39</td>
-
-    </tr>
-    <tr>
-      <td>Mid Floor North Zone VAV</td>
-      <td>54.7</td>
-      <td>0.3</td>
-      <td>4.32</td>
 
 
-    </tr>
-    <tr>
-      <td>Mid Floor West Zone VAV</td>
-      <td>49.8</td>
-      <td>0.3</td>
-      <td>3.93</td>
+
+    </tr>
+    <tr>
+      <td>Bot Floor East Zone VAV</td>
+      <td>5.364</td>
+      <td>0.3</td>
+      <td>0.424</td>
 
 
-    </tr>
-    <tr>
-      <td>Top Floor South Zone VAV</td>
-      <td>6.48</td>
-      <td>0.3</td>
-      <td>0.51</td>
 
 
-    </tr>
-    <tr>
-      <td>Top Floor East Zone VAV</td>
-      <td>4.29</td>
-      <td>0.3</td>
-      <td>0.34</td>
+
+    </tr>
+    <tr>
+      <td>Bot Floor North Zone VAV</td>
+      <td>6.84</td>
+      <td>0.3</td>
+      <td>0.5404</td>
 
 
-    </tr>
-    <tr>
-      <td>Top Floor North Zone VAV</td>
-      <td>5.47</td>
-      <td>0.3</td>
-      <td>0.43</td>
+
+    </tr>
+    <tr>
+      <td>Bot Floor West Zone VAV</td>
+      <td>6.228</td>
+      <td>0.3</td>
+      <td>0.492</td>
 
 
-    </tr>
-    <tr>
-        <td>Top Floor West Zone VAV</td>
-        <td>4.98</td>
-        <td>0.3</td>
-        <td>0.39</td>
 
-      </tr>
+
+
+    </tr>
+    <tr>
+      <td>Mid Floor South Zone VAV</td>
+      <td>81</td>
+      <td>0.3</td>
+      <td>6.339</td>
+
+
+
+
+
+    </tr>
+    <tr>
+      <td>Mid Floor East Zone VAV</td>
+      <td>53.64</td>
+      <td>0.3</td>
+      <td>4.238</td>
+
+
+
+    </tr>
+    <tr>
+      <td>Mid Floor North Zone VAV</td>
+      <td>68.4</td>
+      <td>0.3</td>
+      <td>5.404</td>
+
+
+
+
+
+    </tr>
+    <tr>
+      <td>Mid Floor West Zone VAV</td>
+      <td>62.28</td>
+      <td>0.3</td>
+      <td>4.92</td>
+
+
+
+
+
+    </tr>
+    <tr>
+      <td>Top Floor South Zone VAV</td>
+      <td>8.1</td>
+      <td>0.3</td>
+      <td>0.6399</td>
+
+
+
+
+
+    </tr>
+    <tr>
+      <td>Top Floor East Zone VAV</td>
+      <td>5.364</td>
+      <td>0.3</td>
+      <td>0.424</td>
+
+
+
+
+
+    </tr>
+    <tr>
+      <td>Top Floor North Zone VAV</td>
+      <td>6.84</td>
+      <td>0.3</td>
+      <td>0.54</td>
+
+
+
+
+
+    </tr>
+    <tr>
+        <td>Top Floor West Zone VAV</td>
+        <td>6.228</td>
+        <td>0.3</td>
+        <td>0.492</td>
+
+
+
+      </tr>
   </tbody>
   </table>
 
- <br>  
-<table cellspacing=\"2\" cellpadding=\"0\" border=\"0\" summary=\"Layers\">
-    <thead>
-      <tr>
-        <th>AHU Cooling Coils</th>
-        <th>Design Coil Capacity [W]</th>
-        <th>Design Water Mass Flow Rate [kg/s]</th>
-        <th>Design Air Mass Flow Rate [m3/s]</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td>Bot Floor Cooling Coil</td>
-        <td>871812</td>
-        <td>35.79</td>
-        <td>52.68</td>
-      </tr>
-      <tr>
-        <td>Mid Floor Cooling Coil</td>
-        <td>6150400</td>
-        <td>357.8</td>
-        <td>526.7</td>
-      </tr>
-      <tr>
-        <td>Top Floor Cooling Coil</td>
-        <td>847273</td>
-        <td>35.79</td>
-        <td>52.68</td>
-      </tr>
-    </tbody>
-    </table>
- <br>	
-<table cellspacing=\"2\" cellpadding=\"0\" border=\"0\" summary=\"Layers\">
-        <thead>
-          <tr>
-            <th>Fans</th>
-            <th>Type</th>
-            <th>Design Size Supply Fan Mass Flow Rate [kg/s]</th>
-            <th>Design Size Supply Fan Pressure Head [Pa]</th>
-            <th>Total Efficiency</th>
-            <th>Design Power Consumption [W]</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td>Bot Floor Supply Fan</td>
-            <td>Variable speed</td>
-            <td>53</td>
-            <td>1088</td>
-            <td>0.55</td>
-            <td>120438</td>
-          </tr>
-          <tr>
-            <td>Mid Floor Supply Fan</td>
-            <td>Variable speed</td>
-            <td>527</td>
-            <td>1082</td>
-            <td>0.54</td>
-            <td>1199110</td>
-          </tr>
-          <tr>
-            <td>Top Floor Supply Fan</td>
-            <td>Variable speed</td>
-            <td>53</td>
-            <td>1101</td>
-            <td>0.55</td>
-            <td>120084</td>
-          </tr>
-          <tr>
-            <td>Bot Floor Return Fan</td>
-            <td>Variable speed</td>
-            <td>53</td>
-            <td>252</td>
-            <td>0.57</td>
-            <td>36235</td>
-          </tr>
-          <tr>
-            <td>Mid Floor Return Fan</td>
-            <td>Variable speed</td>
-            <td>527</td>
-            <td>262</td>
-            <td>0.57</td>
-            <td>328304</td>
-          </tr>
-          <tr>
-            <td>Top Floor Return Fan</td>
-            <td>Variable speed</td>
-            <td>53</td>
-            <td>307</td>
-            <td>0.58</td>
-            <td>35350</td>
-          </tr>
-        </tbody>
-        </table>
- <br>
-<table cellspacing=\"2\" cellpadding=\"0\" border=\"0\" summary=\"Layers\">
-            <thead>
-              <tr>
-                <th>Pumps</th>
-                <th>Type</th>
-                <th>Design Mass Flow Rate [kg/s]</th>
-                <th>Design Size Supply Pump Pressure Head [Pa]</th>
-                <th>Total Efficiency</th>
-                <th>Design Power Consumption [W]</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr>
-                <td>CHW Primary Pumps 1-3</td>
-                <td>Constant speed</td>
-                <td>107</td>
-                <td>496586</td>
-                <td>0.87</td>
-                <td>61378</td>
-              </tr>
-			  
-              <tr>
-                <td>CHW Secondary Pumps 1-2</td>
-                <td>Variable speed</td>
-                <td>180</td>
-                <td>65385</td>
-                <td>0.88</td>
-                <td>93278</td>
-              </tr>
 
-              <tr>
-                <td>CW Pumps 1-3</td>
-                <td>Variable speed</td>
-                <td>123.2</td>
-                <td>1731010</td>
-                <td>0.87</td>
-                <td>246320</td>
-              </tr>
-			  
-              <tr>
-                <td>HW Pumps 1-2</td>
-                <td>Variable speed</td>
-                <td>21.5</td>
-                <td>477027</td>
-                <td>0.65</td>
-                <td>9605</td>
-              </tr>
 
-            </tbody>
-            </table>
- <br>
+<br>  
 <table cellspacing=\"2\" cellpadding=\"0\" border=\"0\" summary=\"Layers\">
-                <thead>
-                  <tr>
-                    <th>Chillers</th>
-                    <th>Design Chilled Water Mass Flow Rate [kg/s]</th>
-					<th>Design Condenser Water Mass Flow Rate [kg/s]</th>
-                    <th>Design Capacity [W]</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  <tr>
-                    <td>Chillers 1-3</td>
-                    <td>123</td>
-					<td>107</td>
-                    <td>2980980</td>
-
-                  </tr>
-
-                </tbody>
-                </table>
- <br>				
+    <thead>
+      <tr>
+        <th>AHU Cooling Coils</th>
+        <th>Design Coil Capacity [W]</th>
+        <th>Design Water Mass Flow Rate [kg/s]</th>
+        <th>Design Air Mass Flow Rate [m3/s]</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>Bot Floor Cooling Coil</td>
+        <td>871812</td>
+        <td>26.7</td>
+        <td>52.68</td>
+      </tr>
+      <tr>
+        <td>Mid Floor Cooling Coil</td>
+        <td>6150400</td>
+        <td>267</td>
+        <td>526.7</td>
+      </tr>
+      <tr>
+        <td>Top Floor Cooling Coil</td>
+        <td>847273</td>
+        <td>26.7</td>
+        <td>52.68</td>
+      </tr>
+    </tbody>
+    </table>
+<br>  
 <table cellspacing=\"2\" cellpadding=\"0\" border=\"0\" summary=\"Layers\">
-                    <thead>
-                      <tr>
-                        <th>Boilers</th>
-                        <th>Design Size Nominal Capacity [W]</th>
-                        <th>Design Size Design Water Mass Flow Rate [kg/s]</th>
-                      </tr>
-                    </thead>
-                    <tbody>
-                      <tr>
-                        <td>Boiler 1-2</td>
-                        <td>1726710</td>
-                        <td>21.5</td>
-                      </tr>
-
-                    </tbody>
-                    </table>
- <br>					
+        <thead>
+          <tr>
+            <th>Fans</th>
+            <th>Type</th>
+            <th>Design Size Supply Fan Mass Flow Rate [kg/s]</th>
+            <th>Design Size Supply Fan Pressure Head [Pa]</th>
+            <th>Total Efficiency</th>
+            <th>Design Power Consumption [W]</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>Bot Floor Supply Fan</td>
+            <td>Variable speed</td>
+            <td>53</td>
+            <td>1088</td>
+            <td>0.55</td>
+            <td>120438</td>
+          </tr>
+          <tr>
+            <td>Mid Floor Supply Fan</td>
+            <td>Variable speed</td>
+            <td>527</td>
+            <td>1082</td>
+            <td>0.54</td>
+            <td>1199110</td>
+          </tr>
+          <tr>
+            <td>Top Floor Supply Fan</td>
+            <td>Variable speed</td>
+            <td>53</td>
+            <td>1101</td>
+            <td>0.55</td>
+            <td>120084</td>
+          </tr>
+          <tr>
+            <td>Bot Floor Return Fan</td>
+            <td>Variable speed</td>
+            <td>53</td>
+            <td>252</td>
+            <td>0.57</td>
+            <td>36235</td>
+          </tr>
+          <tr>
+            <td>Mid Floor Return Fan</td>
+            <td>Variable speed</td>
+            <td>527</td>
+            <td>262</td>
+            <td>0.57</td>
+            <td>328304</td>
+          </tr>
+          <tr>
+            <td>Top Floor Return Fan</td>
+            <td>Variable speed</td>
+            <td>53</td>
+            <td>307</td>
+            <td>0.58</td>
+            <td>35350</td>
+          </tr>
+        </tbody>
+        </table>
+<br>
 <table cellspacing=\"2\" cellpadding=\"0\" border=\"0\" summary=\"Layers\">
-                        <thead>
-                          <tr>
-                            <th>Cooling Towers</th>
-                            <th>Design Water Mass Flow Rate [kg/s]</th>
-							<th>Design Air Mass Flow Rate [kg/s]</th>
-                            <th>Fan Power at Design Air Flow Rate [W]</th>
-                          </tr>
-                        </thead>
-                        <tbody>
-                          <tr>
-                            <td>Cooling Towers 1-2</td>
-                            <td>138</td>
-							<td>220</td>
-                            <td>10000</td>
-                          </tr>
+            <thead>
+              <tr>
+                <th>Pumps</th>
+                <th>Type</th>
+                <th>Design Mass Flow Rate [kg/s]</th>
+                <th>Design Size Supply Pump Pressure Head [Pa]</th>
+                <th>Total Efficiency</th>
+                <th>Design Power Consumption [W]</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>CHW Primary Pumps 1-3</td>
+                <td>Constant speed</td>
+                <td>107</td>
+                <td>211,000</td>
+                <td>0.87</td>
+                <td>25,951</td>
+              </tr>
+        
+              <tr>
+                <td>CHW Secondary Pumps 1-2</td>
+                <td>Variable speed</td>
+                <td>161</td>
+                <td>478,000</td>
+                <td>0.88</td>
+                <td>87,452</td>
+              </tr>
 
-                        </tbody>
-                        </table>
+
+
+              <tr>
+                <td>CW Pumps 1-3</td>
+                <td>Variable speed</td>
+                <td>123</td>
+                <td>571,100</td>
+                <td>0.87</td>
+                <td>80,742</td>
+              </tr>
+        
+              <tr>
+                <td>HW Pumps 1-2</td>
+                <td>Variable speed</td>
+                <td>31.2</td>
+                <td>478,250</td>
+                <td>0.86</td>
+                <td>17,350</td>
+              </tr>
+
+
+
+            </tbody>
+            </table>
+<br>
+<table cellspacing=\"2\" cellpadding=\"0\" border=\"0\" summary=\"Layers\">
+                <thead>
+                  <tr>
+                    <th>Chillers</th>
+                    <th>Design Chilled Water Mass Flow Rate [kg/s]</th>
+          <th>Design Condenser Water Mass Flow Rate [kg/s]</th>
+                    <th>Design Capacity [W]</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr>
+                    <td>Chillers 1-3</td>
+                    <td>107</td>
+          <td>123</td>
+                    <td>1,834,000</td>
+
+
+
+                  </tr>
+
+
+
+                </tbody>
+                </table>
+<br>        
+<table cellspacing=\"2\" cellpadding=\"0\" border=\"0\" summary=\"Layers\">
+                    <thead>
+                      <tr>
+                        <th>Boilers</th>
+                        <th>Design Size Nominal Capacity [W]</th>
+                        <th>Design Size Design Water Mass Flow Rate [kg/s]</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      <tr>
+                        <td>Boiler 1-2</td>
+                        <td>2,100,000</td>
+                        <td>31.2</td>
+                      </tr>
+
+
+
+                    </tbody>
+                    </table>
+<br>          
+<table cellspacing=\"2\" cellpadding=\"0\" border=\"0\" summary=\"Layers\">
+                        <thead>
+                          <tr>
+                            <th>Cooling Towers</th>
+                            <th>Design Water Mass Flow Rate [kg/s]</th>
+              <th>Design Air Mass Flow Rate [kg/s]</th>
+                            <th>Fan Power at Design Air Flow Rate [W]</th>
+                          </tr>
+                        </thead>
+                        <tbody>
+                          <tr>
+                            <td>Cooling Towers 1-2</td>
+                            <td>123</td>
+              <td>220</td>
+                            <td>32,000</td>
+                          </tr>
+
+
+
+                        </tbody>
+                        </table>
  <br>						
  <h4>Supervisory-level mode control</h4>
  <p>
@@ -1716,7 +1772,7 @@
 			<code>hva_floor3_reaAhu_CO2_AHURet_y</code> [ppm] [min=None, max=None]: AHU CO2 measurement for return air of floor 3
             </li>
             <li>
-            <code>hva_reaChiWatSys_TW_y</code> [K] [min=None, max=None]: Chilled water temperature measurement of floor 3
+            <code>hva_reaChiWatSys_TW_y</code> [K] [min=None, max=None]: Chilled water temperature measurement
             </li>
             <li>
             <code>hva_reaChiWatSys_dp_y</code> [K] [min=None, max=None]: Differential pressure of chilled/hot water measurement
@@ -1731,7 +1787,7 @@
             <code>hva_reaChiWatSys_reaPPum_y</code> [W] [min=None, max=None]: Chilled water plant pump power consumption
             </li>
             <li>
-            <code>hva_reaHotWatSys_TW_y</code> [K] [min=None, max=None]: Chilled water temperature measurement
+            <code>hva_reaHotWatSys_TW_y</code> [K] [min=None, max=None]: Hot water temperature measurement
             </li>
             <li>
             <code>hva_reaHotWatSys_dp_y</code> [K] [min=None, max=None]: Differential pressure of chilled/hot water measurement

--- a/testcases/multizone_office_complex_air/doc/index.html
+++ b/testcases/multizone_office_complex_air/doc/index.html
@@ -1098,6 +1098,9 @@
             <code>hva_floor1_reaZonCor_yReheaVal_y</code> [1] [min=None, max=None]: Reheat valve position measurement for zone cor of floor 1
             </li>
             <li>
+			<code>hva_floor1_reaZonCor_CO2Zon_y</code> [ppm] [min=None, max=None]: Zone air CO2 measurement for zone cor of floor 1
+            </li>
+            <li>
             <code>hva_floor1_reaZonEas_TRoo_Coo_set_y</code> [K] [min=None, max=None]: Zone temperature cooling setpoint for zone eas of floor 1
             </li>
             <li>
@@ -1126,6 +1129,9 @@
             </li>
             <li>
             <code>hva_floor1_reaZonEas_yReheaVal_y</code> [1] [min=None, max=None]: Reheat valve position measurement for zone eas of floor 1
+            </li>
+            <li>
+			<code>hva_floor1_reaZonEas_CO2Zon_y</code> [ppm] [min=None, max=None]: Zone air CO2 measurement for zone eas of floor 1
             </li>
             <li>
             <code>hva_floor1_reaZonNor_TRoo_Coo_set_y</code> [K] [min=None, max=None]: Zone temperature cooling setpoint for zone nor of floor 1
@@ -1158,6 +1164,9 @@
             <code>hva_floor1_reaZonNor_yReheaVal_y</code> [1] [min=None, max=None]: Reheat valve position measurement for zone nor of floor 1
             </li>
             <li>
+			<code>hva_floor1_reaZonNor_CO2Zon_y</code> [ppm] [min=None, max=None]: Zone air CO2 measurement for zone nor of floor 1
+            </li>
+            <li>
             <code>hva_floor1_reaZonSou_TRoo_Coo_set_y</code> [K] [min=None, max=None]: Zone temperature cooling setpoint for zone sou of floor 1
             </li>
             <li>
@@ -1188,6 +1197,9 @@
             <code>hva_floor1_reaZonSou_yReheaVal_y</code> [1] [min=None, max=None]: Reheat valve position measurement for zone sou of floor 1
             </li>
             <li>
+			<code>hva_floor1_reaZonSou_CO2Zon_y</code> [ppm] [min=None, max=None]: Zone air CO2 measurement for zone sou of floor 1
+            </li>
+            <li>
             <code>hva_floor1_reaZonWes_TRoo_Coo_set_y</code> [K] [min=None, max=None]: Zone temperature cooling setpoint for zone wes of floor 1
             </li>
             <li>
@@ -1216,6 +1228,9 @@
             </li>
             <li>
             <code>hva_floor1_reaZonWes_yReheaVal_y</code> [1] [min=None, max=None]: Reheat valve position measurement for zone wes of floor 1
+            </li>
+            <li>
+			<code>hva_floor1_reaZonWes_CO2Zon_y</code> [ppm] [min=None, max=None]: Zone air CO2 measurement for zone wes of floor 1
             </li>
             <li>
             <code>hva_floor1_reaAhu_PFanTot_y</code> [W] [min=None, max=None]: Total electrical power measurement of supply and return fans for AHU of floor 1
@@ -1260,6 +1275,15 @@
             <code>hva_floor1_reaAhu_yOA_y</code> [1] [min=None, max=None]: AHU cooling coil valve position measurement of floor 1
             </li>
             <li>
+			<code>hva_floor1_reaAhu_CO2_AHUSup_y</code> [ppm] [min=None, max=None]: AHU CO2 measurement for supply air of floor 1
+            </li>
+            <li>
+			<code>hva_floor1_reaAhu_CO2_AHUFre_y</code> [ppm] [min=None, max=None]: AHU CO2 measurement for fresh air of floor 1
+            </li>
+            <li>
+			<code>hva_floor1_reaAhu_CO2_AHURet_y</code> [ppm] [min=None, max=None]: AHU CO2 measurement for return air of floor 1
+            </li>
+            <li>		
             <code>hva_floor2_reaZonCor_TRoo_Coo_set_y</code> [K] [min=None, max=None]: Zone temperature cooling setpoint for zone cor of floor 2
             </li>
             <li>
@@ -1288,6 +1312,9 @@
             </li>
             <li>
             <code>hva_floor2_reaZonCor_yReheaVal_y</code> [1] [min=None, max=None]: Reheat valve position measurement for zone cor of floor 2
+            </li>
+            <li>
+			<code>hva_floor2_reaZonCor_CO2Zon_y</code> [ppm] [min=None, max=None]: Zone air CO2 measurement for zone cor of floor 2
             </li>
             <li>
             <code>hva_floor2_reaZonEas_TRoo_Coo_set_y</code> [K] [min=None, max=None]: Zone temperature cooling setpoint for zone eas of floor 2
@@ -1320,6 +1347,9 @@
             <code>hva_floor2_reaZonEas_yReheaVal_y</code> [1] [min=None, max=None]: Reheat valve position measurement for zone eas of floor 2
             </li>
             <li>
+			<code>hva_floor2_reaZonEas_CO2Zon_y</code> [ppm] [min=None, max=None]: Zone air CO2 measurement for zone eas of floor 2
+            </li>
+            <li>
             <code>hva_floor2_reaZonNor_TRoo_Coo_set_y</code> [K] [min=None, max=None]: Zone temperature cooling setpoint for zone nor of floor 2
             </li>
             <li>
@@ -1348,6 +1378,9 @@
             </li>
             <li>
             <code>hva_floor2_reaZonNor_yReheaVal_y</code> [1] [min=None, max=None]: Reheat valve position measurement for zone nor of floor 2
+            </li>
+            <li>
+			<code>hva_floor2_reaZonNor_CO2Zon_y</code> [ppm] [min=None, max=None]: Zone air CO2 measurement for zone nor of floor 2
             </li>
             <li>
             <code>hva_floor2_reaZonSou_TRoo_Coo_set_y</code> [K] [min=None, max=None]: Zone temperature cooling setpoint for zone sou of floor 2
@@ -1380,6 +1413,9 @@
             <code>hva_floor2_reaZonSou_yReheaVal_y</code> [1] [min=None, max=None]: Reheat valve position measurement for zone sou of floor 2
             </li>
             <li>
+			<code>hva_floor2_reaZonSou_CO2Zon_y</code> [ppm] [min=None, max=None]: Zone air CO2 measurement for zone sou of floor 2
+            </li>
+            <li>
             <code>hva_floor2_reaZonWes_TRoo_Coo_set_y</code> [K] [min=None, max=None]: Zone temperature cooling setpoint for zone wes of floor 2
             </li>
             <li>
@@ -1408,6 +1444,9 @@
             </li>
             <li>
             <code>hva_floor2_reaZonWes_yReheaVal_y</code> [1] [min=None, max=None]: Reheat valve position measurement for zone wes of floor 2
+            </li>
+            <li>
+			<code>hva_floor2_reaZonWes_CO2Zon_y</code> [ppm] [min=None, max=None]: Zone air CO2 measurement for zone wes of floor 2
             </li>
             <li>
             <code>hva_floor2_reaAhu_PFanTot_y</code> [W] [min=None, max=None]: Total electrical power measurement of supply and return fans for AHU of floor 2
@@ -1452,6 +1491,15 @@
             <code>hva_floor2_reaAhu_yOA_y</code> [1] [min=None, max=None]: AHU cooling coil valve position measurement of floor 2
             </li>
             <li>
+			<code>hva_floor2_reaAhu_CO2_AHUSup_y</code> [ppm] [min=None, max=None]: AHU CO2 measurement for supply air of floor 2
+            </li>
+            <li>
+			<code>hva_floor2_reaAhu_CO2_AHUFre_y</code> [ppm] [min=None, max=None]: AHU CO2 measurement for fresh air of floor 2
+            </li>
+            <li>
+			<code>hva_floor2_reaAhu_CO2_AHURet_y</code> [ppm] [min=None, max=None]: AHU CO2 measurement for return air of floor 2
+            </li>
+            <li>
             <code>hva_floor3_reaZonCor_TRoo_Coo_set_y</code> [K] [min=None, max=None]: Zone temperature cooling setpoint for zone cor of floor 3
             </li>
             <li>
@@ -1480,6 +1528,9 @@
             </li>
             <li>
             <code>hva_floor3_reaZonCor_yReheaVal_y</code> [1] [min=None, max=None]: Reheat valve position measurement for zone cor of floor 3
+            </li>
+            <li>
+			<code>hva_floor3_reaZonCor_CO2Zon_y</code> [ppm] [min=None, max=None]: Zone air CO2 measurement for zone cor of floor 3
             </li>
             <li>
             <code>hva_floor3_reaZonEas_TRoo_Coo_set_y</code> [K] [min=None, max=None]: Zone temperature cooling setpoint for zone eas of floor 3
@@ -1512,6 +1563,9 @@
             <code>hva_floor3_reaZonEas_yReheaVal_y</code> [1] [min=None, max=None]: Reheat valve position measurement for zone eas of floor 3
             </li>
             <li>
+			<code>hva_floor3_reaZonEas_CO2Zon_y</code> [ppm] [min=None, max=None]: Zone air CO2 measurement for zone eas of floor 3
+            </li>
+            <li>
             <code>hva_floor3_reaZonNor_TRoo_Coo_set_y</code> [K] [min=None, max=None]: Zone temperature cooling setpoint for zone nor of floor 3
             </li>
             <li>
@@ -1540,6 +1594,9 @@
             </li>
             <li>
             <code>hva_floor3_reaZonNor_yReheaVal_y</code> [1] [min=None, max=None]: Reheat valve position measurement for zone nor of floor 3
+            </li>
+            <li>
+			<code>hva_floor3_reaZonNor_CO2Zon_y</code> [ppm] [min=None, max=None]: Zone air CO2 measurement for zone nor of floor 3
             </li>
             <li>
             <code>hva_floor3_reaZonSou_TRoo_Coo_set_y</code> [K] [min=None, max=None]: Zone temperature cooling setpoint for zone sou of floor 3
@@ -1572,6 +1629,9 @@
             <code>hva_floor3_reaZonSou_yReheaVal_y</code> [1] [min=None, max=None]: Reheat valve position measurement for zone sou of floor 3
             </li>
             <li>
+			<code>hva_floor3_reaZonSou_CO2Zon_y</code> [ppm] [min=None, max=None]: Zone air CO2 measurement for zone sou of floor 3
+            </li>
+            <li>
             <code>hva_floor3_reaZonWes_TRoo_Coo_set_y</code> [K] [min=None, max=None]: Zone temperature cooling setpoint for zone wes of floor 3
             </li>
             <li>
@@ -1600,6 +1660,9 @@
             </li>
             <li>
             <code>hva_floor3_reaZonWes_yReheaVal_y</code> [1] [min=None, max=None]: Reheat valve position measurement for zone wes of floor 3
+            </li>
+            <li>
+			<code>hva_floor3_reaZonWes_CO2Zon_y</code> [ppm] [min=None, max=None]: Zone air CO2 measurement for zone wes of floor 3
             </li>
             <li>
             <code>hva_floor3_reaAhu_PFanTot_y</code> [W] [min=None, max=None]: Total electrical power measurement of supply and return fans for AHU of floor 3
@@ -1642,6 +1705,15 @@
             </li>
             <li>
             <code>hva_floor3_reaAhu_yOA_y</code> [1] [min=None, max=None]: AHU cooling coil valve position measurement of floor 3
+            </li>
+            <li>
+			<code>hva_floor3_reaAhu_CO2_AHUSup_y</code> [ppm] [min=None, max=None]: AHU CO2 measurement for supply air of floor 3
+            </li>
+            <li>
+			<code>hva_floor3_reaAhu_CO2_AHUFre_y</code> [ppm] [min=None, max=None]: AHU CO2 measurement for fresh air of floor 3
+            </li>
+            <li>
+			<code>hva_floor3_reaAhu_CO2_AHURet_y</code> [ppm] [min=None, max=None]: AHU CO2 measurement for return air of floor 3
             </li>
             <li>
             <code>hva_reaChiWatSys_TW_y</code> [K] [min=None, max=None]: Chilled water temperature measurement of floor 3

--- a/testcases/multizone_office_complex_air/doc/index.html
+++ b/testcases/multizone_office_complex_air/doc/index.html
@@ -335,21 +335,21 @@
     <tbody>
       <tr>
         <td>Bot Floor Cooling Coil</td>
-        <td>871812</td>
+        <td>458,333</td>
         <td>26.7</td>
-        <td>52.68</td>
+        <td>65.844</td>
       </tr>
       <tr>
         <td>Mid Floor Cooling Coil</td>
-        <td>6150400</td>
+        <td>4,583,333</td>
         <td>267</td>
-        <td>526.7</td>
+        <td>658.44</td>
       </tr>
       <tr>
         <td>Top Floor Cooling Coil</td>
-        <td>847273</td>
+        <td>458,333</td>
         <td>26.7</td>
-        <td>52.68</td>
+        <td>65.844</td>
       </tr>
     </tbody>
     </table>
@@ -369,50 +369,50 @@
           <tr>
             <td>Bot Floor Supply Fan</td>
             <td>Variable speed</td>
-            <td>53</td>
-            <td>1088</td>
-            <td>0.55</td>
-            <td>120438</td>
+            <td>66</td>
+            <td>1400</td>
+            <td>0.93</td>
+            <td>82,796</td>
           </tr>
           <tr>
             <td>Mid Floor Supply Fan</td>
             <td>Variable speed</td>
-            <td>527</td>
-            <td>1082</td>
-            <td>0.54</td>
-            <td>1199110</td>
+            <td>660</td>
+            <td>1400</td>
+            <td>0.93</td>
+            <td>827,960</td>
           </tr>
           <tr>
             <td>Top Floor Supply Fan</td>
             <td>Variable speed</td>
-            <td>53</td>
-            <td>1101</td>
-            <td>0.55</td>
-            <td>120084</td>
+            <td>66</td>
+            <td>1400</td>
+            <td>0.93</td>
+            <td>82,796</td>
           </tr>
           <tr>
             <td>Bot Floor Return Fan</td>
             <td>Variable speed</td>
-            <td>53</td>
-            <td>252</td>
-            <td>0.57</td>
-            <td>36235</td>
+            <td>66</td>
+            <td>400</td>
+            <td>0.6045</td>
+            <td>36,394</td>
           </tr>
           <tr>
             <td>Mid Floor Return Fan</td>
             <td>Variable speed</td>
-            <td>527</td>
-            <td>262</td>
-            <td>0.57</td>
-            <td>328304</td>
+            <td>660</td>
+            <td>400</td>
+            <td>0.6045</td>
+            <td>363,940</td>
           </tr>
           <tr>
             <td>Top Floor Return Fan</td>
             <td>Variable speed</td>
-            <td>53</td>
-            <td>307</td>
-            <td>0.58</td>
-            <td>35350</td>
+            <td>66</td>
+            <td>400</td>
+            <td>0.6045</td>
+            <td>36,394</td>
           </tr>
         </tbody>
         </table>

--- a/testcases/multizone_office_complex_air/doc/index.html
+++ b/testcases/multizone_office_complex_air/doc/index.html
@@ -1218,46 +1218,46 @@
             <code>hva_floor1_reaZonWes_yReheaVal_y</code> [1] [min=None, max=None]: Reheat valve position measurement for zone wes of floor 1
             </li>
             <li>
-            <code>hva_floor1_readAhu_PFanTot_y</code> [W] [min=None, max=None]: Total electrical power measurement of supply and return fans for AHU of floor 1
+            <code>hva_floor1_reaAhu_PFanTot_y</code> [W] [min=None, max=None]: Total electrical power measurement of supply and return fans for AHU of floor 1
             </li>
             <li>
-            <code>hva_floor1_readAhu_TCooCoiRet_y</code> [K] [min=None, max=None]: Cooling coil return water temperature measurement for AHU of floor 1
+            <code>hva_floor1_reaAhu_TCooCoiRet_y</code> [K] [min=None, max=None]: Cooling coil return water temperature measurement for AHU of floor 1
             </li>
             <li>
-            <code>hva_floor1_readAhu_TCooCoiSup_y</code> [K] [min=None, max=None]: Cooling coil supply water temperature measurement for AHU of floor 1
+            <code>hva_floor1_reaAhu_TCooCoiSup_y</code> [K] [min=None, max=None]: Cooling coil supply water temperature measurement for AHU of floor 1
             </li>
             <li>
-            <code>hva_floor1_readAhu_TMix_y</code> [K] [min=None, max=None]: Mixed air temperature measurement for AHU of floor 1
+            <code>hva_floor1_reaAhu_TMix_y</code> [K] [min=None, max=None]: Mixed air temperature measurement for AHU of floor 1
             </li>
             <li>
-            <code>hva_floor1_readAhu_TRet_y</code> [K] [min=None, max=None]: Return air temperature measurement for AHU of floor 1
+            <code>hva_floor1_reaAhu_TRet_y</code> [K] [min=None, max=None]: Return air temperature measurement for AHU of floor 1
             </li>
             <li>
-            <code>hva_floor1_readAhu_TSup_set_y</code> [K] [min=None, max=None]: Supply air temperature setpoint measurement for AHU of floor 1
+            <code>hva_floor1_reaAhu_TSup_set_y</code> [K] [min=None, max=None]: Supply air temperature setpoint measurement for AHU of floor 1
             </li>
             <li>
-            <code>hva_floor1_readAhu_TSup_y</code> [K] [min=None, max=None]: Supply air temperature measurement for AHU of floor 1
+            <code>hva_floor1_reaAhu_TSup_y</code> [K] [min=None, max=None]: Supply air temperature measurement for AHU of floor 1
             </li>
             <li>
-            <code>hva_floor1_readAhu_V_flow_OA_y</code> [m3/s] [min=None, max=None]: Supply outdoor airflow rate measurement for AHU of floor 1
+            <code>hva_floor1_reaAhu_V_flow_OA_y</code> [m3/s] [min=None, max=None]: Supply outdoor airflow rate measurement for AHU of floor 1
             </li>
             <li>
-            <code>hva_floor1_readAhu_V_flow_ret_y</code> [m3/s] [min=None, max=None]: Return air flowrate measurement for AHU of floor 1
+            <code>hva_floor1_reaAhu_V_flow_ret_y</code> [m3/s] [min=None, max=None]: Return air flowrate measurement for AHU of floor 1
             </li>
             <li>
-            <code>hva_floor1_readAhu_V_flow_sup_y</code> [m3/s] [min=None, max=None]: Supply air flowrate measurement for AHU of floor 1
+            <code>hva_floor1_reaAhu_V_flow_sup_y</code> [m3/s] [min=None, max=None]: Supply air flowrate measurement for AHU of floor 1
             </li>
             <li>
-            <code>hva_floor1_readAhu_dp_sup_y</code> [Pa] [min=None, max=None]: Discharge pressure of supply fan for AHU of floor 1
+            <code>hva_floor1_reaAhu_dp_sup_y</code> [Pa] [min=None, max=None]: Discharge pressure of supply fan for AHU of floor 1
             </li>
             <li>
-            <code>hva_floor1_readAhu_occ_y</code> [1] [min=None, max=None]: Occupancy status of floor 1 (1 occupied, 0 unoccupied)
+            <code>hva_floor1_reaAhu_occ_y</code> [1] [min=None, max=None]: Occupancy status of floor 1 (1 occupied, 0 unoccupied)
             </li>
             <li>
-            <code>hva_floor1_readAhu_yCooVal_y</code> [1] [min=None, max=None]: AHU cooling coil valve position measurement of floor 1
+            <code>hva_floor1_reaAhu_yCooVal_y</code> [1] [min=None, max=None]: AHU cooling coil valve position measurement of floor 1
             </li>
             <li>
-            <code>hva_floor1_readAhu_yOA_y</code> [1] [min=None, max=None]: AHU cooling coil valve position measurement of floor 1
+            <code>hva_floor1_reaAhu_yOA_y</code> [1] [min=None, max=None]: AHU cooling coil valve position measurement of floor 1
             </li>
             <li>
             <code>hva_floor2_reaZonCor_TRoo_Coo_set_y</code> [K] [min=None, max=None]: Zone temperature cooling setpoint for zone cor of floor 2
@@ -1410,46 +1410,46 @@
             <code>hva_floor2_reaZonWes_yReheaVal_y</code> [1] [min=None, max=None]: Reheat valve position measurement for zone wes of floor 2
             </li>
             <li>
-            <code>hva_floor2_readAhu_PFanTot_y</code> [W] [min=None, max=None]: Total electrical power measurement of supply and return fans for AHU of floor 2
+            <code>hva_floor2_reaAhu_PFanTot_y</code> [W] [min=None, max=None]: Total electrical power measurement of supply and return fans for AHU of floor 2
             </li>
             <li>
-            <code>hva_floor2_readAhu_TCooCoiRet_y</code> [K] [min=None, max=None]: Cooling coil return water temperature measurement for AHU of floor 2
+            <code>hva_floor2_reaAhu_TCooCoiRet_y</code> [K] [min=None, max=None]: Cooling coil return water temperature measurement for AHU of floor 2
             </li>
             <li>
-            <code>hva_floor2_readAhu_TCooCoiSup_y</code> [K] [min=None, max=None]: Cooling coil supply water temperature measurement for AHU of floor 2
+            <code>hva_floor2_reaAhu_TCooCoiSup_y</code> [K] [min=None, max=None]: Cooling coil supply water temperature measurement for AHU of floor 2
             </li>
             <li>
-            <code>hva_floor2_readAhu_TMix_y</code> [K] [min=None, max=None]: Mixed air temperature measurement for AHU of floor 2
+            <code>hva_floor2_reaAhu_TMix_y</code> [K] [min=None, max=None]: Mixed air temperature measurement for AHU of floor 2
             </li>
             <li>
-            <code>hva_floor2_readAhu_TRet_y</code> [K] [min=None, max=None]: Return air temperature measurement for AHU of floor 2
+            <code>hva_floor2_reaAhu_TRet_y</code> [K] [min=None, max=None]: Return air temperature measurement for AHU of floor 2
             </li>
             <li>
-            <code>hva_floor2_readAhu_TSup_set_y</code> [K] [min=None, max=None]: Supply air temperature setpoint measurement for AHU of floor 2
+            <code>hva_floor2_reaAhu_TSup_set_y</code> [K] [min=None, max=None]: Supply air temperature setpoint measurement for AHU of floor 2
             </li>
             <li>
-            <code>hva_floor2_readAhu_TSup_y</code> [K] [min=None, max=None]: Supply air temperature measurement for AHU of floor 2
+            <code>hva_floor2_reaAhu_TSup_y</code> [K] [min=None, max=None]: Supply air temperature measurement for AHU of floor 2
             </li>
             <li>
-            <code>hva_floor2_readAhu_V_flow_OA_y</code> [m3/s] [min=None, max=None]: Supply outdoor airflow rate measurement for AHU of floor 2
+            <code>hva_floor2_reaAhu_V_flow_OA_y</code> [m3/s] [min=None, max=None]: Supply outdoor airflow rate measurement for AHU of floor 2
             </li>
             <li>
-            <code>hva_floor2_readAhu_V_flow_ret_y</code> [m3/s] [min=None, max=None]: Return air flowrate measurement for AHU of floor 2
+            <code>hva_floor2_reaAhu_V_flow_ret_y</code> [m3/s] [min=None, max=None]: Return air flowrate measurement for AHU of floor 2
             </li>
             <li>
-            <code>hva_floor2_readAhu_V_flow_sup_y</code> [m3/s] [min=None, max=None]: Supply air flowrate measurement for AHU of floor 2
+            <code>hva_floor2_reaAhu_V_flow_sup_y</code> [m3/s] [min=None, max=None]: Supply air flowrate measurement for AHU of floor 2
             </li>
             <li>
-            <code>hva_floor2_readAhu_dp_sup_y</code> [Pa] [min=None, max=None]: Discharge pressure of supply fan for AHU of floor 2
+            <code>hva_floor2_reaAhu_dp_sup_y</code> [Pa] [min=None, max=None]: Discharge pressure of supply fan for AHU of floor 2
             </li>
             <li>
-            <code>hva_floor2_readAhu_occ_y</code> [1] [min=None, max=None]: Occupancy status of floor 2 (1 occupied, 0 unoccupied)
+            <code>hva_floor2_reaAhu_occ_y</code> [1] [min=None, max=None]: Occupancy status of floor 2 (1 occupied, 0 unoccupied)
             </li>
             <li>
-            <code>hva_floor2_readAhu_yCooVal_y</code> [1] [min=None, max=None]: AHU cooling coil valve position measurement of floor 2
+            <code>hva_floor2_reaAhu_yCooVal_y</code> [1] [min=None, max=None]: AHU cooling coil valve position measurement of floor 2
             </li>
             <li>
-            <code>hva_floor2_readAhu_yOA_y</code> [1] [min=None, max=None]: AHU cooling coil valve position measurement of floor 2
+            <code>hva_floor2_reaAhu_yOA_y</code> [1] [min=None, max=None]: AHU cooling coil valve position measurement of floor 2
             </li>
             <li>
             <code>hva_floor3_reaZonCor_TRoo_Coo_set_y</code> [K] [min=None, max=None]: Zone temperature cooling setpoint for zone cor of floor 3
@@ -1602,46 +1602,46 @@
             <code>hva_floor3_reaZonWes_yReheaVal_y</code> [1] [min=None, max=None]: Reheat valve position measurement for zone wes of floor 3
             </li>
             <li>
-            <code>hva_floor3_readAhu_PFanTot_y</code> [W] [min=None, max=None]: Total electrical power measurement of supply and return fans for AHU of floor 3
+            <code>hva_floor3_reaAhu_PFanTot_y</code> [W] [min=None, max=None]: Total electrical power measurement of supply and return fans for AHU of floor 3
             </li>
             <li>
-            <code>hva_floor3_readAhu_TCooCoiRet_y</code> [K] [min=None, max=None]: Cooling coil return water temperature measurement for AHU of floor 3
+            <code>hva_floor3_reaAhu_TCooCoiRet_y</code> [K] [min=None, max=None]: Cooling coil return water temperature measurement for AHU of floor 3
             </li>
             <li>
-            <code>hva_floor3_readAhu_TCooCoiSup_y</code> [K] [min=None, max=None]: Cooling coil supply water temperature measurement for AHU of floor 3
+            <code>hva_floor3_reaAhu_TCooCoiSup_y</code> [K] [min=None, max=None]: Cooling coil supply water temperature measurement for AHU of floor 3
             </li>
             <li>
-            <code>hva_floor3_readAhu_TMix_y</code> [K] [min=None, max=None]: Mixed air temperature measurement for AHU of floor 3
+            <code>hva_floor3_reaAhu_TMix_y</code> [K] [min=None, max=None]: Mixed air temperature measurement for AHU of floor 3
             </li>
             <li>
-            <code>hva_floor3_readAhu_TRet_y</code> [K] [min=None, max=None]: Return air temperature measurement for AHU of floor 3
+            <code>hva_floor3_reaAhu_TRet_y</code> [K] [min=None, max=None]: Return air temperature measurement for AHU of floor 3
             </li>
             <li>
-            <code>hva_floor3_readAhu_TSup_set_y</code> [K] [min=None, max=None]: Supply air temperature setpoint measurement for AHU of floor 3
+            <code>hva_floor3_reaAhu_TSup_set_y</code> [K] [min=None, max=None]: Supply air temperature setpoint measurement for AHU of floor 3
             </li>
             <li>
-            <code>hva_floor3_readAhu_TSup_y</code> [K] [min=None, max=None]: Supply air temperature measurement for AHU of floor 3
+            <code>hva_floor3_reaAhu_TSup_y</code> [K] [min=None, max=None]: Supply air temperature measurement for AHU of floor 3
             </li>
             <li>
-            <code>hva_floor3_readAhu_V_flow_OA_y</code> [m3/s] [min=None, max=None]: Supply outdoor airflow rate measurement for AHU of floor 3
+            <code>hva_floor3_reaAhu_V_flow_OA_y</code> [m3/s] [min=None, max=None]: Supply outdoor airflow rate measurement for AHU of floor 3
             </li>
             <li>
-            <code>hva_floor3_readAhu_V_flow_ret_y</code> [m3/s] [min=None, max=None]: Return air flowrate measurement for AHU of floor 3
+            <code>hva_floor3_reaAhu_V_flow_ret_y</code> [m3/s] [min=None, max=None]: Return air flowrate measurement for AHU of floor 3
             </li>
             <li>
-            <code>hva_floor3_readAhu_V_flow_sup_y</code> [m3/s] [min=None, max=None]: Supply air flowrate measurement for AHU of floor 3
+            <code>hva_floor3_reaAhu_V_flow_sup_y</code> [m3/s] [min=None, max=None]: Supply air flowrate measurement for AHU of floor 3
             </li>
             <li>
-            <code>hva_floor3_readAhu_dp_sup_y</code> [Pa] [min=None, max=None]: Discharge pressure of supply fan for AHU of floor 3
+            <code>hva_floor3_reaAhu_dp_sup_y</code> [Pa] [min=None, max=None]: Discharge pressure of supply fan for AHU of floor 3
             </li>
             <li>
-            <code>hva_floor3_readAhu_occ_y</code> [1] [min=None, max=None]: Occupancy status of floor 3 (1 occupied, 0 unoccupied)
+            <code>hva_floor3_reaAhu_occ_y</code> [1] [min=None, max=None]: Occupancy status of floor 3 (1 occupied, 0 unoccupied)
             </li>
             <li>
-            <code>hva_floor3_readAhu_yCooVal_y</code> [1] [min=None, max=None]: AHU cooling coil valve position measurement of floor 3
+            <code>hva_floor3_reaAhu_yCooVal_y</code> [1] [min=None, max=None]: AHU cooling coil valve position measurement of floor 3
             </li>
             <li>
-            <code>hva_floor3_readAhu_yOA_y</code> [1] [min=None, max=None]: AHU cooling coil valve position measurement of floor 3
+            <code>hva_floor3_reaAhu_yOA_y</code> [1] [min=None, max=None]: AHU cooling coil valve position measurement of floor 3
             </li>
             <li>
             <code>hva_reaChiWatSys_TW_y</code> [K] [min=None, max=None]: Chilled water temperature measurement of floor 3

--- a/testcases/multizone_office_complex_air/doc/index.html
+++ b/testcases/multizone_office_complex_air/doc/index.html
@@ -1772,7 +1772,13 @@
 			<code>hva_floor3_reaAhu_CO2_AHURet_y</code> [ppm] [min=None, max=None]: AHU CO2 measurement for return air of floor 3
             </li>
             <li>
-            <code>hva_reaChiWatSys_TW_y</code> [K] [min=None, max=None]: Chilled water temperature measurement
+            <code>hva_reaChiWatSys_TCHW_sup_y</code> [K] [min=None, max=None]: Chilled water supply temperature measurement
+            </li>
+            <li>
+			<code>hva_reaChiWatSys_TCHW_ret_y</code> [K] [min=None, max=None]: Chilled water return temperature measurement
+            </li>
+            <li>
+			<code>hva_reaChiWatSys_mCHW_tot_y</code> [kg/s] [min=None, max=None]: Chilled water total mass flow rate measurement
             </li>
             <li>
             <code>hva_reaChiWatSys_dp_y</code> [K] [min=None, max=None]: Differential pressure of chilled/hot water measurement
@@ -1787,7 +1793,13 @@
             <code>hva_reaChiWatSys_reaPPum_y</code> [W] [min=None, max=None]: Chilled water plant pump power consumption
             </li>
             <li>
-            <code>hva_reaHotWatSys_TW_y</code> [K] [min=None, max=None]: Hot water temperature measurement
+            <code>hva_reaHotWatSys_THW_sup_y</code> [K] [min=None, max=None]: Hot water supply temperature measurement
+            </li>
+            <li>
+			<code>hva_reaHotWatSys_THW_ret_y</code> [K] [min=None, max=None]: Hot water return temperature measurement
+            </li>
+            <li>
+			<code>hva_reaHotWatSys_mHW_tot_y</code> [kg/s] [min=None, max=None]: Hot water total mass flow rate measurement
             </li>
             <li>
             <code>hva_reaHotWatSys_dp_y</code> [K] [min=None, max=None]: Differential pressure of chilled/hot water measurement

--- a/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/BaseClasses/HVACSide/BaseClasses/AirSide.mo
+++ b/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/BaseClasses/HVACSide/BaseClasses/AirSide.mo
@@ -31,8 +31,8 @@ model Airside "Air side system"
       mAirFloRat5[3])/1.2*2}} "Volume flow rate curve";
   parameter Real HydEff[n,:] = {{0.93*0.65,0.93*0.7,0.93,0.93*0.6} for i in linspace(1,n,n)} "Hydraulic efficiency";
   parameter Real MotEff[n,:] = {{0.6045*0.65,0.6045*0.7,0.6045,0.6045*0.6} for i in linspace(1,n,n)} "Motor efficiency";
-  parameter Modelica.Units.SI.Pressure SupPreCur[n,:]={{1400,1000,700,700*0.5} for i in linspace(1,n,n)} "Pressure curve";
-  parameter Modelica.Units.SI.Pressure RetPreCur[n,:]={{600,400,200,100} for i in linspace(1,n,n)} "Pressure curve";
+  parameter Modelica.Units.SI.Pressure SupPreCur[n,:]={{1400*beta,1000*beta,700*beta,700*0.5*beta} for i in linspace(1,n,n)} "Pressure curve";
+  parameter Modelica.Units.SI.Pressure RetPreCur[n,:]={{600*beta,400*beta,200*beta,100*beta} for i in linspace(1,n,n)} "Pressure curve";
   parameter Modelica.Units.SI.Pressure PreAirDroMai1=140
     "Pressure drop 1 across the duct";
   parameter Modelica.Units.SI.Pressure PreAirDroMai2=140
@@ -131,6 +131,7 @@ model Airside "Air side system"
   parameter Modelica.Units.SI.Efficiency eps5(max=1) = 0.8
     "Heat exchanger effectiveness of vav 1";
   final parameter Real alpha = 0.8  "Sizing factor";
+  final parameter Real beta = 2  "Sizing factor for AHU fan pressure";
 
   //package MediumAir = Buildings.Media.Air "Medium model for air";
   package MediumAir = Buildings.Media.Air(extraPropertiesNames={"CO2"}) "Buildings library air media package with CO2";
@@ -261,8 +262,8 @@ model Airside "Air side system"
     redeclare package MediumHeaWat = MediumHeaWat,
     C_start=fill(400e-6*Modelica.Media.IdealGases.Common.SingleGasesData.CO2.MM/Modelica.Media.IdealGases.Common.SingleGasesData.Air.MM, MediumAir.nC),
     m_flow_lea={10*0.206*1.2, 10*0.137*1.2, 10*0.206*1.2, 10*0.137*1.2},
-    PreDroCoiAir=PreDroCoiAir*10,
-    PreDroMixingBoxAir=PreDroMixingBoxAir*10,
+    PreDroCoiAir=PreDroCoiAir,
+    PreDroMixingBoxAir=PreDroMixingBoxAir,
     PreDroCooWat=PreDroCooWat/2,
     TemEcoHig=TemEcoHig,
     TemEcoLow=TemEcoLow,
@@ -273,24 +274,24 @@ model Airside "Air side system"
     VolFloCur=VolFloCur[2, :],
     SupPreCur=SupPreCur[2, :],
     RetPreCur=RetPreCur[2, :],
-    PreAirDroMai1=PreAirDroMai1*10,
-    PreAirDroMai2=PreAirDroMai2*10,
-    PreAirDroMai3=PreAirDroMai3*10,
-    PreAirDroMai4=PreAirDroMai4*10,
-    PreAirDroBra1=PreAirDroBra1*10,
-    PreAirDroBra2=PreAirDroBra2*10,
-    PreAirDroBra3=PreAirDroBra3*10,
-    PreAirDroBra4=PreAirDroBra4*10,
-    PreAirDroBra5=PreAirDroBra5*10,
-    PreWatDroMai1=PreWatDroMai1*10,
-    PreWatDroMai2=PreWatDroMai2*10,
-    PreWatDroMai3=PreWatDroMai3*10,
-    PreWatDroMai4=PreWatDroMai4*10,
-    PreWatDroBra1=PreWatDroBra1*10,
-    PreWatDroBra2=PreWatDroBra2*10,
-    PreWatDroBra3=PreWatDroBra3*10,
-    PreWatDroBra4=PreWatDroBra4*10,
-    PreWatDroBra5=PreWatDroBra5*10,
+    PreAirDroMai1=PreAirDroMai1,
+    PreAirDroMai2=PreAirDroMai2,
+    PreAirDroMai3=PreAirDroMai3,
+    PreAirDroMai4=PreAirDroMai4,
+    PreAirDroBra1=PreAirDroBra1,
+    PreAirDroBra2=PreAirDroBra2,
+    PreAirDroBra3=PreAirDroBra3,
+    PreAirDroBra4=PreAirDroBra4,
+    PreAirDroBra5=PreAirDroBra5,
+    PreWatDroMai1=PreWatDroMai1,
+    PreWatDroMai2=PreWatDroMai2,
+    PreWatDroMai3=PreWatDroMai3,
+    PreWatDroMai4=PreWatDroMai4,
+    PreWatDroBra1=PreWatDroBra1,
+    PreWatDroBra2=PreWatDroBra2,
+    PreWatDroBra3=PreWatDroBra3,
+    PreWatDroBra4=PreWatDroBra4,
+    PreWatDroBra5=PreWatDroBra5,
     mAirFloRat1=mAirFloRat1[2],
     mAirFloRat2=mAirFloRat2[2],
     mAirFloRat3=mAirFloRat3[2],
@@ -301,20 +302,20 @@ model Airside "Air side system"
     mWatFloRat3=mWatFloRat3[2],
     mWatFloRat4=mWatFloRat4[2],
     mWatFloRat5=mWatFloRat5[2],
-    PreDroAir1=PreDroAir1*10,
-    PreDroWat1=PreDroWat1*10,
+    PreDroAir1=PreDroAir1,
+    PreDroWat1=PreDroWat1,
     eps1=eps1,
-    PreDroAir2=PreDroAir2*10,
-    PreDroWat2=PreDroWat2*10,
+    PreDroAir2=PreDroAir2,
+    PreDroWat2=PreDroWat2,
     eps2=eps2,
-    PreDroAir3=PreDroAir3*10,
-    PreDroWat3=PreDroWat3*10,
+    PreDroAir3=PreDroAir3,
+    PreDroWat3=PreDroWat3,
     eps3=eps3,
-    PreDroAir4=PreDroAir4*10,
-    PreDroWat4=PreDroWat4*10,
+    PreDroAir4=PreDroAir4,
+    PreDroWat4=PreDroWat4,
     eps4=eps4,
-    PreDroAir5=PreDroAir5*10,
-    PreDroWat5=PreDroWat5*10,
+    PreDroAir5=PreDroAir5,
+    PreDroWat5=PreDroWat5,
     eps5=eps5,
     redeclare package MediumCooWat = MediumCHW,
     mWatFloRat=mWatFloRatMid)
@@ -337,7 +338,7 @@ model Airside "Air side system"
     m_flow_lea={1*0.206*1.2, 1*0.137*1.2, 1*0.206*1.2, 1*0.137*1.2},
     PreDroCoiAir=PreDroCoiAir,
     PreDroMixingBoxAir=PreDroMixingBoxAir,
-    PreDroCooWat=PreDroCooWat/2,
+    PreDroCooWat=PreDroCooWat,
     TemEcoHig=TemEcoHig,
     TemEcoLow=TemEcoLow,
     MixingBoxDamMin=MixingBoxDamMin,

--- a/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/BaseClasses/HVACSide/BaseClasses/AirSide.mo
+++ b/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/BaseClasses/HVACSide/BaseClasses/AirSide.mo
@@ -181,7 +181,7 @@ model Airside "Air side system"
       MixingBox_Ti=600,
       Fan_k=0.001,
       Fan_Ti=600,
-      booleanExpression(y=if floor1.duaFanAirHanUni.TOut < 253.15 then floor1.duaFanAirHanUni.occ
+      booleanExpression(y=if floor1.duaFanAirHanUni.TOut < 253.15 then floor1.duaFanAirHanUni.onFanOcc
              else true)),
     fivZonVAV(vol(each V=200000)),
     redeclare package MediumAir = MediumAir,
@@ -257,7 +257,7 @@ model Airside "Air side system"
       MixingBox_Ti=600,
       Fan_k=0.001,
       Fan_Ti=600,
-      booleanExpression(y=if floor2.duaFanAirHanUni.TOut < 253.15 then floor2.duaFanAirHanUni.occ
+      booleanExpression(y=if floor2.duaFanAirHanUni.TOut < 253.15 then floor2.duaFanAirHanUni.onFanOcc
              else true)),
     fivZonVAV(vol(each V=200000)),
     redeclare package MediumAir = MediumAir,
@@ -333,7 +333,7 @@ model Airside "Air side system"
       MixingBox_Ti=600,
       Fan_k=0.001,
       Fan_Ti=600,
-      booleanExpression(y=if floor3.duaFanAirHanUni.TOut < 253.15 then floor3.duaFanAirHanUni.occ
+      booleanExpression(y=if floor3.duaFanAirHanUni.TOut < 253.15 then floor3.duaFanAirHanUni.onFanOcc
              else true)),
     fivZonVAV(vol(each V=200000)),
     redeclare package MediumAir = MediumAir,
@@ -439,8 +439,8 @@ equation
                                         color={0,0,127}));
   connect(TSupAirSet[1].y, floor1.disTSet) annotation (Line(points={{-39,70},{
           108,70},{108,48},{112.438,48}}, color={0,0,127}));
-  connect(reaToBooOcc.y, floor1.occ) annotation (Line(points={{-39,100},{-36,
-          100},{-36,86},{106,86},{106,27},{112.438,27}}, color={255,0,255}));
+  connect(reaToBooOcc.y, floor1.onFanOcc) annotation (Line(points={{-39,100},{
+          -36,100},{-36,86},{106,86},{106,27},{112.438,27}}, color={255,0,255}));
   connect(floor1.onZon, onZon[1].y) annotation (Line(points={{112.438,21.75},{
           104,21.75},{104,76},{61,76}},               color={255,0,255}));
 
@@ -465,7 +465,7 @@ equation
   connect(floor2.port_Fre_Air, sou[2].ports[2]);
   connect(dpStaSet[2].y, floor2.pSet);
   connect(TSupAirSet[2].y, floor2.disTSet);
-  connect(reaToBooOcc.y, floor2.occ);
+  connect(reaToBooOcc.y, floor2.onFanOcc);
   connect(floor2.onZon, onZon[2].y);
 
    for j in 1:5 loop
@@ -481,7 +481,7 @@ equation
   connect(floor3.port_Fre_Air, sou[3].ports[2]);
   connect(dpStaSet[3].y, floor3.pSet);
   connect(TSupAirSet[3].y, floor3.disTSet);
-  connect(reaToBooOcc.y, floor3.occ);
+  connect(reaToBooOcc.y, floor3.onFanOcc);
   connect(floor3.onZon, onZon[3].y);
 
    for j in 1:5 loop

--- a/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/BaseClasses/HVACSide/BaseClasses/AirSide.mo
+++ b/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/BaseClasses/HVACSide/BaseClasses/AirSide.mo
@@ -1,5 +1,6 @@
 within MultizoneOfficeComplexAir.BaseClasses.HVACSide.BaseClasses;
 model Airside "Air side system"
+  parameter Real alpha = 1  "Sizing factor for overall system design capacity and mass flow rate";
   parameter Integer n =  3  "Number of floors";
   parameter Modelica.Units.SI.Pressure PreDroCoiAir=50
     "Pressure drop in the air side";
@@ -31,8 +32,8 @@ model Airside "Air side system"
       mAirFloRat5[3])/1.2*2}} "Volume flow rate curve";
   parameter Real HydEff[n,:] = {{0.93*0.65,0.93*0.7,0.93,0.93*0.6} for i in linspace(1,n,n)} "Hydraulic efficiency";
   parameter Real MotEff[n,:] = {{0.6045*0.65,0.6045*0.7,0.6045,0.6045*0.6} for i in linspace(1,n,n)} "Motor efficiency";
-  parameter Modelica.Units.SI.Pressure SupPreCur[n,:]={{1400*beta,1000*beta,700*beta,700*0.5*beta} for i in linspace(1,n,n)} "Pressure curve";
-  parameter Modelica.Units.SI.Pressure RetPreCur[n,:]={{600*beta,400*beta,200*beta,100*beta} for i in linspace(1,n,n)} "Pressure curve";
+  parameter Modelica.Units.SI.Pressure SupPreCur[n,:]={{2800,2000,1400,700} for i in linspace(1,n,n)} "Pressure curve";
+  parameter Modelica.Units.SI.Pressure RetPreCur[n,:]={{1200,800,400,200} for i in linspace(1,n,n)} "Pressure curve";
   parameter Modelica.Units.SI.Pressure PreAirDroMai1=140
     "Pressure drop 1 across the duct";
   parameter Modelica.Units.SI.Pressure PreAirDroMai2=140
@@ -94,11 +95,11 @@ model Airside "Air side system"
   parameter Modelica.Units.SI.MassFlowRate mWatFloRat5[n]={mAirFloRat5[1]*0.3*(
       35 - 12.88)/4.2/20,mAirFloRat5[2]*0.3*(35 - 12.88)/4.2/20,mAirFloRat5[3]*
       0.3*(35 - 12.88)/4.2/20} "mass flow rate for vav 5";
-  parameter Modelica.Units.SI.MassFlowRate mWatFloRatBot=26.7
+  parameter Modelica.Units.SI.MassFlowRate mWatFloRatBot=26.7*alpha
     "mass flow rate for cooling coil chilled water in floor 1";
-  parameter Modelica.Units.SI.MassFlowRate mWatFloRatMid=267
+  parameter Modelica.Units.SI.MassFlowRate mWatFloRatMid=267*alpha
     "mass flow rate for cooling coil chilled water in floor 2";
-  parameter Modelica.Units.SI.MassFlowRate mWatFloRatTop=26.7
+  parameter Modelica.Units.SI.MassFlowRate mWatFloRatTop=26.7*alpha
     "mass flow rate for cooling coil chilled water in floor 3";
   parameter Modelica.Units.SI.Pressure PreDroAir1=200
     "Pressure drop in the air side of vav 1";
@@ -130,8 +131,6 @@ model Airside "Air side system"
     "Pressure drop in the water side of vav 1";
   parameter Modelica.Units.SI.Efficiency eps5(max=1) = 0.8
     "Heat exchanger effectiveness of vav 1";
-  final parameter Real alpha = 0.8  "Sizing factor";
-  final parameter Real beta = 2  "Sizing factor for AHU fan pressure";
 
   //package MediumAir = Buildings.Media.Air "Medium model for air";
   package MediumAir = Buildings.Media.Air(extraPropertiesNames={"CO2"}) "Buildings library air media package with CO2";

--- a/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/BaseClasses/HVACSide/BaseClasses/AirSide.mo
+++ b/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/BaseClasses/HVACSide/BaseClasses/AirSide.mo
@@ -181,12 +181,15 @@ model Airside "Air side system"
       MixingBox_Ti=600,
       Fan_k=0.001,
       Fan_Ti=600,
-      booleanExpression(y=if floor1.duaFanAirHanUni.TOut < 253.15 then floor1.duaFanAirHanUni.On else true)),
+      booleanExpression(y=if floor1.duaFanAirHanUni.TOut < 253.15 then floor1.duaFanAirHanUni.occ
+             else true)),
     fivZonVAV(vol(each V=200000)),
     redeclare package MediumAir = MediumAir,
     redeclare package MediumHeaWat = MediumHeaWat,
-    C_start=fill(400e-6*Modelica.Media.IdealGases.Common.SingleGasesData.CO2.MM/Modelica.Media.IdealGases.Common.SingleGasesData.Air.MM, MediumAir.nC),
-    m_flow_lea={1*0.206*1.2, 1*0.137*1.2, 1*0.206*1.2, 1*0.137*1.2},
+    C_start=fill(400e-6*Modelica.Media.IdealGases.Common.SingleGasesData.CO2.MM
+        /Modelica.Media.IdealGases.Common.SingleGasesData.Air.MM, MediumAir.nC),
+
+    m_flow_lea={1*0.206*1.2,1*0.137*1.2,1*0.206*1.2,1*0.137*1.2},
     PreDroCoiAir=PreDroCoiAir,
     PreDroMixingBoxAir=PreDroMixingBoxAir,
     PreDroCooWat=PreDroCooWat/2,
@@ -254,13 +257,15 @@ model Airside "Air side system"
       MixingBox_Ti=600,
       Fan_k=0.001,
       Fan_Ti=600,
-      booleanExpression(y=if floor2.duaFanAirHanUni.TOut < 253.15 then floor2.duaFanAirHanUni.On
+      booleanExpression(y=if floor2.duaFanAirHanUni.TOut < 253.15 then floor2.duaFanAirHanUni.occ
              else true)),
     fivZonVAV(vol(each V=200000)),
     redeclare package MediumAir = MediumAir,
     redeclare package MediumHeaWat = MediumHeaWat,
-    C_start=fill(400e-6*Modelica.Media.IdealGases.Common.SingleGasesData.CO2.MM/Modelica.Media.IdealGases.Common.SingleGasesData.Air.MM, MediumAir.nC),
-    m_flow_lea={10*0.206*1.2, 10*0.137*1.2, 10*0.206*1.2, 10*0.137*1.2},
+    C_start=fill(400e-6*Modelica.Media.IdealGases.Common.SingleGasesData.CO2.MM
+        /Modelica.Media.IdealGases.Common.SingleGasesData.Air.MM, MediumAir.nC),
+
+    m_flow_lea={10*0.206*1.2,10*0.137*1.2,10*0.206*1.2,10*0.137*1.2},
     PreDroCoiAir=PreDroCoiAir,
     PreDroMixingBoxAir=PreDroMixingBoxAir,
     PreDroCooWat=PreDroCooWat/2,
@@ -328,13 +333,15 @@ model Airside "Air side system"
       MixingBox_Ti=600,
       Fan_k=0.001,
       Fan_Ti=600,
-      booleanExpression(y=if floor3.duaFanAirHanUni.TOut < 253.15 then floor3.duaFanAirHanUni.On
+      booleanExpression(y=if floor3.duaFanAirHanUni.TOut < 253.15 then floor3.duaFanAirHanUni.occ
              else true)),
     fivZonVAV(vol(each V=200000)),
     redeclare package MediumAir = MediumAir,
     redeclare package MediumHeaWat = MediumHeaWat,
-    C_start=fill(400e-6*Modelica.Media.IdealGases.Common.SingleGasesData.CO2.MM/Modelica.Media.IdealGases.Common.SingleGasesData.Air.MM, MediumAir.nC),
-    m_flow_lea={1*0.206*1.2, 1*0.137*1.2, 1*0.206*1.2, 1*0.137*1.2},
+    C_start=fill(400e-6*Modelica.Media.IdealGases.Common.SingleGasesData.CO2.MM
+        /Modelica.Media.IdealGases.Common.SingleGasesData.Air.MM, MediumAir.nC),
+
+    m_flow_lea={1*0.206*1.2,1*0.137*1.2,1*0.206*1.2,1*0.137*1.2},
     PreDroCoiAir=PreDroCoiAir,
     PreDroMixingBoxAir=PreDroMixingBoxAir,
     PreDroCooWat=PreDroCooWat,
@@ -391,7 +398,7 @@ model Airside "Air side system"
     PreDroWat5=PreDroWat5,
     eps5=eps5,
     redeclare package MediumCooWat = MediumCHW,
-    mWatFloRat=mWatFloRatTop)                      "Top Floor"
+    mWatFloRat=mWatFloRatTop) "Top Floor"
     annotation (Placement(transformation(extent={{114,20},{164,62}})));
 
   MultizoneOfficeComplexAir.BaseClasses.HVACSide.BaseClasses.Component.AirSide.AirHandlingUnit.BaseClasses.ZoneSetpoint
@@ -432,10 +439,9 @@ equation
                                         color={0,0,127}));
   connect(TSupAirSet[1].y, floor1.disTSet) annotation (Line(points={{-39,70},{
           108,70},{108,48},{112.438,48}}, color={0,0,127}));
-  connect(reaToBooOcc.y, floor1.OnFan) annotation (Line(points={{-39,100},{-36,
-          100},{-36,86},{106,86},{106,27},{112.438,27}},
-                                                      color={255,0,255}));
-  connect(floor1.OnZon, onZon[1].y) annotation (Line(points={{112.438,21.75},{
+  connect(reaToBooOcc.y, floor1.occ) annotation (Line(points={{-39,100},{-36,
+          100},{-36,86},{106,86},{106,27},{112.438,27}}, color={255,0,255}));
+  connect(floor1.onZon, onZon[1].y) annotation (Line(points={{112.438,21.75},{
           104,21.75},{104,76},{61,76}},               color={255,0,255}));
 
    for j in 1:5 loop
@@ -459,8 +465,8 @@ equation
   connect(floor2.port_Fre_Air, sou[2].ports[2]);
   connect(dpStaSet[2].y, floor2.pSet);
   connect(TSupAirSet[2].y, floor2.disTSet);
-  connect(reaToBooOcc.y, floor2.OnFan);
-  connect(floor2.OnZon, onZon[2].y);
+  connect(reaToBooOcc.y, floor2.occ);
+  connect(floor2.onZon, onZon[2].y);
 
    for j in 1:5 loop
     connect(loaMulMidFlo[j].y, floor2.Q_flow[j]) annotation (Line(points={{-81.4,
@@ -475,8 +481,8 @@ equation
   connect(floor3.port_Fre_Air, sou[3].ports[2]);
   connect(dpStaSet[3].y, floor3.pSet);
   connect(TSupAirSet[3].y, floor3.disTSet);
-  connect(reaToBooOcc.y, floor3.OnFan);
-  connect(floor3.OnZon, onZon[3].y);
+  connect(reaToBooOcc.y, floor3.occ);
+  connect(floor3.onZon, onZon[3].y);
 
    for j in 1:5 loop
     connect(loa[(3 - 1)*5 + j], floor3.Q_flow[j]);

--- a/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/BaseClasses/HVACSide/BaseClasses/AirsideFloor.mo
+++ b/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/BaseClasses/HVACSide/BaseClasses/AirsideFloor.mo
@@ -268,39 +268,41 @@ model AirsideFloor "Thermal zones and corresponding air side HVAC systems"
     PreDroWat5=PreDroWat5,
     eps5=eps5)
     annotation (Placement(transformation(extent={{30,-18},{66,-46}})));
-  Modelica.Fluid.Interfaces.FluidPort_b port_b_CooWat(redeclare package Medium =
-        MediumCooWat)
+  Modelica.Fluid.Interfaces.FluidPort_b port_b_CooWat(redeclare package Medium
+      = MediumCooWat)
     "Fluid connector b (positive design flow direction is from port_a to port_b)"
     annotation (Placement(transformation(extent={{-70,-110},{-50,-90}}),
         iconTransformation(extent={{-70,-110},{-50,-90}})));
-  Modelica.Fluid.Interfaces.FluidPort_a port_a_CooWat(redeclare package Medium =
-        MediumCooWat)
+  Modelica.Fluid.Interfaces.FluidPort_a port_a_CooWat(redeclare package Medium
+      = MediumCooWat)
     "Fluid connector a (positive design flow direction is from port_a to port_b)"
     annotation (Placement(transformation(extent={{-40,-110},{-20,-90}}),
         iconTransformation(extent={{-40,-110},{-20,-90}})));
-  Modelica.Fluid.Interfaces.FluidPort_a port_a_HeaWat(redeclare package Medium =
-        MediumHeaWat)
+  Modelica.Fluid.Interfaces.FluidPort_a port_a_HeaWat(redeclare package Medium
+      = MediumHeaWat)
     "Second port, typically outlet"
     annotation (Placement(transformation(extent={{30,-110},{50,-90}}),
         iconTransformation(extent={{30,-110},{50,-90}})));
-  Modelica.Fluid.Interfaces.FluidPort_b port_b_HeaWat(redeclare package Medium =
-        MediumHeaWat)
+  Modelica.Fluid.Interfaces.FluidPort_b port_b_HeaWat(redeclare package Medium
+      = MediumHeaWat)
     "Second port, typically outlet"
     annotation (Placement(transformation(extent={{60,-110},{80,-90}}),
         iconTransformation(extent={{60,-110},{80,-90}})));
-  Modelica.Fluid.Interfaces.FluidPort_b port_Exh_Air(redeclare package Medium = MediumAir)
+  Modelica.Fluid.Interfaces.FluidPort_b port_Exh_Air(redeclare package Medium
+      =                                                                         MediumAir)
     "Fluid connector b (positive design flow direction is from port_a to port_b)"
     annotation (Placement(transformation(extent={{-174,-50},{-154,-30}})));
-  Modelica.Fluid.Interfaces.FluidPort_a port_Fre_Air(redeclare package Medium = MediumAir)
+  Modelica.Fluid.Interfaces.FluidPort_a port_Fre_Air(redeclare package Medium
+      =                                                                         MediumAir)
     "Fluid connector b (positive design flow direction is from port_a to port_b)"
     annotation (Placement(transformation(extent={{-170,30},{-150,50}})));
   Modelica.Blocks.Routing.BooleanReplicator booleanReplicator(nout=5)
     annotation (Placement(transformation(extent={{-140,-96},{-126,-84}})));
-  Modelica.Blocks.Interfaces.BooleanInput OnFan
-    "Connector of Boolean input signal"
-    annotation (Placement(transformation(extent={{-180,-70},{-160,-50}}),
-        iconTransformation(extent={{-180,-70},{-160,-50}})));
-  Modelica.Blocks.Interfaces.BooleanInput OnZon
+  Modelica.Blocks.Interfaces.BooleanInput occ
+    "Connector of Boolean input signal" annotation (Placement(transformation(
+          extent={{-180,-70},{-160,-50}}), iconTransformation(extent={{-180,-70},
+            {-160,-50}})));
+  Modelica.Blocks.Interfaces.BooleanInput onZon
     "Connector of Boolean input signal"
     annotation (Placement(transformation(extent={{-180,-100},{-160,-80}}),
         iconTransformation(extent={{-180,-100},{-160,-80}})));
@@ -422,7 +424,7 @@ equation
       points={{-78,-7.27273},{-114,-7.27273},{-114,40},{-160,40}},
       color={0,140,72},
       thickness=0.5));
-  connect(booleanReplicator.y, fivZonVAV.On) annotation (Line(
+  connect(booleanReplicator.y,fivZonVAV.on)  annotation (Line(
       points={{-125.3,-90},{4,-90},{4,-31.7455},{28.8,-31.7455}},
       color={255,0,255}));
   connect(fivZonVAV.p, duaFanAirHanUni.pMea) annotation (Line(points={{55.2,
@@ -434,10 +436,9 @@ equation
           4.54545}},
         color={0,0,127}));
 
-  connect(OnFan, duaFanAirHanUni.On) annotation (Line(points={{-170,-60},{-108,
-          -60},{-108,11.6364},{-79.4,11.6364}},
-                                      color={255,0,255}));
-  connect(booleanReplicator.u, OnZon) annotation (Line(
+  connect(occ, duaFanAirHanUni.occ) annotation (Line(points={{-170,-60},{-108,
+          -60},{-108,11.6364},{-79.4,11.6364}}, color={255,0,255}));
+  connect(booleanReplicator.u,onZon)  annotation (Line(
       points={{-141.4,-90},{-170,-90}},
       color={255,0,255}));
   connect(fivZonVAV.Q_flow, Q_flow) annotation (Line(
@@ -450,8 +451,8 @@ equation
   connect(port_a_CooWat, port_a_CooWat) annotation (Line(points={{-30,-100},
           {-30,-100}},     color={0,127,255}));
 
-  connect(OnFan, reaAhu.occ_in) annotation (Line(points={{-170,-60},{-112,-60},
-          {-112,62},{26,62},{26,62.8}},    color={255,0,255}));
+  connect(occ, reaAhu.occ_in) annotation (Line(points={{-170,-60},{-112,-60},{-112,
+          62},{26,62},{26,62.8}}, color={255,0,255}));
   connect(duaFanAirHanUni.TSupAir, reaAhu.TSup_in) annotation (Line(
       points={{-48.6,-4.90909},{-34,-4.90909},{-34,56.1538},{26,56.1538}},
       color={0,0,127},

--- a/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/BaseClasses/HVACSide/BaseClasses/AirsideFloor.mo
+++ b/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/BaseClasses/HVACSide/BaseClasses/AirsideFloor.mo
@@ -298,8 +298,8 @@ model AirsideFloor "Thermal zones and corresponding air side HVAC systems"
     annotation (Placement(transformation(extent={{-170,30},{-150,50}})));
   Modelica.Blocks.Routing.BooleanReplicator booleanReplicator(nout=5)
     annotation (Placement(transformation(extent={{-140,-96},{-126,-84}})));
-  Modelica.Blocks.Interfaces.BooleanInput occ
-    "Connector of Boolean input signal" annotation (Placement(transformation(
+  Modelica.Blocks.Interfaces.BooleanInput onFanOcc
+    "Fan On signal during occupied period" annotation (Placement(transformation(
           extent={{-180,-70},{-160,-50}}), iconTransformation(extent={{-180,-70},
             {-160,-50}})));
   Modelica.Blocks.Interfaces.BooleanInput onZon
@@ -436,8 +436,8 @@ equation
           4.54545}},
         color={0,0,127}));
 
-  connect(occ, duaFanAirHanUni.occ) annotation (Line(points={{-170,-60},{-108,
-          -60},{-108,11.6364},{-79.4,11.6364}}, color={255,0,255}));
+  connect(onFanOcc, duaFanAirHanUni.onFanOcc) annotation (Line(points={{-170,
+          -60},{-108,-60},{-108,11.6364},{-79.4,11.6364}}, color={255,0,255}));
   connect(booleanReplicator.u,onZon)  annotation (Line(
       points={{-141.4,-90},{-170,-90}},
       color={255,0,255}));
@@ -451,8 +451,8 @@ equation
   connect(port_a_CooWat, port_a_CooWat) annotation (Line(points={{-30,-100},
           {-30,-100}},     color={0,127,255}));
 
-  connect(occ, reaAhu.occ_in) annotation (Line(points={{-170,-60},{-112,-60},{-112,
-          62},{26,62},{26,62.8}}, color={255,0,255}));
+  connect(onFanOcc, reaAhu.occ_in) annotation (Line(points={{-170,-60},{-112,-60},
+          {-112,62},{26,62},{26,62.8}}, color={255,0,255}));
   connect(duaFanAirHanUni.TSupAir, reaAhu.TSup_in) annotation (Line(
       points={{-48.6,-4.90909},{-34,-4.90909},{-34,56.1538},{26,56.1538}},
       color={0,0,127},

--- a/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/BaseClasses/HVACSide/BaseClasses/AirsideFloor.mo
+++ b/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/BaseClasses/HVACSide/BaseClasses/AirsideFloor.mo
@@ -359,7 +359,7 @@ model AirsideFloor "Thermal zones and corresponding air side HVAC systems"
     zonVAVCon[5](
     each MinFlowRateSetPoi=0.3,
     each HeatingFlowRateSetPoi=0.5,
-    heaCon(Ti=60, yMin=0.),
+    heaCon(Ti=60, yMin=0.005),
     cooCon(k=11, Ti=60))
     "Zone terminal VAV controller (airflow rate, reheat valve)l "
     annotation (Placement(transformation(extent={{-14,118},{6,138}})));
@@ -855,6 +855,8 @@ MultizoneOfficeComplexAir.BaseClasses.HVACSide.BaseClasses.Component.AirSide.Zon
 MultizoneOfficeComplexAir.BaseClasses.HVACSide.BaseClasses.Component.AirSide.ZoneTerminal.Controls.ZonCon</a> for a description of the zone terminal VAV controller. </p>
 </html>", revisions = "<html>
 <ul>
+<li> August 8, 2024, by Guowen Li, Xing Lu, Yan Chen: </li>
+<p> Added CO2 and air infiltration features; Adjusted system equipment sizing; Reduced nonlinear system warnings.</p>
 <li> August 17, 2023, by Xing Lu, Sen Huang, Lingzhe Wang:
 <p> First implementation.</p>
 </ul>

--- a/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/BaseClasses/HVACSide/BaseClasses/BoilerPlant.mo
+++ b/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/BaseClasses/HVACSide/BaseClasses/BoilerPlant.mo
@@ -206,6 +206,8 @@ MultizoneOfficeComplexAir.BaseClasses.HVACSide.BaseClasses.Component.WaterSide.B
 MultizoneOfficeComplexAir.BaseClasses.HVACSide.BaseClasses.Component.WaterSide.Control.PlantStageN</a> for a description of the boiler stage control. </p>
 </html>", revisions = "<html>
 <ul>
+<li>August 8, 2024, by Guowen Li, Xing Lu, Yan Chen: </li>
+<p>Adjusted system equipment sizing; Reduced nonlinear system warnings.</p>
 <li> August 17, 2023, by Xing Lu, Sen Huang, Lingzhe Wang:
 <p> First implementation.</p>
 </ul>

--- a/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/BaseClasses/HVACSide/BaseClasses/BoilerPlant.mo
+++ b/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/BaseClasses/HVACSide/BaseClasses/BoilerPlant.mo
@@ -87,10 +87,10 @@ model BoilerPlant "Boiler hot water plant"
     annotation (Placement(transformation(extent={{-320,-20},{-280,20}}),
         iconTransformation(extent={{-140,-20},{-100,20}})));
 
-  Modelica.Blocks.Interfaces.RealOutput THWLea
-    "Temperature of the passing fluid"
-    annotation (Placement(transformation(extent={{240,-10},{260,10}}),
-        iconTransformation(extent={{100,-10},{120,10}})));
+  Modelica.Blocks.Interfaces.RealOutput THW_sup
+    "Temperature of the passing fluid" annotation (Placement(transformation(
+          extent={{240,-30},{260,-10}}), iconTransformation(extent={{100,-40},{
+            120,-20}})));
   Buildings.Fluid.Sensors.TemperatureTwoPort senTHWBuiLea(
     allowFlowReversal=true,
     redeclare package Medium = MediumHW,
@@ -120,6 +120,13 @@ model BoilerPlant "Boiler hot water plant"
     annotation (Placement(transformation(extent={{140,-120},{160,-100}})));
   Modelica.Blocks.Continuous.Integrator ETot
     annotation (Placement(transformation(extent={{180,-120},{200,-100}})));
+  Modelica.Blocks.Interfaces.RealOutput THW_ret
+    "Temperature of the passing fluid" annotation (Placement(transformation(
+          extent={{240,-10},{260,10}}), iconTransformation(extent={{100,-10},{
+            120,10}})));
+  Modelica.Blocks.Interfaces.RealOutput mHW_tot annotation (Placement(
+        transformation(extent={{240,50},{260,70}}), iconTransformation(extent={
+            {100,60},{120,80}})));
 equation
   connect(On.y, reaToBoolea.u)
     annotation (Line(points={{-239,90},{-162,90}}, color={0,0,127}));
@@ -145,9 +152,8 @@ equation
           {-120,90},{-139,90}}, color={255,0,255}));
   connect(secPumCon.dpMea, dp) annotation (Line(points={{58,56},{-180,56},{
           -180,0},{-300,0}}, color={0,0,127}));
-  connect(senTHWBuiEnt.T, THWLea) annotation (Line(
-      points={{64,-85},{64,0},{250,0}},
-      color={0,0,127}));
+  connect(senTHWBuiEnt.T, THW_sup) annotation (Line(points={{64,-85},{64,-56},{
+          220,-56},{220,-20},{250,-20}}, color={0,0,127}));
   connect(mulBoi.Rat, boiSta.sta) annotation (Line(points={{-60.3,-35.6},{-32,
           -35.6},{-32,34},{-92,34},{-92,62},{-82,62}}, color={0,0,127}));
   connect(boiSta.y, mulBoi.On) annotation (Line(points={{-59,70},{-42,70},{
@@ -180,6 +186,10 @@ equation
   connect(PTot.y,ETot. u) annotation (Line(
       points={{161,-110},{178,-110}},
       color={0,0,127}));
+  connect(senTHWBuiLea.T, THW_ret) annotation (Line(points={{120,33},{120,36},{
+          220,36},{220,0},{250,0}}, color={0,0,127}));
+  connect(senMasFlo.m_flow, mHW_tot) annotation (Line(points={{82,35.2},{100,
+          35.2},{100,60},{250,60}}, color={0,0,127}));
   annotation (__Dymola_Commands(file=
           "modelica://ChillerPlantSystem/Resources/Scripts/Dymola/LejeunePlant/ChillerPlantSystem.mos"
         "Simulate and plot"),

--- a/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/BaseClasses/HVACSide/BaseClasses/BoilerPlant.mo
+++ b/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/BaseClasses/HVACSide/BaseClasses/BoilerPlant.mo
@@ -3,14 +3,15 @@ model BoilerPlant "Boiler hot water plant"
   replaceable package MediumHW =
      Modelica.Media.Interfaces.PartialMedium
     "Medium in the hot water side";
+  parameter Real alpha = 1  "Sizing factor for overall system design capacity and mass flow rate";
   parameter Integer n=2
     "Number of boilers";
   parameter Integer m=2
     "Number of pumps";
   parameter Real thrhol[:]= {0.95}
     "Threshold for boiler staging";
-  parameter Real Cap[:] = {4191000/n for i in linspace(1, n, n)} "Rated Plant Capacity";
-  parameter Modelica.Units.SI.MassFlowRate mHW_flow_nominal[:]={4191000/n/20
+  parameter Real Cap[:] = {4191000*alpha/n for i in linspace(1, n, n)} "Rated Plant Capacity";
+  parameter Modelica.Units.SI.MassFlowRate mHW_flow_nominal[:]={4191000*alpha/n/20
       /4200 for i in linspace(
       1,
       n,

--- a/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/BaseClasses/HVACSide/BaseClasses/BoilerPlant.mo
+++ b/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/BaseClasses/HVACSide/BaseClasses/BoilerPlant.mo
@@ -9,8 +9,8 @@ model BoilerPlant "Boiler hot water plant"
     "Number of pumps";
   parameter Real thrhol[:]= {0.95}
     "Threshold for boiler staging";
-  parameter Real Cap[:] = {2762738.20/n for i in linspace(1, n, n)} "Rated Plant Capacity";
-  parameter Modelica.Units.SI.MassFlowRate mHW_flow_nominal[:]={2762738.20/n/20
+  parameter Real Cap[:] = {4191000/n for i in linspace(1, n, n)} "Rated Plant Capacity";
+  parameter Modelica.Units.SI.MassFlowRate mHW_flow_nominal[:]={4191000/n/20
       /4200 for i in linspace(
       1,
       n,

--- a/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/BaseClasses/HVACSide/BaseClasses/ChillerPlant.mo
+++ b/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/BaseClasses/HVACSide/BaseClasses/ChillerPlant.mo
@@ -242,9 +242,10 @@ model ChillerPlant
     annotation (Placement(transformation(extent={{-312,-22},{-280,10}}),
         iconTransformation(extent={{-132,-16},{-100,16}})));
 
-  Modelica.Blocks.Interfaces.RealOutput T "Temperature of the passing fluid"
-    annotation (Placement(transformation(extent={{240,-10},{260,10}}),
-        iconTransformation(extent={{100,-10},{120,10}})));
+  Modelica.Blocks.Interfaces.RealOutput TCHW_sup
+    "Temperature of the passing fluid" annotation (Placement(transformation(
+          extent={{240,-30},{260,-10}}), iconTransformation(extent={{100,-20},{
+            120,0}})));
   Buildings.Fluid.Sensors.TemperatureTwoPort senTCHWBuiLea(
     redeclare package Medium = MediumCHW,
     allowFlowReversal=true,
@@ -265,6 +266,13 @@ model ChillerPlant
     "Static differential pressure setpoint for the secondary pump"
     annotation (Placement(transformation(extent={{-312,30},{-280,62}}),
         iconTransformation(extent={{-132,26},{-100,58}})));
+  Modelica.Blocks.Interfaces.RealOutput TCHW_ret
+    "Temperature of the passing fluid" annotation (Placement(transformation(
+          extent={{240,-10},{260,10}}), iconTransformation(extent={{100,10},{
+            120,30}})));
+  Modelica.Blocks.Interfaces.RealOutput mCHW_tot annotation (Placement(
+        transformation(extent={{240,-70},{260,-50}}), iconTransformation(extent
+          ={{100,-80},{120,-60}})));
 equation
   connect(senTCHWByp.port_a, senMasFloByp.port_b) annotation (Line(
       points={{-4.44089e-016,-20},{-4.44089e-016,-32},{0,-32},{0,-42}},
@@ -371,9 +379,8 @@ equation
   connect(pumSecCHW.speSig, secPumCon.y) annotation (Line(
       points={{39.1,-62},{18,-62},{18,0},{88,0},{88,48},{81,48}},
       color={0,0,127}));
-  connect(senTCHWBuiEnt.T, T) annotation (Line(
-      points={{96,-81.2},{96,0},{250,0}},
-      color={0,0,127}));
+  connect(senTCHWBuiEnt.T, TCHW_sup) annotation (Line(points={{96,-81.2},{96,-8},
+          {234,-8},{234,-20},{250,-20}}, color={0,0,127}));
   connect(pumPriCHW.port_a, senTCHWBuiLea.port_b) annotation (Line(
       points={{-12,18},{60,18}},
       color={0,127,255},
@@ -392,6 +399,10 @@ equation
           65},{-79.6,65}}, color={0,0,127}));
   connect(secPumCon.dpSet, dpSet) annotation (Line(points={{58,44},{-120,44},
           {-120,46},{-296,46}}, color={0,0,127}));
+  connect(senTCHWBuiLea.T, TCHW_ret) annotation (Line(points={{70,29},{134,29},
+          {134,0},{250,0}}, color={0,0,127}));
+  connect(senMasFloSecCHW.m_flow, mCHW_tot) annotation (Line(points={{130,-81.2},
+          {130,-60},{250,-60}}, color={0,0,127}));
   annotation (__Dymola_Commands(file=
           "modelica://ChillerPlantSystem/Resources/Scripts/Dymola/LejeunePlant/ChillerPlantSystem.mos"
         "Simulate and plot"),

--- a/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/BaseClasses/HVACSide/BaseClasses/ChillerPlant.mo
+++ b/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/BaseClasses/HVACSide/BaseClasses/ChillerPlant.mo
@@ -19,7 +19,7 @@ model ChillerPlant
   parameter Modelica.Units.SI.Power PTow_nominal[:]={-datChi[1].QEva_flow_nominal*(COP_nominal + 1)/COP_nominal*0.015 for i in linspace(
       1,
       n,
-      n)} "Nominal cooling tower power (assume specific fan power is 0.015kW per 1kW of CT heat rejected)";
+      n)} "Nominal cooling tower power based on CT capacity Q_cond (assume specific fan power is 0.015kW per 1kW of CT heat rejected)";
   parameter Modelica.Units.SI.TemperatureDifference dTCHW_nominal=5.56
     "Temperature difference at chilled water side";
   parameter Modelica.Units.SI.TemperatureDifference dTCW_nominal=5.18

--- a/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/BaseClasses/HVACSide/BaseClasses/ChillerPlant.mo
+++ b/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/BaseClasses/HVACSide/BaseClasses/ChillerPlant.mo
@@ -16,10 +16,10 @@ model ChillerPlant
   parameter Real tWai = 900 "Waiting time";
   parameter Modelica.Units.SI.TemperatureDifference dT=0.5
     "Temperature difference for stage control";
-  parameter Modelica.Units.SI.Power PTow_nominal[:]={10E3 for i in linspace(
+  parameter Modelica.Units.SI.Power PTow_nominal[:]={-datChi[1].QEva_flow_nominal*(COP_nominal + 1)/COP_nominal*0.015 for i in linspace(
       1,
       n,
-      n)} "Nominal cooling tower power (at y=1)";
+      n)} "Nominal cooling tower power (assume specific fan power is 0.015kW per 1kW of CT heat rejected)";
   parameter Modelica.Units.SI.TemperatureDifference dTCHW_nominal=5.56
     "Temperature difference at chilled water side";
   parameter Modelica.Units.SI.TemperatureDifference dTCW_nominal=5.18
@@ -40,12 +40,12 @@ model ChillerPlant
     "Approach temperature for controlling cooling towers";
   parameter Real COP_nominal = datChi[1].COP_nominal "Chiller COP";
   parameter Modelica.Units.SI.MassFlowRate mCHW_flow_nominal[:]={-datChi[1].QEva_flow_nominal
-      /4200/5.56 for i in linspace(
+      /4200/dTCHW_nominal for i in linspace(
       1,
       n,
       n)} "Nominal mass flow rate at chilled water side";
   parameter Modelica.Units.SI.MassFlowRate mCW_flow_nominal[:]={
-      mCHW_flow_nominal[1]*(datChi[1].COP_nominal + 1)/datChi[1].COP_nominal
+      -datChi[1].QEva_flow_nominal*(COP_nominal + 1)/COP_nominal/4200/dTCW_nominal
       for i in linspace(
       1,
       n,
@@ -164,7 +164,7 @@ model ChillerPlant
         1,
         n,
         n)},
-    dp_nominal=dPCW_nominal*10)
+    dp_nominal=dPCW_nominal + dP_nominal + dPByp_nominal)
     annotation (Placement(transformation(extent={{-144,-102},{-116,-76}})));
   Buildings.Fluid.Storage.ExpansionVessel expVesCW(
       redeclare package Medium = MediumCW, V_start=1)

--- a/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/BaseClasses/HVACSide/BaseClasses/ChillerPlant.mo
+++ b/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/BaseClasses/HVACSide/BaseClasses/ChillerPlant.mo
@@ -428,6 +428,8 @@ MultizoneOfficeComplexAir.BaseClasses.HVACSide.BaseClasses.Component.WaterSide.C
 MultizoneOfficeComplexAir.BaseClasses.HVACSide.BaseClasses.Component.FlowMover.Pump.Control.SecPumCon</a> for a description of the chilled water secondary pump control. </p>
 </html>", revisions = "<html>
 <ul>
+<li> August 8, 2024, by Guowen Li, Xing Lu, Yan Chen: </li>
+<p> Adjusted system equipment sizing; Reduced nonlinear system warnings.</p>
 <li> August 17, 2023, by Xing Lu, Sen Huang, Lingzhe Wang:
 <p> First implementation.</p>
 </ul>

--- a/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/BaseClasses/HVACSide/BaseClasses/Component/AirSide/AirHandlingUnit/DuaFanAirHanUnit.mo
+++ b/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/BaseClasses/HVACSide/BaseClasses/Component/AirSide/AirHandlingUnit/DuaFanAirHanUnit.mo
@@ -122,7 +122,8 @@ model DuaFanAirHanUnit "AHU with supply/return fans and cooling coil."
                 MediumAir)
     "Fluid connector a (positive design flow direction is from port_a to port_b)"
     annotation (Placement(transformation(extent={{90,-90},{110,-70}})));
-  Modelica.Blocks.Interfaces.BooleanInput occ "occupied boolean signal"
+  Modelica.Blocks.Interfaces.BooleanInput onFanOcc
+    "Fan On signal during occupied period"
     annotation (Placement(transformation(extent={{-120,-110},{-100,-90}})));
   Modelica.Blocks.Interfaces.RealInput disTSet
     "Connector of setpoint input signal" annotation (Placement(
@@ -333,10 +334,10 @@ equation
           {8,-50},{8,12},{-0.2,12}},      color={255,0,255}));
   connect(mixBox.TOut, TOut) annotation (Line(points={{-54,-12},{-54,-80},
           {-110,-80}}, color={0,0,127}));
-  connect(occ, mixBox.On) annotation (Line(points={{-110,-100},{-68,-100},{-68,
-          -12}}, color={255,0,255}));
-  connect(occ, supFan.occ) annotation (Line(points={{-110,-100},{4,-100},{4,6},
-          {16,6}}, color={255,0,255}));
+  connect(onFanOcc, mixBox.On) annotation (Line(points={{-110,-100},{-68,-100},
+          {-68,-12}}, color={255,0,255}));
+  connect(onFanOcc, supFan.onFanOcc) annotation (Line(points={{-110,-100},{4,-100},
+          {4,6},{16,6}}, color={255,0,255}));
   connect(senTDisAir.T, TSupAir) annotation (Line(points={{82,6.6},{82,40},
           {110,40}},     color={0,0,127},
       pattern=LinePattern.Dash));

--- a/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/BaseClasses/HVACSide/BaseClasses/Component/AirSide/AirHandlingUnit/DuaFanAirHanUnit.mo
+++ b/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/BaseClasses/HVACSide/BaseClasses/Component/AirSide/AirHandlingUnit/DuaFanAirHanUnit.mo
@@ -72,8 +72,8 @@ model DuaFanAirHanUnit "AHU with supply/return fans and cooling coil."
     VolFloCur=VolFloCur,
     PreCur=SupPreCur)
     annotation (Placement(transformation(extent={{18,-10},{38,10}})));
-  Modelica.Fluid.Interfaces.FluidPort_b port_b_Air(redeclare package
-      Medium = MediumAir)
+  Modelica.Fluid.Interfaces.FluidPort_b port_b_Air(redeclare package Medium =
+               MediumAir)
     "Fluid connector b (positive design flow direction is from port_a to port_b)"
     annotation (Placement(transformation(extent={{90,-10},{110,10}})));
   MultizoneOfficeComplexAir.BaseClasses.HVACSide.BaseClasses.Component.AirSide.Coil.CoolingCoil
@@ -102,27 +102,27 @@ model DuaFanAirHanUnit "AHU with supply/return fans and cooling coil."
         extent={{-10,-10},{10,10}},
         rotation=90,
         origin={-60,0})));
-  Modelica.Fluid.Interfaces.FluidPort_a port_a_Wat(redeclare package
-      Medium =  MediumWat)
+  Modelica.Fluid.Interfaces.FluidPort_a port_a_Wat(redeclare package Medium =
+                MediumWat)
     "Fluid connector a (positive design flow direction is from port_a to port_b)"
     annotation (Placement(transformation(extent={{10,90},{30,110}})));
-  Modelica.Fluid.Interfaces.FluidPort_b port_b_Wat(redeclare package
-      Medium = MediumWat)
+  Modelica.Fluid.Interfaces.FluidPort_b port_b_Wat(redeclare package Medium =
+               MediumWat)
     "Fluid connector b (positive design flow direction is from port_a to port_b)"
     annotation (Placement(transformation(extent={{-50,90},{-30,110}})));
-  Modelica.Fluid.Interfaces.FluidPort_b port_Exh_Air(redeclare package
-      Medium =  MediumAir)
+  Modelica.Fluid.Interfaces.FluidPort_b port_Exh_Air(redeclare package Medium
+      =         MediumAir)
     "Fluid connector b (positive design flow direction is from port_a to port_b)"
     annotation (Placement(transformation(extent={{-112,-10},{-92,10}})));
-  Modelica.Fluid.Interfaces.FluidPort_a port_Fre_Air(redeclare package
-      Medium = MediumAir)
+  Modelica.Fluid.Interfaces.FluidPort_a port_Fre_Air(redeclare package Medium
+      =        MediumAir)
     "Fluid connector b (positive design flow direction is from port_a to port_b)"
     annotation (Placement(transformation(extent={{-110,50},{-90,70}})));
-  Modelica.Fluid.Interfaces.FluidPort_a port_a_Air(redeclare package
-      Medium =  MediumAir)
+  Modelica.Fluid.Interfaces.FluidPort_a port_a_Air(redeclare package Medium =
+                MediumAir)
     "Fluid connector a (positive design flow direction is from port_a to port_b)"
     annotation (Placement(transformation(extent={{90,-90},{110,-70}})));
-  Modelica.Blocks.Interfaces.BooleanInput On
+  Modelica.Blocks.Interfaces.BooleanInput occ "occupied boolean signal"
     annotation (Placement(transformation(extent={{-120,-110},{-100,-90}})));
   Modelica.Blocks.Interfaces.RealInput disTSet
     "Connector of setpoint input signal" annotation (Placement(
@@ -241,7 +241,7 @@ model DuaFanAirHanUnit "AHU with supply/return fans and cooling coil."
       unit="1"))
     annotation (Placement(transformation(extent={{48,-56},{64,-40}})));
   Buildings.Fluid.Sensors.TraceSubstancesTwoPort senCO2RetAir(redeclare package
-              Medium = MediumAir, m_flow_nominal=mAirFloRat,
+      Medium =         MediumAir, m_flow_nominal=mAirFloRat,
     C_start=400e-6*Modelica.Media.IdealGases.Common.SingleGasesData.CO2.MM/
         Modelica.Media.IdealGases.Common.SingleGasesData.Air.MM)
     "Sensor at AHU return air"
@@ -257,7 +257,7 @@ model DuaFanAirHanUnit "AHU with supply/return fans and cooling coil."
         transformation(extent={{100,-110},{120,-90}}), iconTransformation(
           extent={{100,-110},{120,-90}})));
   Buildings.Fluid.Sensors.TraceSubstancesTwoPort senCO2FreAir(redeclare package
-              Medium = MediumAir,
+      Medium =         MediumAir,
     allowFlowReversal=false,      m_flow_nominal=mAirFloRat,
     C_start=400e-6*Modelica.Media.IdealGases.Common.SingleGasesData.CO2.MM/
         Modelica.Media.IdealGases.Common.SingleGasesData.Air.MM)
@@ -286,7 +286,7 @@ model DuaFanAirHanUnit "AHU with supply/return fans and cooling coil."
         transformation(extent={{100,-148},{120,-128}}),
         iconTransformation(extent={{100,-132},{120,-112}})));
   Buildings.Fluid.Sensors.TraceSubstancesTwoPort senCO2SupAir(redeclare package
-              Medium = MediumAir, m_flow_nominal=mAirFloRat,
+      Medium =         MediumAir, m_flow_nominal=mAirFloRat,
     C_start=400e-6*Modelica.Media.IdealGases.Common.SingleGasesData.CO2.MM/
         Modelica.Media.IdealGases.Common.SingleGasesData.Air.MM)
     "Sensor at AHU supply air" annotation (Placement(transformation(
@@ -333,10 +333,10 @@ equation
           {8,-50},{8,12},{-0.2,12}},      color={255,0,255}));
   connect(mixBox.TOut, TOut) annotation (Line(points={{-54,-12},{-54,-80},
           {-110,-80}}, color={0,0,127}));
-  connect(On, mixBox.On) annotation (Line(points={{-110,-100},{-68,-100},
-          {-68,-12}}, color={255,0,255}));
-  connect(On, supFan.On) annotation (Line(points={{-110,-100},{4,-100},{4,6},{16,
-          6}},     color={255,0,255}));
+  connect(occ, mixBox.On) annotation (Line(points={{-110,-100},{-68,-100},{-68,
+          -12}}, color={255,0,255}));
+  connect(occ, supFan.occ) annotation (Line(points={{-110,-100},{4,-100},{4,6},
+          {16,6}}, color={255,0,255}));
   connect(senTDisAir.T, TSupAir) annotation (Line(points={{82,6.6},{82,40},
           {110,40}},     color={0,0,127},
       pattern=LinePattern.Dash));

--- a/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/BaseClasses/HVACSide/BaseClasses/Component/AirSide/AirHandlingUnit/DuaFanAirHanUnit.mo
+++ b/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/BaseClasses/HVACSide/BaseClasses/Component/AirSide/AirHandlingUnit/DuaFanAirHanUnit.mo
@@ -89,7 +89,7 @@ model DuaFanAirHanUnit "AHU with supply/return fans and cooling coil."
     UA=UA*1.2*eps)
     annotation (Placement(transformation(extent={{-2,-2},{-20,18}})));
   MultizoneOfficeComplexAir.BaseClasses.HVACSide.BaseClasses.Component.AirSide.MixingBox.MixingBoxWithControl
-    mixBox(
+    mixingBox(
     mTotAirFloRat=mAirFloRat,
     redeclare package Medium = MediumAir,
     PreDro=PreDroMixingBoxAir,
@@ -110,12 +110,12 @@ model DuaFanAirHanUnit "AHU with supply/return fans and cooling coil."
                MediumWat)
     "Fluid connector b (positive design flow direction is from port_a to port_b)"
     annotation (Placement(transformation(extent={{-50,90},{-30,110}})));
-  Modelica.Fluid.Interfaces.FluidPort_b port_Exh_Air(redeclare package Medium
-      =         MediumAir)
+  Modelica.Fluid.Interfaces.FluidPort_b port_Exh_Air(redeclare package Medium =
+                MediumAir)
     "Fluid connector b (positive design flow direction is from port_a to port_b)"
     annotation (Placement(transformation(extent={{-112,-10},{-92,10}})));
-  Modelica.Fluid.Interfaces.FluidPort_a port_Fre_Air(redeclare package Medium
-      =        MediumAir)
+  Modelica.Fluid.Interfaces.FluidPort_a port_Fre_Air(redeclare package Medium =
+               MediumAir)
     "Fluid connector b (positive design flow direction is from port_a to port_b)"
     annotation (Placement(transformation(extent={{-110,50},{-90,70}})));
   Modelica.Fluid.Interfaces.FluidPort_a port_a_Air(redeclare package Medium =
@@ -190,7 +190,7 @@ model DuaFanAirHanUnit "AHU with supply/return fans and cooling coil."
   Modelica.Blocks.Interfaces.RealOutput V_flowRetAir
     "Return air volume flow rate "
     annotation (Placement(transformation(extent={{100,-76},{120,-56}})));
-  Modelica.Blocks.Sources.RealExpression yDamOutAirMea(y=mixBox.mixBox.valFre.y)
+  Modelica.Blocks.Sources.RealExpression yDamOutAirMea(y=mixingBox.mixBox.valFre.y)
     annotation (Placement(transformation(extent={{40,84},{60,104}})));
   Modelica.Blocks.Interfaces.RealOutput yDamOutAir(
     final min=0,
@@ -299,7 +299,7 @@ equation
       points={{-1.82,0},{18,0}},
       color={0,140,72},
       thickness=0.5));
-  connect(mixBox.TMix, disTSet) annotation (Line(points={{-60,-12},{-60,-20},
+  connect(mixingBox.TMix, disTSet) annotation (Line(points={{-60,-12},{-60,-20},
           {-110,-20}}, color={0,0,127}));
   connect(cooCoi.SetPoi, disTSet) annotation (Line(points={{-0.2,6},{6,
           6},{6,-20},{-110,-20}}, color={0,0,127}));
@@ -307,11 +307,11 @@ equation
           -40}}, color={0,0,127}));
   connect(supFan.pSet, pSet) annotation (Line(points={{16,2},{12,2},{12,
           -60},{-110,-60}}, color={0,0,127}));
-  connect(port_Exh_Air, mixBox.port_Exh) annotation (Line(
+  connect(port_Exh_Air, mixingBox.port_Exh) annotation (Line(
       points={{-102,0},{-82,0},{-82,-6},{-70,-6}},
       color={0,140,72},
       thickness=0.5));
-  connect(mixBox.port_Ret, retFan.port_b) annotation (Line(
+  connect(mixingBox.port_Ret, retFan.port_b) annotation (Line(
       points={{-50,-5.8},{-42,-5.8},{-42,-80},{-30,-80}},
       color={0,140,72},
       thickness=0.5));
@@ -332,9 +332,9 @@ equation
           -2},{-46,40},{-110,40}}, color={0,0,127}));
   connect(booleanExpression.y, cooCoi.On) annotation (Line(points={{-13,-50},
           {8,-50},{8,12},{-0.2,12}},      color={255,0,255}));
-  connect(mixBox.TOut, TOut) annotation (Line(points={{-54,-12},{-54,-80},
-          {-110,-80}}, color={0,0,127}));
-  connect(onFanOcc, mixBox.On) annotation (Line(points={{-110,-100},{-68,-100},
+  connect(mixingBox.TOut, TOut) annotation (Line(points={{-54,-12},{-54,-80},{-110,
+          -80}}, color={0,0,127}));
+  connect(onFanOcc, mixingBox.On) annotation (Line(points={{-110,-100},{-68,-100},
           {-68,-12}}, color={255,0,255}));
   connect(onFanOcc, supFan.onFanOcc) annotation (Line(points={{-110,-100},{4,-100},
           {4,6},{16,6}}, color={255,0,255}));
@@ -345,7 +345,7 @@ equation
       points={{-24,0},{-20,0}},
       color={0,140,72},
       thickness=0.5));
-  connect(mixBox.port_Sup, senTMixAir.port_a) annotation (Line(
+  connect(mixingBox.port_Sup, senTMixAir.port_a) annotation (Line(
       points={{-49.8,6},{-48,6},{-48,0},{-44,0}},
       color={0,140,72},
       thickness=0.5));
@@ -389,8 +389,8 @@ equation
   connect(yCooValMea.y, yCooVal)
     annotation (Line(points={{91,-40},{110,-40}}, color={0,0,127},
       pattern=LinePattern.Dash));
-  connect(senVolFloOutAir.port_b, mixBox.port_Fre) annotation (Line(
-        points={{-80,20},{-80,6},{-70,6}}, color={0,127,255}));
+  connect(senVolFloOutAir.port_b, mixingBox.port_Fre)
+    annotation (Line(points={{-80,20},{-80,6},{-70,6}}, color={0,127,255}));
   connect(senVolFloOutAir.V_flow, V_flowOutAir) annotation (Line(points={{-71.2,
           28},{80,28},{80,60},{110,60}},      color={0,0,127},
       pattern=LinePattern.Dash));

--- a/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/BaseClasses/HVACSide/BaseClasses/Component/AirSide/Coil/CoolingCoil.mo
+++ b/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/BaseClasses/HVACSide/BaseClasses/Component/AirSide/Coil/CoolingCoil.mo
@@ -3,7 +3,8 @@ model CoolingCoil "The model of the cooling coil"
   extends
     MultizoneOfficeComplexAir.BaseClasses.HVACSide.BaseClasses.Component.AirSide.Coil.BaseClasses.WatCoil(      val(
         dpValve_nominal=PreDroWat, y_start=0.1),
-                                    pI(reverseActing=false, conPID(y_reset=1)));
+                                    pI(
+      yMin=0.01,                       reverseActing=false, conPID(y_reset=1)));
   parameter Real UA "Rated heat exchange coefficients";
 
   MultizoneOfficeComplexAir.BaseClasses.HVACSide.BaseClasses.Component.AirSide.Coil.BaseClasses.WetCoil coi(

--- a/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/BaseClasses/HVACSide/BaseClasses/Component/AirSide/ZoneTerminal/Examples.mo
+++ b/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/BaseClasses/HVACSide/BaseClasses/Component/AirSide/ZoneTerminal/Examples.mo
@@ -255,7 +255,7 @@ package Examples
     connect(Q_flow.y, fivZonVAV.Q_flow) annotation (Line(points={{-79,-50},{-48,
             -50},{-48,-18.8},{-30.5333,-18.8}},
                                         color={0,0,127}));
-    connect(booleanExpression.y, fivZonVAV.On) annotation (Line(points={{-49,-4},
+    connect(booleanExpression.y,fivZonVAV.on)  annotation (Line(points={{-49,-4},
             {-38,-4},{-38,-6.4},{-30.5333,-6.4}},                                                                 color={255,0,255}));
     connect(yVal.y, fivZonVAV.yVal) annotation (Line(points={{-79,22},{-40,22},
             {-40,8},{-30.5333,8}},

--- a/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/BaseClasses/HVACSide/BaseClasses/Component/AirSide/ZoneTerminal/FiveZoneVAV.mo
+++ b/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/BaseClasses/HVACSide/BaseClasses/Component/AirSide/ZoneTerminal/FiveZoneVAV.mo
@@ -221,10 +221,11 @@ model FiveZoneVAV "Thermal zones, VAV terminals, and duct network"
   Modelica.Blocks.Interfaces.RealInput yVal[5]
     "Actuator position (0: closed, 1: open)"
     annotation (Placement(transformation(extent={{-120,50},{-100,70}})));
-  Modelica.Blocks.Interfaces.BooleanInput On[5]
+  Modelica.Blocks.Interfaces.BooleanInput on[5]
+    "Zonal On signal (not implemented)"
     annotation (Placement(transformation(extent={{-120,-22},{-100,-2}})));
-  Modelica.Fluid.Sensors.TemperatureTwoPort TZonSen[5](redeclare package Medium =
-               MediumAir)
+  Modelica.Fluid.Sensors.TemperatureTwoPort TZonSen[5](redeclare package Medium
+      =        MediumAir)
     annotation (Placement(transformation(extent={{138,-68},{118,-48}})));
   Modelica.Blocks.Interfaces.RealOutput p "Pressure at port" annotation (
       Placement(transformation(extent={{200,-22},{220,-2}}),
@@ -370,7 +371,7 @@ model FiveZoneVAV "Thermal zones, VAV terminals, and duct network"
   Modelica.Blocks.Sources.RealExpression m_flow_infAir[4](y=m_flow_lea)
     "Infiltration nominal air flow rate"
     annotation (Placement(transformation(extent={{-86,-114},{-66,-94}})));
-  Modelica.Blocks.Sources.RealExpression schFac_infAir[4](y={if On[1] == true
+  Modelica.Blocks.Sources.RealExpression schFac_infAir[4](y={if on[1] == true
          then 0.25 else 1.0 for i in 1:4})
     "Schedule factor for infiltration air (refer to E+)"
     annotation (Placement(transformation(extent={{-86,-134},{-66,-114}})));
@@ -442,18 +443,18 @@ equation
       points={{191,80},{210,80}},
       color={0,0,127},
       pattern=LinePattern.Dash));
-  connect(On[2], vAV2.On) annotation (Line(points={{-110,-14},{18,-14},{18,0},{29,
+  connect(on[2], vAV2.On) annotation (Line(points={{-110,-14},{18,-14},{18,0},{29,
           0}}, color={255,0,255}));
-  connect(On[3], vAV3.On) annotation (Line(points={{-110,-12},{-72,-12},{
+  connect(on[3], vAV3.On) annotation (Line(points={{-110,-12},{-72,-12},{
           -72,-8},{56,-8},{56,0},{71,0}},
                               color={255,0,255}));
-  connect(On[4], vAV4.On) annotation (Line(points={{-110,-10},{-72,-10},{-72,-10},
+  connect(on[4], vAV4.On) annotation (Line(points={{-110,-10},{-72,-10},{-72,-10},
           {100,-10},{100,0},{117,0}},
                                  color={255,0,255}));
-  connect(On[5], vAV5.On) annotation (Line(points={{-110,-8},{-72,-8},{-72,-10},
+  connect(on[5], vAV5.On) annotation (Line(points={{-110,-8},{-72,-8},{-72,-10},
           {148,-10},{148,0},{157,0}},
                                  color={255,0,255}));
-  connect(On[1], vAV1.On) annotation (Line(points={{-110,-16},{-72,-16},{-72,0},
+  connect(on[1], vAV1.On) annotation (Line(points={{-110,-16},{-72,-16},{-72,0},
           {-11,0}},
                color={255,0,255}));
   connect(yVal[1], vAV1.yVal) annotation (Line(points={{-110,56},{-34,56},{-34,12},

--- a/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/BaseClasses/HVACSide/BaseClasses/Component/FlowMover/BaseClasses/FlowMover.mo
+++ b/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/BaseClasses/HVACSide/BaseClasses/Component/FlowMover/BaseClasses/FlowMover.mo
@@ -15,12 +15,10 @@ partial model FlowMover
     PreCur=PreCur,
     TimCon=TimCon)
     annotation (Placement(transformation(extent={{-18,-10},{2,10}})));
-  Modelica.Fluid.Sensors.TemperatureTwoPort temEnt(redeclare package
-      Medium =
+  Modelica.Fluid.Sensors.TemperatureTwoPort temEnt(redeclare package Medium =
         Medium)
     annotation (Placement(transformation(extent={{-80,-10},{-60,10}})));
-  Modelica.Fluid.Sensors.TemperatureTwoPort temLea(redeclare package
-      Medium =
+  Modelica.Fluid.Sensors.TemperatureTwoPort temLea(redeclare package Medium =
         Medium)
     annotation (Placement(transformation(extent={{30,-10},{50,10}})));
   Modelica.Fluid.Sensors.MassFlowRate masFloRat(redeclare package Medium =
@@ -38,7 +36,8 @@ partial model FlowMover
     annotation (Placement(transformation(extent={{90,-10},{110,10}})));
   Modelica.Blocks.Interfaces.RealOutput P "Electrical power consumed"
     annotation (Placement(transformation(extent={{100,30},{120,50}})));
-  Modelica.Blocks.Interfaces.BooleanInput On "On-off signal" annotation (Placement(transformation(extent={{-140,40},{-100,80}})));
+  Modelica.Blocks.Interfaces.BooleanInput occ "On-off signal"
+    annotation (Placement(transformation(extent={{-140,40},{-100,80}})));
   Modelica.Blocks.Interfaces.RealOutput Rat
     "Actual normalised pump speed that is used for computations"
     annotation (Placement(transformation(extent={{100,-70},{120,-50}})));

--- a/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/BaseClasses/HVACSide/BaseClasses/Component/FlowMover/BaseClasses/FlowMover.mo
+++ b/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/BaseClasses/HVACSide/BaseClasses/Component/FlowMover/BaseClasses/FlowMover.mo
@@ -36,7 +36,7 @@ partial model FlowMover
     annotation (Placement(transformation(extent={{90,-10},{110,10}})));
   Modelica.Blocks.Interfaces.RealOutput P "Electrical power consumed"
     annotation (Placement(transformation(extent={{100,30},{120,50}})));
-  Modelica.Blocks.Interfaces.BooleanInput occ "On-off signal"
+  Modelica.Blocks.Interfaces.BooleanInput onFanOcc "On-off signal"
     annotation (Placement(transformation(extent={{-140,40},{-100,80}})));
   Modelica.Blocks.Interfaces.RealOutput Rat
     "Actual normalised pump speed that is used for computations"

--- a/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/BaseClasses/HVACSide/BaseClasses/Component/FlowMover/Control/VAVDualFanControl.mo
+++ b/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/BaseClasses/HVACSide/BaseClasses/Component/FlowMover/Control/VAVDualFanControl.mo
@@ -17,7 +17,8 @@ model VAVDualFanControl
     Ti=Ti,
     conPID(y_reset=1))
     annotation (Placement(transformation(extent={{-60,36},{-40,56}})));
-  Modelica.Blocks.Interfaces.BooleanInput occ
+  Modelica.Blocks.Interfaces.BooleanInput onFanOcc
+    "Fan On signal during occupied period"
     annotation (Placement(transformation(extent={{-140,40},{-100,80}})));
   Modelica.Blocks.Interfaces.RealInput SetPoi
     "Connector of setpoint input signal"
@@ -27,7 +28,8 @@ model VAVDualFanControl
     annotation (Placement(transformation(extent={{-140,-40},{-100,0}})));
   Modelica.Blocks.Interfaces.RealOutput ySup "Connector of Real output signal"
     annotation (Placement(transformation(extent={{100,-10},{120,10}})));
-  Modelica.Blocks.Interfaces.BooleanInput CyclingOn
+  Modelica.Blocks.Interfaces.BooleanInput onFanUnocc
+    "Fan On signal during unoccupied period"
     annotation (Placement(transformation(extent={{-140,-80},{-100,-40}})));
   Modelica.Blocks.Logical.Not not1
     annotation (Placement(transformation(extent={{-62,0},{-42,20}})));
@@ -41,16 +43,15 @@ model VAVDualFanControl
   Modelica.Blocks.Math.BooleanToReal booToRea
     annotation (Placement(transformation(extent={{-20,-40},{0,-20}})));
 equation
-  connect(variableSpeed.On, occ) annotation (Line(points={{-62,52},{-80,52},{-80,
-          60},{-120,60}}, color={255,0,255}));
+  connect(variableSpeed.On, onFanOcc) annotation (Line(points={{-62,52},{-80,52},
+          {-80,60},{-120,60}}, color={255,0,255}));
   connect(variableSpeed.mea, Mea) annotation (Line(
       points={{-62,40},{-70,40},{-70,-20},{-120,-20}},
       color={0,0,127}));
-  connect(cyclingOn.CyclingOn, CyclingOn) annotation (Line(
-      points={{-62,-30},{-80,-30},{-80,-60},{-120,-60}},
-      color={255,0,255}));
-  connect(not1.u, occ) annotation (Line(points={{-64,10},{-80,10},{-80,60},{-120,
-          60}}, color={255,0,255}));
+  connect(cyclingOn.CyclingOn, onFanUnocc) annotation (Line(points={{-62,-30},{
+          -80,-30},{-80,-60},{-120,-60}}, color={255,0,255}));
+  connect(not1.u, onFanOcc) annotation (Line(points={{-64,10},{-80,10},{-80,60},
+          {-120,60}}, color={255,0,255}));
   connect(not1.y, cyclingOn.OnSigIn) annotation (Line(
       points={{-41,10},{-24,10},{-24,-8},{-80,-8},{-80,-26},{-62,-26}},
       color={255,0,255}));
@@ -64,8 +65,8 @@ equation
           38},{34,38}}, color={0,0,127}));
   connect(SetPoi, variableSpeed.set) annotation (Line(points={{-120,20},
           {-74,20},{-74,46},{-62,46}}, color={0,0,127}));
-  connect(occ, swi.u2) annotation (Line(points={{-120,60},{-80,60},{-80,28},{-20,
-          28},{-20,38},{10,38}}, color={255,0,255}));
+  connect(onFanOcc, swi.u2) annotation (Line(points={{-120,60},{-80,60},{-80,28},
+          {-20,28},{-20,38},{10,38}}, color={255,0,255}));
   connect(cyclingOn.OnSigOut, booToRea.u)
     annotation (Line(points={{-39,-30},{-22,-30}}, color={255,0,255}));
   connect(booToRea.y, swi.u3) annotation (Line(points={{1,-30},{6,-30},{6,

--- a/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/BaseClasses/HVACSide/BaseClasses/Component/FlowMover/Control/VAVDualFanControl.mo
+++ b/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/BaseClasses/HVACSide/BaseClasses/Component/FlowMover/Control/VAVDualFanControl.mo
@@ -17,7 +17,7 @@ model VAVDualFanControl
     Ti=Ti,
     conPID(y_reset=1))
     annotation (Placement(transformation(extent={{-60,36},{-40,56}})));
-  Modelica.Blocks.Interfaces.BooleanInput On
+  Modelica.Blocks.Interfaces.BooleanInput occ
     annotation (Placement(transformation(extent={{-140,40},{-100,80}})));
   Modelica.Blocks.Interfaces.RealInput SetPoi
     "Connector of setpoint input signal"
@@ -41,18 +41,16 @@ model VAVDualFanControl
   Modelica.Blocks.Math.BooleanToReal booToRea
     annotation (Placement(transformation(extent={{-20,-40},{0,-20}})));
 equation
-  connect(variableSpeed.On, On) annotation (Line(
-      points={{-62,52},{-80,52},{-80,60},{-120,60}},
-      color={255,0,255}));
+  connect(variableSpeed.On, occ) annotation (Line(points={{-62,52},{-80,52},{-80,
+          60},{-120,60}}, color={255,0,255}));
   connect(variableSpeed.mea, Mea) annotation (Line(
       points={{-62,40},{-70,40},{-70,-20},{-120,-20}},
       color={0,0,127}));
   connect(cyclingOn.CyclingOn, CyclingOn) annotation (Line(
       points={{-62,-30},{-80,-30},{-80,-60},{-120,-60}},
       color={255,0,255}));
-  connect(not1.u, On) annotation (Line(
-      points={{-64,10},{-80,10},{-80,60},{-120,60}},
-      color={255,0,255}));
+  connect(not1.u, occ) annotation (Line(points={{-64,10},{-80,10},{-80,60},{-120,
+          60}}, color={255,0,255}));
   connect(not1.y, cyclingOn.OnSigIn) annotation (Line(
       points={{-41,10},{-24,10},{-24,-8},{-80,-8},{-80,-26},{-62,-26}},
       color={255,0,255}));
@@ -66,8 +64,8 @@ equation
           38},{34,38}}, color={0,0,127}));
   connect(SetPoi, variableSpeed.set) annotation (Line(points={{-120,20},
           {-74,20},{-74,46},{-62,46}}, color={0,0,127}));
-  connect(On, swi.u2) annotation (Line(points={{-120,60},{-80,60},{-80,
-          28},{-20,28},{-20,38},{10,38}}, color={255,0,255}));
+  connect(occ, swi.u2) annotation (Line(points={{-120,60},{-80,60},{-80,28},{-20,
+          28},{-20,38},{10,38}}, color={255,0,255}));
   connect(cyclingOn.OnSigOut, booToRea.u)
     annotation (Line(points={{-39,-30},{-22,-30}}, color={255,0,255}));
   connect(booToRea.y, swi.u3) annotation (Line(points={{1,-30},{6,-30},{6,

--- a/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/BaseClasses/HVACSide/BaseClasses/Component/FlowMover/Pump/PumpSystem.mo
+++ b/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/BaseClasses/HVACSide/BaseClasses/Component/FlowMover/Pump/PumpSystem.mo
@@ -72,5 +72,28 @@ equation
           extent={{-100,100},{100,-100}},
           lineColor={0,0,127},
           fillColor={255,255,255},
-          fillPattern=FillPattern.Solid)}));
+          fillPattern=FillPattern.Solid),
+        Line(
+          points={{-94,0},{-16,0}},
+          color={0,0,255},
+          smooth=Smooth.None),
+        Line(
+          points={{90,0},{14,0}},
+          color={0,0,255},
+          smooth=Smooth.None),
+        Ellipse(
+          extent={{-28,28},{32,-30}},
+          lineColor={0,0,255},
+          fillColor={255,255,255},
+          fillPattern=FillPattern.Solid),
+        Polygon(
+          points={{32,0},{-16,-24},{-16,22},{32,0}},
+          lineColor={0,0,255},
+          smooth=Smooth.None,
+          fillColor={0,0,255},
+          fillPattern=FillPattern.Solid),
+        Text(
+          extent={{40,86},{-36,46}},
+          textColor={28,108,200},
+          textString="[n]")}));
 end PumpSystem;

--- a/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/BaseClasses/HVACSide/BaseClasses/Component/FlowMover/VAVSupFan.mo
+++ b/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/BaseClasses/HVACSide/BaseClasses/Component/FlowMover/VAVSupFan.mo
@@ -24,8 +24,8 @@ model VAVSupFan
         transformation(extent={{-140,-120},{-100,-80}})));
   Modelica.Blocks.Interfaces.RealOutput yRet "Output signal connector"
     annotation (Placement(transformation(extent={{100,-92},{120,-72}})));
-  Control.TemperatureCheck onFan(numTemp=numTemp)
-    "Circulation fan ON signal based on zonal temperature and setpoints"
+  Control.TemperatureCheck onFanUnocc(numTemp=numTemp)
+    "Circulation fan ON signal based on zonal temperature and setpoints during unoccupied period"
     annotation (Placement(transformation(extent={{-92,-50},{-72,-30}})));
   Modelica.Blocks.Interfaces.RealInput T[numTemp]
     "Connector of setpoint input signal" annotation (Placement(
@@ -76,21 +76,21 @@ equation
   connect(withoutMotor.P, P) annotation (Line(
       points={{3,6},{12,6},{20,6},{20,40},{110,40}},
       color={0,0,127}));
-  connect(occ, varSpe.occ)
+  connect(onFanOcc, varSpe.onFanOcc)
     annotation (Line(points={{-120,60},{-62,60}}, color={255,0,255}));
   connect(varSpe.SetPoi, pSet) annotation (Line(points={{-62,56},{-80,56},
           {-80,20},{-120,20}}, color={0,0,127}));
   connect(varSpe.Mea, pMea) annotation (Line(points={{-62,52},{-66,52},{-66,
           16},{-56,16},{-56,-100},{-120,-100}}, color={0,0,127}));
-  connect(onFan.Temp, T) annotation (Line(points={{-94,-40},{-100,-40},{-100,-60},
-          {-120,-60}}, color={0,0,127}));
-  connect(onFan.On, varSpe.CyclingOn) annotation (Line(points={{-71,-40},{-68,-40},
-          {-68,48},{-62,48}}, color={255,0,255}));
-  connect(onFan.CooSetPoi, cooTSet) annotation (Line(points={{-94,-34},{-98,-34},
-          {-98,-20},{-120,-20}}, color={0,0,127}));
-  connect(onFan.HeaSetPoi, heaTSet) annotation (Line(points={{-94,-46},{-98,-46},
-          {-98,-60},{-60,-60},{-60,34},{-88,34},{-88,100},{-120,100}}, color={0,
-          0,127}));
+  connect(onFanUnocc.Temp, T) annotation (Line(points={{-94,-40},{-100,-40},{-100,
+          -60},{-120,-60}}, color={0,0,127}));
+  connect(onFanUnocc.On, varSpe.onFanUnocc) annotation (Line(points={{-71,-40},
+          {-68,-40},{-68,48},{-62,48}}, color={255,0,255}));
+  connect(onFanUnocc.CooSetPoi, cooTSet) annotation (Line(points={{-94,-34},{-98,
+          -34},{-98,-20},{-120,-20}}, color={0,0,127}));
+  connect(onFanUnocc.HeaSetPoi, heaTSet) annotation (Line(points={{-94,-46},{-98,
+          -46},{-98,-60},{-60,-60},{-60,34},{-88,34},{-88,100},{-120,100}},
+        color={0,0,127}));
   connect(varSpe.ySup, oveSpeSupFan.u)
     annotation (Line(points={{-39,54},{-28,54}}, color={0,0,127}));
   connect(oveSpeSupFan.y, withoutMotor.u) annotation (Line(points={{-5,54},

--- a/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/BaseClasses/HVACSide/BaseClasses/Component/FlowMover/VAVSupFan.mo
+++ b/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/BaseClasses/HVACSide/BaseClasses/Component/FlowMover/VAVSupFan.mo
@@ -24,7 +24,8 @@ model VAVSupFan
         transformation(extent={{-140,-120},{-100,-80}})));
   Modelica.Blocks.Interfaces.RealOutput yRet "Output signal connector"
     annotation (Placement(transformation(extent={{100,-92},{120,-72}})));
-  Control.TemperatureCheck TChe(numTemp=numTemp)
+  Control.TemperatureCheck onFan(numTemp=numTemp)
+    "Circulation fan ON signal based on zonal temperature and setpoints"
     annotation (Placement(transformation(extent={{-92,-50},{-72,-30}})));
   Modelica.Blocks.Interfaces.RealInput T[numTemp]
     "Connector of setpoint input signal" annotation (Placement(
@@ -75,21 +76,21 @@ equation
   connect(withoutMotor.P, P) annotation (Line(
       points={{3,6},{12,6},{20,6},{20,40},{110,40}},
       color={0,0,127}));
-  connect(On, varSpe.On)
+  connect(occ, varSpe.occ)
     annotation (Line(points={{-120,60},{-62,60}}, color={255,0,255}));
   connect(varSpe.SetPoi, pSet) annotation (Line(points={{-62,56},{-80,56},
           {-80,20},{-120,20}}, color={0,0,127}));
   connect(varSpe.Mea, pMea) annotation (Line(points={{-62,52},{-66,52},{-66,
           16},{-56,16},{-56,-100},{-120,-100}}, color={0,0,127}));
-  connect(TChe.Temp, T) annotation (Line(points={{-94,-40},{-100,-40},{-100,
-          -60},{-120,-60}}, color={0,0,127}));
-  connect(TChe.On, varSpe.CyclingOn) annotation (Line(points={{-71,-40},{
-          -68,-40},{-68,48},{-62,48}}, color={255,0,255}));
-  connect(TChe.CooSetPoi, cooTSet) annotation (Line(points={{-94,-34},{-98,
-          -34},{-98,-20},{-120,-20}}, color={0,0,127}));
-  connect(TChe.HeaSetPoi, heaTSet) annotation (Line(points={{-94,-46},{-98,
-          -46},{-98,-60},{-60,-60},{-60,34},{-88,34},{-88,100},{-120,100}},
-        color={0,0,127}));
+  connect(onFan.Temp, T) annotation (Line(points={{-94,-40},{-100,-40},{-100,-60},
+          {-120,-60}}, color={0,0,127}));
+  connect(onFan.On, varSpe.CyclingOn) annotation (Line(points={{-71,-40},{-68,-40},
+          {-68,48},{-62,48}}, color={255,0,255}));
+  connect(onFan.CooSetPoi, cooTSet) annotation (Line(points={{-94,-34},{-98,-34},
+          {-98,-20},{-120,-20}}, color={0,0,127}));
+  connect(onFan.HeaSetPoi, heaTSet) annotation (Line(points={{-94,-46},{-98,-46},
+          {-98,-60},{-60,-60},{-60,34},{-88,34},{-88,100},{-120,100}}, color={0,
+          0,127}));
   connect(varSpe.ySup, oveSpeSupFan.u)
     annotation (Line(points={{-39,54},{-28,54}}, color={0,0,127}));
   connect(oveSpeSupFan.y, withoutMotor.u) annotation (Line(points={{-5,54},

--- a/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/BaseClasses/HVACSide/BaseClasses/Component/FlowMover/VariableSpeedMover.mo
+++ b/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/BaseClasses/HVACSide/BaseClasses/Component/FlowMover/VariableSpeedMover.mo
@@ -51,9 +51,8 @@ equation
   connect(variableSpeed.y, withoutMotor.u) annotation (Line(
       points={{-39,54},{-30,54},{-30,6},{-19,6}},
       color={0,0,127}));
-  connect(On, variableSpeed.On) annotation (Line(
-      points={{-120,60},{-62,60}},
-      color={255,0,255}));
+  connect(occ, variableSpeed.On)
+    annotation (Line(points={{-120,60},{-62,60}}, color={255,0,255}));
   connect(variableSpeed.set, SetPoi) annotation (Line(
       points={{-62,54},{-78,54},{-78,20},{-120,20}},
       color={0,0,127}));

--- a/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/BaseClasses/HVACSide/BaseClasses/Component/FlowMover/VariableSpeedMover.mo
+++ b/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/BaseClasses/HVACSide/BaseClasses/Component/FlowMover/VariableSpeedMover.mo
@@ -51,7 +51,7 @@ equation
   connect(variableSpeed.y, withoutMotor.u) annotation (Line(
       points={{-39,54},{-30,54},{-30,6},{-19,6}},
       color={0,0,127}));
-  connect(occ, variableSpeed.On)
+  connect(onFanOcc, variableSpeed.On)
     annotation (Line(points={{-120,60},{-62,60}}, color={255,0,255}));
   connect(variableSpeed.set, SetPoi) annotation (Line(
       points={{-62,54},{-78,54},{-78,20},{-120,20}},

--- a/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/BaseClasses/HVACSide/BaseClasses/Examples/AirsideFloor.mo
+++ b/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/BaseClasses/HVACSide/BaseClasses/Examples/AirsideFloor.mo
@@ -289,7 +289,7 @@ equation
       points={{-79,-96},{-34,-96},{-34,-18.25},{-25.5625,-18.25}},
       color={255,0,255},
       pattern=LinePattern.Dash));
-  connect(airsideFloor.occ, airsideFloor.onZon) annotation (Line(
+  connect(airsideFloor.onFanOcc, airsideFloor.onZon) annotation (Line(
       points={{-25.5625,-13},{-34,-13},{-34,-18.25},{-25.5625,-18.25}},
       color={255,0,255},
       pattern=LinePattern.Dash));

--- a/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/BaseClasses/HVACSide/BaseClasses/Examples/AirsideFloor.mo
+++ b/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/BaseClasses/HVACSide/BaseClasses/Examples/AirsideFloor.mo
@@ -285,11 +285,11 @@ equation
       points={{19,-50},{3.5,-50},{3.5,-21.75}},
       color={0,0,127},
       pattern=LinePattern.Dash));
-  connect(booleanExpression.y, airsideFloor.OnZon) annotation (Line(
+  connect(booleanExpression.y,airsideFloor.onZon)  annotation (Line(
       points={{-79,-96},{-34,-96},{-34,-18.25},{-25.5625,-18.25}},
       color={255,0,255},
       pattern=LinePattern.Dash));
-  connect(airsideFloor.OnFan, airsideFloor.OnZon) annotation (Line(
+  connect(airsideFloor.occ, airsideFloor.onZon) annotation (Line(
       points={{-25.5625,-13},{-34,-13},{-34,-18.25},{-25.5625,-18.25}},
       color={255,0,255},
       pattern=LinePattern.Dash));

--- a/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/BaseClasses/HVACSide/HVAC.mo
+++ b/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/BaseClasses/HVACSide/HVAC.mo
@@ -237,15 +237,20 @@ equation
           {182,-118},{110,-118},{110,-100},{114,-100}},     color={0,0,127}));
 
   connect(PCHWPum.y, reaChiWatSys.PPum_in) annotation (Line(points={{5,-44},{8,
-          -44},{8,-38},{16,-38}}, color={0,0,127}));
+          -44},{8,-40.3846},{16,-40.3846}},
+                                  color={0,0,127}));
   connect(PChi.y, reaChiWatSys.PChi_in) annotation (Line(points={{5,-58},{10,
-          -58},{10,-42},{16,-42}}, color={0,0,127}));
+          -58},{10,-43.7692},{16,-43.7692}},
+                                   color={0,0,127}));
   connect(PCooTow.y, reaChiWatSys.PCooTow_in) annotation (Line(points={{5,-74},
-          {12,-74},{12,-45},{16,-45}}, color={0,0,127}));
+          {12,-74},{12,-46.3077},{16,-46.3077}},
+                                       color={0,0,127}));
   connect(PBoi.y, reaHotWatSys.PBoi_in) annotation (Line(points={{135,-60},{150,
-          -60},{150,-42},{158,-42}}, color={0,0,127}));
-  connect(PHWPum.y, reaHotWatSys.PPum_in) annotation (Line(points={{135,-44},{150,
-          -44},{150,-38},{158,-38}},     color={0,0,127}));
+          -60},{150,-46.1667},{158,-46.1667}},
+                                     color={0,0,127}));
+  connect(PHWPum.y, reaHotWatSys.PPum_in) annotation (Line(points={{135,-44},{
+          150,-44},{150,-42.5},{158,-42.5}},
+                                         color={0,0,127}));
   connect(TCHWSupSet.y, oveChiWatSys.TW_set_in)
     annotation (Line(points={{-61,-20},{-52,-20}}, color={0,0,127}));
   connect(oveChiWatSys.TW_set_out, chiWatPla.TCHWSet) annotation (Line(points={{-29,-20},
@@ -260,14 +265,6 @@ equation
           {64,-64},{64,-30},{68,-30}},         color={0,0,127}));
   connect(oveHotWatSys.dp_set_out, boiWatPla.dpSet) annotation (Line(points={{91,-30},
           {96,-30},{96,-106},{114,-106}},         color={0,0,127}));
-  connect(oveChiWatSys.dp_set_out, reaChiWatSys.dp_in)
-    annotation (Line(points={{-29,-30},{16,-30}}, color={0,0,127}));
-  connect(oveChiWatSys.TW_set_out, reaChiWatSys.TW_in) annotation (Line(points=
-          {{-29,-20},{-22,-20},{-22,-34},{16,-34}}, color={0,0,127}));
-  connect(oveHotWatSys.TW_set_out, reaHotWatSys.TW_in) annotation (Line(points=
-          {{91,-20},{150,-20},{150,-34},{158,-34}}, color={0,0,127}));
-  connect(oveHotWatSys.dp_set_out, reaHotWatSys.dp_in)
-    annotation (Line(points={{91,-30},{158,-30}}, color={0,0,127}));
   connect(THWSupSet.y, oveHotWatSys.TW_set_in)
     annotation (Line(points={{61,-20},{68,-20}}, color={0,0,127}));
 
@@ -319,6 +316,26 @@ equation
       points={{40,-120},{12,-120},{12,44},{38,44}},
       color={255,204,51},
       thickness=0.5));
+  connect(chiWatNet.p, reaChiWatSys.dp_in) annotation (Line(points={{41,-98},{
+          52,-98},{52,-80},{-18,-80},{-18,-31.0769},{16,-31.0769}}, color={0,0,
+          127}));
+  connect(boiWatNet.p, reaHotWatSys.dp_in) annotation (Line(points={{177,-102},
+          {182,-102},{182,-60},{154,-60},{154,-31.5},{158,-31.5}}, color={0,0,
+          127}));
+  connect(chiWatPla.TCHW_ret, reaChiWatSys.TCHW_ret_in) annotation (Line(points
+        ={{11,-96},{16,-96},{16,-62},{6,-62},{6,-33.6154},{16,-33.6154}}, color
+        ={0,0,127}));
+  connect(chiWatPla.TCHW_sup, reaChiWatSys.TCHW_sup_in) annotation (Line(points
+        ={{11,-99},{18,-99},{18,-60},{8,-60},{8,-37},{16,-37}}, color={0,0,127}));
+  connect(boiWatPla.THW_ret, reaHotWatSys.THW_ret_in) annotation (Line(points={
+          {137,-100},{144,-100},{144,-35.1667},{158,-35.1667}}, color={0,0,127}));
+  connect(boiWatPla.THW_sup, reaHotWatSys.THW_sup_in) annotation (Line(points={
+          {137,-103},{146,-103},{146,-38.8333},{158,-38.8333}}, color={0,0,127}));
+  connect(boiWatPla.mHW_tot, reaHotWatSys.mHW_tot_in) annotation (Line(points={
+          {137,-93},{142,-93},{142,-27.8333},{158,-27.8333}}, color={0,0,127}));
+  connect(chiWatPla.mCHW_tot, reaChiWatSys.mCHW_tot_in) annotation (Line(points
+        ={{11,-105},{24,-105},{24,-20},{10,-20},{10,-27.6923},{16,-27.6923}},
+        color={0,0,127}));
   annotation (experiment(
       StartTime=17280000,
       StopTime=17452800,

--- a/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/BaseClasses/HVACSide/HVAC.mo
+++ b/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/BaseClasses/HVACSide/HVAC.mo
@@ -122,7 +122,8 @@ model HVAC "Full HVAC system that contains the air side and water side systems"
   Modelica.Blocks.Sources.Constant TCHWSupSet(k=273.15 + 5.56)
     "Chilled water supply temperature setpoint"
     annotation (Placement(transformation(extent={{-82,-30},{-62,-10}})));
-  Modelica.Blocks.Sources.RealExpression PHWPum(y=sum(boiWatPla.pumSecHW.P))
+  Modelica.Blocks.Sources.RealExpression PHWPum(y=max(0, boiWatPla.pumSecHW.P[1])
+         + max(0, boiWatPla.pumSecHW.P[2]))
     "Hot water pump power consumption"
     annotation (Placement(transformation(extent={{114,-54},{134,-34}})));
   Modelica.Blocks.Sources.RealExpression PBoi(y=boiWatPla.mulBoi.boi[1].boi.QFue_flow

--- a/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/BaseClasses/HVACSide/HVAC.mo
+++ b/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/BaseClasses/HVACSide/HVAC.mo
@@ -350,6 +350,8 @@ See the model <a href=\"modelica://MultizoneOfficeComplexAir.BaseClasses.HVACSid
 <p>The water side system controls include the chiller plant staging control, chilled water supply temperature control, secondary chilled water pump staging control, secondary chilled water loop static pressure control, cooling tower supply water temperature control, minimum condenser supply water temperature control, boiler staging control, boiler water temperature control, and boiler hot water loop static pressure control.</p>
 </html>", revisions = "<html>
 <ul>
+<li>August 8, 2024, by Guowen Li, Xing Lu, Yan Chen: </li>
+<p>Added CO2 and air infiltration features; Adjusted system equipment sizing; Reduced nonlinear system warnings.</p>
 <li> August 17, 2023, by Xing Lu, Sen Huang, Lingzhe Wang, Yan Chen:
 <p> First implementation.</p>
 </ul>

--- a/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/BaseClasses/HVACSide/HVAC.mo
+++ b/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/BaseClasses/HVACSide/HVAC.mo
@@ -41,16 +41,16 @@ model HVAC "Full HVAC system that contains the air side and water side systems"
 
   parameter Modelica.Units.SI.MassFlowRate mFloRat1=-datChi[1].QEva_flow_nominal
       /4200/chiWatPla.dTCHW_nominal*chiWatPla.n/12
-    "mass flow rate for floor 1 (bottom floor)";
+    "CHW mass flow rate for floor 1 (bottom floor)";
   parameter Modelica.Units.SI.MassFlowRate mFloRat2=-datChi[1].QEva_flow_nominal
       /4200/chiWatPla.dTCHW_nominal*chiWatPla.n/12*10
-    "mass flow rate for floor 2 (middle floor)";
+    "CHW mass flow rate for floor 2 (middle floor)";
   parameter Modelica.Units.SI.MassFlowRate mFloRat3=-datChi[1].QEva_flow_nominal
       /4200/chiWatPla.dTCHW_nominal*chiWatPla.n/12
-    "mass flow rate for floor 3 (top floor)";
+    "CHW mass flow rate for floor 3 (top floor)";
 
   parameter Modelica.Units.SI.MassFlowRate mCHW_flow_nominal[:]={-datChi[1].QEva_flow_nominal
-      /4200/5.56 for i in linspace(
+      /4200/chiWatPla.dTCHW_nominal for i in linspace(
       1,
       3,
       3)} "Nominal mass flow rate at chilled water side";
@@ -109,7 +109,8 @@ model HVAC "Full HVAC system that contains the air side and water side systems"
                              "Chilled water plant distribution network"
     annotation (Placement(transformation(extent={{20,-88},{40,-108}})));
   Buildings.Fluid.Chillers.Data.ElectricEIR.ElectricEIRChiller_Trane_CVHE_1442kW_6_61COP_VSD
-    datChi[3](each QEva_flow_nominal=-2500000) "Chiller data record"
+    datChi[3](each QEva_flow_nominal=-5500000/3)
+                                               "Chiller data record"
                                                annotation (Placement(transformation(extent={{-52,
             -106},{-32,-86}})));
 

--- a/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/BaseClasses/HVACSide/HVAC.mo
+++ b/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/BaseClasses/HVACSide/HVAC.mo
@@ -76,7 +76,7 @@ model HVAC "Full HVAC system that contains the air side and water side systems"
     PreDroBra2(displayUnit="Pa") = 0,
     PreDroBra3(displayUnit="Pa") = 0,
     PreDroMai1(displayUnit="Pa") = (79712/4),
-    PreDroMai2(displayUnit="Pa") = (79712/4),
+    PreDroMai2(displayUnit="Pa") = (79712/4/2),
     mFloRat1=boiWatPla.Cap[1]/4190/boiWatPla.dTHW_nominal*boiWatPla.n/12,
     mFloRat2=boiWatPla.Cap[1]/4190/boiWatPla.dTHW_nominal*boiWatPla.n/12*10,
     mFloRat3=boiWatPla.Cap[1]/4190/boiWatPla.dTHW_nominal*boiWatPla.n/12,
@@ -101,11 +101,11 @@ model HVAC "Full HVAC system that contains the air side and water side systems"
     mFloRat1=mFloRat1,
     mFloRat2=mFloRat2,
     mFloRat3=mFloRat3,
-    PreDroBra1(displayUnit="Pa") = 0,
+    PreDroBra1(displayUnit="Pa") = PreDroCooWat,
     PreDroBra2(displayUnit="Pa") = 0,
     PreDroBra3(displayUnit="Pa") = 0,
-    PreDroMai1=PreDroCooWat*2,
-    PreDroMai2(displayUnit="Pa") = 0)
+    PreDroMai1=PreDroCooWat,
+    PreDroMai2(displayUnit="Pa") = PreDroCooWat/2)
                              "Chilled water plant distribution network"
     annotation (Placement(transformation(extent={{20,-88},{40,-108}})));
   Buildings.Fluid.Chillers.Data.ElectricEIR.ElectricEIRChiller_Trane_CVHE_1442kW_6_61COP_VSD

--- a/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/BaseClasses/HVACSide/HVAC.mo
+++ b/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/BaseClasses/HVACSide/HVAC.mo
@@ -68,7 +68,9 @@ model HVAC "Full HVAC system that contains the air side and water side systems"
     "Medium model";
 
   MultizoneOfficeComplexAir.BaseClasses.HVACSide.BaseClasses.BoilerPlant
-    boiWatPla(secPumCon(conPI(k=0.001)), redeclare package MediumHW =
+    boiWatPla(
+    mHW_flow_nominal={62/2*alpha for i in linspace(1, n, n)},
+              secPumCon(conPI(k=0.001)), redeclare package MediumHW =
         MediumHeaWat,
         alpha=alpha) "Boiler hot water plant"
     annotation (Placement(transformation(extent={{116,-110},{136,-90}})));
@@ -79,9 +81,12 @@ model HVAC "Full HVAC system that contains the air side and water side systems"
     PreDroBra3(displayUnit="Pa") = 0,
     PreDroMai1(displayUnit="Pa") = (79712/4),
     PreDroMai2(displayUnit="Pa") = (79712/4/2),
-    mFloRat1=boiWatPla.Cap[1]/4190/boiWatPla.dTHW_nominal*boiWatPla.n/12,
-    mFloRat2=boiWatPla.Cap[1]/4190/boiWatPla.dTHW_nominal*boiWatPla.n/12*10,
-    mFloRat3=boiWatPla.Cap[1]/4190/boiWatPla.dTHW_nominal*boiWatPla.n/12,
+    mFloRat1=floor1.mWatFloRat1 + floor1.mWatFloRat2 + floor1.mWatFloRat3 +
+        floor1.mWatFloRat4 + floor1.mWatFloRat5,
+    mFloRat2=floor2.mWatFloRat1 + floor2.mWatFloRat2 + floor2.mWatFloRat3 +
+        floor2.mWatFloRat4 + floor2.mWatFloRat5,
+    mFloRat3=floor3.mWatFloRat1 + floor3.mWatFloRat2 + floor3.mWatFloRat3 +
+        floor3.mWatFloRat4 + floor3.mWatFloRat5,
     redeclare package Medium = MediumHeaWat,
     PreDroBra1(displayUnit="Pa") = (79712/4))
     "Hot water plant distribution network"

--- a/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/BaseClasses/HVACSide/HVAC.mo
+++ b/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/BaseClasses/HVACSide/HVAC.mo
@@ -69,7 +69,8 @@ model HVAC "Full HVAC system that contains the air side and water side systems"
 
   MultizoneOfficeComplexAir.BaseClasses.HVACSide.BaseClasses.BoilerPlant
     boiWatPla(secPumCon(conPI(k=0.001)), redeclare package MediumHW =
-        MediumHeaWat) "Boiler hot water plant"
+        MediumHeaWat,
+        alpha=alpha) "Boiler hot water plant"
     annotation (Placement(transformation(extent={{116,-110},{136,-90}})));
 
   MultizoneOfficeComplexAir.BaseClasses.HVACSide.BaseClasses.Component.WaterSide.Network.PipeNetwork

--- a/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/BaseClasses/HVACSide/HVAC.mo
+++ b/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/BaseClasses/HVACSide/HVAC.mo
@@ -1,6 +1,7 @@
 within MultizoneOfficeComplexAir.BaseClasses.HVACSide;
 model HVAC "Full HVAC system that contains the air side and water side systems"
   extends MultizoneOfficeComplexAir.BaseClasses.HVACSide.BaseClasses.Airside(
+      alpha=alpha,
       sou(nPorts=3),
       floor1(
       reaZonCor(zone="bot_floor_cor"),
@@ -38,6 +39,8 @@ model HVAC "Full HVAC system that contains the air side and water side systems"
       oveZonNor(zone="top_floor_nor"),
       oveZonWes(zone="top_floor_wes"),
       final mWatFloRat=mFloRat3));
+
+  parameter Real alpha = 1  "Sizing factor for overall system design capacity and mass flow rate";
 
   parameter Modelica.Units.SI.MassFlowRate mFloRat1=-datChi[1].QEva_flow_nominal
       /4200/chiWatPla.dTCHW_nominal*chiWatPla.n/12
@@ -109,7 +112,7 @@ model HVAC "Full HVAC system that contains the air side and water side systems"
                              "Chilled water plant distribution network"
     annotation (Placement(transformation(extent={{20,-88},{40,-108}})));
   Buildings.Fluid.Chillers.Data.ElectricEIR.ElectricEIRChiller_Trane_CVHE_1442kW_6_61COP_VSD
-    datChi[3](each QEva_flow_nominal=-5500000/3)
+    datChi[3](each QEva_flow_nominal=-5500000/3*alpha)
                                                "Chiller data record"
                                                annotation (Placement(transformation(extent={{-52,
             -106},{-32,-86}})));

--- a/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/BaseClasses/HVACSide/HVAC.mo
+++ b/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/BaseClasses/HVACSide/HVAC.mo
@@ -1,7 +1,7 @@
 within MultizoneOfficeComplexAir.BaseClasses.HVACSide;
 model HVAC "Full HVAC system that contains the air side and water side systems"
   extends MultizoneOfficeComplexAir.BaseClasses.HVACSide.BaseClasses.Airside(
-      alpha=alpha,
+      alpha=1,
       sou(nPorts=3),
       floor1(
       reaZonCor(zone="bot_floor_cor"),
@@ -39,8 +39,6 @@ model HVAC "Full HVAC system that contains the air side and water side systems"
       oveZonNor(zone="top_floor_nor"),
       oveZonWes(zone="top_floor_wes"),
       final mWatFloRat=mFloRat3));
-
-  parameter Real alpha = 1  "Sizing factor for overall system design capacity and mass flow rate";
 
   parameter Modelica.Units.SI.MassFlowRate mFloRat1=-datChi[1].QEva_flow_nominal
       /4200/chiWatPla.dTCHW_nominal*chiWatPla.n/12

--- a/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/BaseClasses/LoadSide/LoadWrapper.mo
+++ b/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/BaseClasses/LoadSide/LoadWrapper.mo
@@ -170,9 +170,12 @@ equation
     Documentation(info="<html>
 <p>This is an EnergyPlus (V9.6) wrapper model that calculates the building&rsquo;s thermal loads with the boundary conditions. The inputs are the zone air temperatures from Modelica that is responsible for the airflow calculation (e.g., building infiltration) and HVAC system and controls.</p>
 <p>See the model <a href=\"modelica://MultizoneOfficeComplexAir.BaseClasses.LoadSide.BaseClasses.WholeBuildingEnergyPlus\">MultizoneOfficeComplexAir.BaseClasses.LoadSide.BaseClasses.WholeBuildingEnergyPlus</a> for the EnergyPlus model.</p>
-</html>", revisions = "<html>
+</html>", revisions="<html>
 <ul>
-<li> August 17, 2023, by Xing Lu, Sen Huang, Lingzhe Wang, Yan Chen:
-<p> First implementation.</p>
-</ul>"));
+<li>August 8, 2024, by Guowen Li, Xing Lu, Yan Chen: </li>
+<p>Added weather bus.</p>
+<li>August 17, 2023, by Xing Lu, Sen Huang, Lingzhe Wang, Yan Chen: </li>
+<p>First implementation.</p>
+</ul>
+</html>"));
 end LoadWrapper;

--- a/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/BaseClasses/ReadOverwrite/ReadChilledWater.mo
+++ b/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/BaseClasses/ReadOverwrite/ReadChilledWater.mo
@@ -5,7 +5,7 @@ model ReadChilledWater
   Buildings.Utilities.IO.SignalExchange.Read dp(
     description="Differential pressure of chilled/hot water measurement",
     KPIs=Buildings.Utilities.IO.SignalExchange.SignalTypes.SignalsForKPIs.None,
-    y(unit="K")) "Differential pressure of chilled/hot water measurement"
+    y(unit="Pa")) "Differential pressure of chilled/hot water measurement"
     annotation (Placement(transformation(extent={{-10,90},{10,110}})));
 
   Buildings.Utilities.IO.SignalExchange.Read TCHW_sup(
@@ -82,8 +82,8 @@ equation
           -68,70},{-12,70}}, color={0,0,127}));
   connect(mCHW_tot.u, mCHW_tot_in)
     annotation (Line(points={{-12,140},{-120,140}}, color={0,0,127}));
-  annotation (Icon(coordinateSystem(preserveAspectRatio=false, extent={{-100,
-            -100},{100,160}}), graphics={Rectangle(
+  annotation (Icon(coordinateSystem(preserveAspectRatio=false, extent={{-100,-100},
+            {100,160}}),       graphics={Rectangle(
           extent={{-100,160},{100,-100}},
           lineColor={0,0,0},
           fillColor={255,170,170},

--- a/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/BaseClasses/ReadOverwrite/ReadChilledWater.mo
+++ b/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/BaseClasses/ReadOverwrite/ReadChilledWater.mo
@@ -6,59 +6,85 @@ model ReadChilledWater
     description="Differential pressure of chilled/hot water measurement",
     KPIs=Buildings.Utilities.IO.SignalExchange.SignalTypes.SignalsForKPIs.None,
     y(unit="K")) "Differential pressure of chilled/hot water measurement"
-    annotation (Placement(transformation(extent={{-10,70},{10,90}})));
+    annotation (Placement(transformation(extent={{-10,90},{10,110}})));
 
-  Buildings.Utilities.IO.SignalExchange.Read TW(
-    description="Chilled water temperature measurement",
+  Buildings.Utilities.IO.SignalExchange.Read TCHW_sup(
+    description="Chilled water supply temperature measurement",
     KPIs=Buildings.Utilities.IO.SignalExchange.SignalTypes.SignalsForKPIs.None,
-    y(unit="K")) "Chilled/hot water temperature measurement"
-    annotation (Placement(transformation(extent={{-10,30},{10,50}})));
+    y(unit="K")) "Chilled water supply temperature measurement"
+    annotation (Placement(transformation(extent={{-10,20},{10,40}})));
 
   Modelica.Blocks.Interfaces.RealInput dp_in
     "Differential pressure of chilled/hot water measurement"
-    annotation (Placement(transformation(extent={{-140,60},{-100,100}})));
-  Modelica.Blocks.Interfaces.RealInput TW_in "CHW/HW temperature measurement"
-    annotation (Placement(transformation(extent={{-140,20},{-100,60}})));
+    annotation (Placement(transformation(extent={{-140,80},{-100,120}}),
+        iconTransformation(extent={{-140,80},{-100,120}})));
+  Modelica.Blocks.Interfaces.RealInput TCHW_sup_in
+    "CHW/HW temperature measurement"
+    annotation (Placement(transformation(extent={{-140,10},{-100,50}})));
 
   Buildings.Utilities.IO.SignalExchange.Read reaPPum(
     description="Chilled water plant pump power consumption",
     KPIs=Buildings.Utilities.IO.SignalExchange.SignalTypes.SignalsForKPIs.ElectricPower,
     y(unit="W")) "Block for outputting the chilled water plant"
-    annotation (Placement(transformation(extent={{-10,-10},{10,10}})));
+    annotation (Placement(transformation(extent={{-10,-20},{10,0}})));
 
   Buildings.Utilities.IO.SignalExchange.Read reaPChi(
     description="Multiple chiller power consumption",
     KPIs=Buildings.Utilities.IO.SignalExchange.SignalTypes.SignalsForKPIs.ElectricPower,
     y(unit="W"))  "Block for outputting the multiple chillers"
-    annotation (Placement(transformation(extent={{-10,-50},{10,-30}})));
+    annotation (Placement(transformation(extent={{-10,-60},{10,-40}})));
 
   Modelica.Blocks.Interfaces.RealInput PPum_in "Water pump power"
-    annotation (Placement(transformation(extent={{-140,-20},{-100,20}})));
+    annotation (Placement(transformation(extent={{-140,-30},{-100,10}})));
   Modelica.Blocks.Interfaces.RealInput PChi_in  "Chiller power "
-    annotation (Placement(transformation(extent={{-140,-60},{-100,-20}})));
+    annotation (Placement(transformation(extent={{-140,-70},{-100,-30}})));
   Buildings.Utilities.IO.SignalExchange.Read reaPCooTow(
     description="Multiple cooling tower power consumption",
     KPIs=Buildings.Utilities.IO.SignalExchange.SignalTypes.SignalsForKPIs.ElectricPower,
     y(unit="W"))  "Block for outputting the multiple cooling towers"
-    annotation (Placement(transformation(extent={{-10,-80},{10,-60}})));
+    annotation (Placement(transformation(extent={{-10,-90},{10,-70}})));
 
   Modelica.Blocks.Interfaces.RealInput PCooTow_in  "Cooling tower power "
-    annotation (Placement(transformation(extent={{-140,-90},{-100,-50}})));
+    annotation (Placement(transformation(extent={{-140,-100},{-100,-60}})));
+  Buildings.Utilities.IO.SignalExchange.Read TCHW_ret(
+    description="Chilled water return temperature measurement",
+    KPIs=Buildings.Utilities.IO.SignalExchange.SignalTypes.SignalsForKPIs.None,
+    y(unit="K")) "Chilled water return temperature measurement"
+    annotation (Placement(transformation(extent={{-10,60},{10,80}})));
+
+  Modelica.Blocks.Interfaces.RealInput TCHW_ret_in
+    "CHW/HW temperature measurement" annotation (Placement(transformation(
+          extent={{-140,50},{-100,90}}), iconTransformation(extent={{-140,50},{-100,
+            90}})));
+  Buildings.Utilities.IO.SignalExchange.Read mCHW_tot(
+    description="Total chilled water mass flow rate ",
+    KPIs=Buildings.Utilities.IO.SignalExchange.SignalTypes.SignalsForKPIs.None,
+    y(unit="kg/s")) "Total chilled water mass flow rate"
+    annotation (Placement(transformation(extent={{-10,130},{10,150}})));
+
+  Modelica.Blocks.Interfaces.RealInput mCHW_tot_in
+    annotation (Placement(transformation(extent={{-140,120},{-100,160}})));
 equation
   connect(dp.u, dp_in)
-    annotation (Line(points={{-12,80},{-120,80}}, color={0,0,127}));
-  connect(TW_in, TW.u)
-    annotation (Line(points={{-120,40},{-12,40}},   color={0,0,127}));
+    annotation (Line(points={{-12,100},{-120,100}},
+                                                  color={0,0,127}));
+  connect(TCHW_sup_in, TCHW_sup.u)
+    annotation (Line(points={{-120,30},{-12,30}}, color={0,0,127}));
   connect(reaPPum.u, PPum_in)
-    annotation (Line(points={{-12,0},{-120,0}},   color={0,0,127}));
+    annotation (Line(points={{-12,-10},{-120,-10}},
+                                                  color={0,0,127}));
     connect(reaPChi.u, PChi_in)
-    annotation (Line(points={{-12,-40},{-120,-40}}, color={0,0,127}));
+    annotation (Line(points={{-12,-50},{-120,-50}}, color={0,0,127}));
     connect(reaPCooTow.u, PCooTow_in)
-    annotation (Line(points={{-12,-70},{-120,-70}}, color={0,0,127}));
+    annotation (Line(points={{-12,-80},{-120,-80}}, color={0,0,127}));
 
+  connect(TCHW_ret_in, TCHW_ret.u) annotation (Line(points={{-120,70},{-68,70},{
+          -68,70},{-12,70}}, color={0,0,127}));
+  connect(mCHW_tot.u, mCHW_tot_in)
+    annotation (Line(points={{-12,140},{-120,140}}, color={0,0,127}));
   annotation (Icon(coordinateSystem(preserveAspectRatio=false, extent={{-100,
-            -100},{100,120}}), graphics={Rectangle(
-          extent={{-100,120},{102,-102}},
+            -100},{100,160}}), graphics={Rectangle(
+          extent={{-100,160},{100,-100}},
           lineColor={0,0,0},
           fillColor={255,170,170},
           fillPattern=FillPattern.Solid),
@@ -67,8 +93,8 @@ equation
           lineColor={0,0,0},
           textString="Read
 Wat"),  Text(
-          extent={{-158,128},{142,168}},
+          extent={{-148,160},{152,200}},
           textString="%name",
           textColor={0,0,255})}),Diagram(coordinateSystem(preserveAspectRatio=
-            false, extent={{-100,-100},{100,120}})));
+            false, extent={{-100,-100},{100,160}})));
 end ReadChilledWater;

--- a/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/BaseClasses/ReadOverwrite/ReadHotWater.mo
+++ b/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/BaseClasses/ReadOverwrite/ReadHotWater.mo
@@ -8,48 +8,72 @@ model ReadHotWater
     y(unit="K")) "Differential pressure of chilled/hot water measurement"
     annotation (Placement(transformation(extent={{-10,70},{10,90}})));
 
-  Buildings.Utilities.IO.SignalExchange.Read TW(
+  Buildings.Utilities.IO.SignalExchange.Read THW_sup(
     description="Chilled water temperature measurement",
     KPIs=Buildings.Utilities.IO.SignalExchange.SignalTypes.SignalsForKPIs.None,
+
     y(unit="K")) "Chilled/hot water temperature measurement"
-    annotation (Placement(transformation(extent={{-10,30},{10,50}})));
+    annotation (Placement(transformation(extent={{-10,-10},{10,10}})));
 
   Modelica.Blocks.Interfaces.RealInput dp_in
     "Differential pressure of chilled/hot water measurement"
     annotation (Placement(transformation(extent={{-140,60},{-100,100}})));
-  Modelica.Blocks.Interfaces.RealInput TW_in "CHW/HW temperature measurement"
-    annotation (Placement(transformation(extent={{-140,20},{-100,60}})));
+  Modelica.Blocks.Interfaces.RealInput THW_sup_in
+    "CHW/HW temperature measurement"
+    annotation (Placement(transformation(extent={{-140,-20},{-100,20}})));
 
   Buildings.Utilities.IO.SignalExchange.Read reaPPum(
     description="Chilled water plant pump power consumption",
     KPIs=Buildings.Utilities.IO.SignalExchange.SignalTypes.SignalsForKPIs.ElectricPower,
     y(unit="W")) "Block for outputting the chilled water plant"
-    annotation (Placement(transformation(extent={{-10,-10},{10,10}})));
+    annotation (Placement(transformation(extent={{-10,-50},{10,-30}})));
 
   Buildings.Utilities.IO.SignalExchange.Read reaPBoi(
     description="Multiple gas power consumption",
     KPIs=Buildings.Utilities.IO.SignalExchange.SignalTypes.SignalsForKPIs.GasPower,
     y(unit="W"))  "Block for outputting the multiple boilers"
-    annotation (Placement(transformation(extent={{-10,-50},{10,-30}})));
+    annotation (Placement(transformation(extent={{-10,-90},{10,-70}})));
 
   Modelica.Blocks.Interfaces.RealInput PPum_in "Water pump power"
-    annotation (Placement(transformation(extent={{-140,-20},{-100,20}})));
-  Modelica.Blocks.Interfaces.RealInput PBoi_in  "Boiler power "
     annotation (Placement(transformation(extent={{-140,-60},{-100,-20}})));
+  Modelica.Blocks.Interfaces.RealInput PBoi_in  "Boiler power "
+    annotation (Placement(transformation(extent={{-140,-100},{-100,-60}})));
 
+  Buildings.Utilities.IO.SignalExchange.Read THW_ret(
+    description="Hot water return temperature measurement",
+    KPIs=Buildings.Utilities.IO.SignalExchange.SignalTypes.SignalsForKPIs.None,
+
+    y(unit="K")) "Hot water return temperature measurement"
+    annotation (Placement(transformation(extent={{-10,30},{10,50}})));
+  Modelica.Blocks.Interfaces.RealInput THW_ret_in
+    "CHW/HW temperature measurement"
+    annotation (Placement(transformation(extent={{-140,20},{-100,60}})));
+  Buildings.Utilities.IO.SignalExchange.Read mHW_tot(
+    description="Total hot water mass flow rate ",
+    KPIs=Buildings.Utilities.IO.SignalExchange.SignalTypes.SignalsForKPIs.None,
+
+    y(unit="kg/s")) "Total hot water mass flow rate"
+    annotation (Placement(transformation(extent={{-10,110},{10,130}})));
+  Modelica.Blocks.Interfaces.RealInput mHW_tot_in
+    annotation (Placement(transformation(extent={{-140,100},{-100,140}})));
 equation
   connect(dp.u, dp_in)
     annotation (Line(points={{-12,80},{-120,80}}, color={0,0,127}));
-  connect(TW_in, TW.u)
-    annotation (Line(points={{-120,40},{-12,40}},   color={0,0,127}));
+  connect(THW_sup_in, THW_sup.u)
+    annotation (Line(points={{-120,0},{-12,0}}, color={0,0,127}));
   connect(reaPPum.u, PPum_in)
-    annotation (Line(points={{-12,0},{-120,0}},   color={0,0,127}));
+    annotation (Line(points={{-12,-40},{-120,-40}},
+                                                  color={0,0,127}));
     connect(reaPBoi.u,PBoi_in)
-    annotation (Line(points={{-12,-40},{-120,-40}}, color={0,0,127}));
+    annotation (Line(points={{-12,-80},{-120,-80}}, color={0,0,127}));
 
+  connect(THW_ret_in, THW_ret.u)
+    annotation (Line(points={{-120,40},{-12,40}}, color={0,0,127}));
+  connect(mHW_tot.u, mHW_tot_in)
+    annotation (Line(points={{-12,120},{-120,120}}, color={0,0,127}));
   annotation (Icon(coordinateSystem(preserveAspectRatio=false, extent={{-100,
-            -100},{100,120}}), graphics={Rectangle(
-          extent={{-100,120},{102,-102}},
+            -100},{100,140}}), graphics={Rectangle(
+          extent={{-100,140},{102,-102}},
           lineColor={0,0,0},
           fillColor={255,170,170},
           fillPattern=FillPattern.Solid),
@@ -58,8 +82,8 @@ equation
           lineColor={0,0,0},
           textString="Read
 Wat"),  Text(
-          extent={{-158,128},{142,168}},
+          extent={{-154,138},{146,178}},
           textString="%name",
           textColor={0,0,255})}),Diagram(coordinateSystem(preserveAspectRatio=
-            false, extent={{-100,-100},{100,120}})));
+            false, extent={{-100,-100},{100,140}})));
 end ReadHotWater;

--- a/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/BaseClasses/ReadOverwrite/ReadHotWater.mo
+++ b/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/BaseClasses/ReadOverwrite/ReadHotWater.mo
@@ -5,13 +5,12 @@ model ReadHotWater
   Buildings.Utilities.IO.SignalExchange.Read dp(
     description="Differential pressure of chilled/hot water measurement",
     KPIs=Buildings.Utilities.IO.SignalExchange.SignalTypes.SignalsForKPIs.None,
-    y(unit="K")) "Differential pressure of chilled/hot water measurement"
+    y(unit="Pa")) "Differential pressure of chilled/hot water measurement"
     annotation (Placement(transformation(extent={{-10,70},{10,90}})));
 
   Buildings.Utilities.IO.SignalExchange.Read THW_sup(
     description="Chilled water temperature measurement",
     KPIs=Buildings.Utilities.IO.SignalExchange.SignalTypes.SignalsForKPIs.None,
-
     y(unit="K")) "Chilled/hot water temperature measurement"
     annotation (Placement(transformation(extent={{-10,-10},{10,10}})));
 
@@ -42,18 +41,18 @@ model ReadHotWater
   Buildings.Utilities.IO.SignalExchange.Read THW_ret(
     description="Hot water return temperature measurement",
     KPIs=Buildings.Utilities.IO.SignalExchange.SignalTypes.SignalsForKPIs.None,
-
     y(unit="K")) "Hot water return temperature measurement"
     annotation (Placement(transformation(extent={{-10,30},{10,50}})));
+
   Modelica.Blocks.Interfaces.RealInput THW_ret_in
     "CHW/HW temperature measurement"
     annotation (Placement(transformation(extent={{-140,20},{-100,60}})));
   Buildings.Utilities.IO.SignalExchange.Read mHW_tot(
     description="Total hot water mass flow rate ",
     KPIs=Buildings.Utilities.IO.SignalExchange.SignalTypes.SignalsForKPIs.None,
-
     y(unit="kg/s")) "Total hot water mass flow rate"
     annotation (Placement(transformation(extent={{-10,110},{10,130}})));
+
   Modelica.Blocks.Interfaces.RealInput mHW_tot_in
     annotation (Placement(transformation(extent={{-140,100},{-100,140}})));
 equation
@@ -71,8 +70,8 @@ equation
     annotation (Line(points={{-120,40},{-12,40}}, color={0,0,127}));
   connect(mHW_tot.u, mHW_tot_in)
     annotation (Line(points={{-12,120},{-120,120}}, color={0,0,127}));
-  annotation (Icon(coordinateSystem(preserveAspectRatio=false, extent={{-100,
-            -100},{100,140}}), graphics={Rectangle(
+  annotation (Icon(coordinateSystem(preserveAspectRatio=false, extent={{-100,-100},
+            {100,140}}),       graphics={Rectangle(
           extent={{-100,140},{102,-102}},
           lineColor={0,0,0},
           fillColor={255,170,170},

--- a/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/TestCases/TestCase.mo
+++ b/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/TestCases/TestCase.mo
@@ -66,10 +66,12 @@ equation
 <p><span style=\"font-family: MS Shell Dlg 2;\">See the model <a href=\"modelica://MultizoneOfficeComplexAir.BaseClasses.HVACSide.HVAC\">MultizoneOfficeComplexAir.BaseClasses.HVACSide.HVAC</a> for a description of the HVAC system, and see the model <a href=\"modelica://MultizoneOfficeComplexAir.BaseClasses.LoadSide.LoadWrapper\">MultizoneOfficeComplexAir.BaseClasses.LoadSide.LoadWrapper</a> for a description of the building thermal load calculated by EnergyPlus. </span></p>
 <h4>Spawn Version</h4>
 <p>Please use version <i>spawn-0.3.0-8d93151657</i> for BOPTEST environment; and use version <i>spawn-0.3.0-0fa49be497</i> for running testcases with Modlelica Buildings library.</p>
-</html>", revisions = "<html>
+</html>", revisions="<html>
 <ul>
-<li> August 17, 2023, by Xing Lu, Sen Huang, Lingzhe Wang, Yan Chen:
-<p> First implementation.</p>
+<li>August 8, 2024, by Guowen Li, Xing Lu, Yan Chen: </li>
+<p>Added CO2 and air infiltration features; Adjusted system equipment sizing; Reduced nonlinear system warnings.</p>
+<li>August 17, 2023, by Xing Lu, Sen Huang, Lingzhe Wang, Yan Chen: </li>
+<p>First implementation.</p>
 </ul>
 </html>"),
     __Dymola_Commands(file="Resources/script/Testcase.mos"

--- a/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/TestCases/TestCase.mo
+++ b/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/TestCases/TestCase.mo
@@ -4,7 +4,7 @@ model TestCase "Complex office building model that includes air side systems, wa
 
   MultizoneOfficeComplexAir.BaseClasses.HVACSide.HVAC hva(
     floor1(duaFanAirHanUni(
-        mixBox(mixBox(
+        mixingBox(mixBox(
             valRet(riseTime=15, y_start=1),
             valExh(riseTime=15, y_start=1),
             valFre(riseTime=15, y_start=1))),
@@ -13,7 +13,7 @@ model TestCase "Complex office building model that includes air side systems, wa
                 use_inputFilter=true, y_start=0))),
         cooCoi(val(use_inputFilter=true, y_start=0)))),
     floor2(duaFanAirHanUni(
-        mixBox(mixBox(
+        mixingBox(mixBox(
             valRet(riseTime=15, y_start=1),
             valExh(riseTime=15, y_start=1),
             valFre(riseTime=15, y_start=1))),
@@ -22,7 +22,7 @@ model TestCase "Complex office building model that includes air side systems, wa
                 use_inputFilter=true, y_start=0))),
         cooCoi(val(use_inputFilter=true, y_start=0)))),
     floor3(duaFanAirHanUni(
-        mixBox(mixBox(
+        mixingBox(mixBox(
             valRet(riseTime=15, y_start=1),
             valExh(riseTime=15, y_start=1),
             valFre(riseTime=15, y_start=1))),

--- a/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/TestCases/TestCase.mo
+++ b/testcases/multizone_office_complex_air/models/MultizoneOfficeComplexAir/TestCases/TestCase.mo
@@ -6,8 +6,8 @@ model TestCase "Complex office building model that includes air side systems, wa
     floor1(duaFanAirHanUni(
         mixBox(mixBox(
             valRet(riseTime=15, y_start=1),
-            valExh(riseTime=15, y_start=0),
-            valFre(riseTime=15, y_start=0))),
+            valExh(riseTime=15, y_start=1),
+            valFre(riseTime=15, y_start=1))),
         retFan(varSpeFloMov(use_inputFilter=true, y_start=0)),
         supFan(varSpe(variableSpeed(zerSpe(k=0))), withoutMotor(varSpeFloMov(
                 use_inputFilter=true, y_start=0))),
@@ -15,8 +15,8 @@ model TestCase "Complex office building model that includes air side systems, wa
     floor2(duaFanAirHanUni(
         mixBox(mixBox(
             valRet(riseTime=15, y_start=1),
-            valExh(riseTime=15, y_start=0),
-            valFre(riseTime=15, y_start=0))),
+            valExh(riseTime=15, y_start=1),
+            valFre(riseTime=15, y_start=1))),
         retFan(varSpeFloMov(use_inputFilter=true, y_start=0)),
         supFan(varSpe(variableSpeed(zerSpe(k=0))), withoutMotor(varSpeFloMov(
                 use_inputFilter=true, y_start=0))),
@@ -24,8 +24,8 @@ model TestCase "Complex office building model that includes air side systems, wa
     floor3(duaFanAirHanUni(
         mixBox(mixBox(
             valRet(riseTime=15, y_start=1),
-            valExh(riseTime=15, y_start=0),
-            valFre(riseTime=15, y_start=0))),
+            valExh(riseTime=15, y_start=1),
+            valFre(riseTime=15, y_start=1))),
         retFan(varSpeFloMov(use_inputFilter=true, y_start=0)),
         supFan(varSpe(variableSpeed(zerSpe(k=0))), withoutMotor(varSpeFloMov(
                 use_inputFilter=true, y_start=0))),
@@ -58,7 +58,7 @@ equation
         coordinateSystem(preserveAspectRatio=false)),
     experiment(
       StopTime=31536000,
-      Interval=3600,
+      Interval=60,
       Tolerance=1e-06,
       __Dymola_Algorithm="Cvode"),
     Documentation(info="<html>

--- a/testcases/multizone_office_complex_air/models/compile_fmu.py
+++ b/testcases/multizone_office_complex_air/models/compile_fmu.py
@@ -1,3 +1,6 @@
+import sys
+import os
+sys.path.insert(0, os.path.sep.join(os.path.dirname(os.path.abspath(__file__)).split(os.path.sep)[:-3]))
 from parsing import parser
 
 def compile_fmu():
@@ -11,8 +14,8 @@ def compile_fmu():
     '''
 
     # DEFINE MODEL
-    mopath = 'MultiZoneOfficeSimpleAir/package.mo'
-    modelpath = 'MultiZoneOfficeSimpleAir.TestCases.TestCase'
+    mopath = 'MultizoneOfficeComplexAir/package.mo'
+    modelpath = 'MultizoneOfficeComplexAir.TestCases.TestCase'
 
     # COMPILE FMU
     fmupath = parser.export_fmu(modelpath, [mopath])

--- a/testcases/multizone_office_complex_air/models/find_days.py
+++ b/testcases/multizone_office_complex_air/models/find_days.py
@@ -1,5 +1,5 @@
 '''
-Finds the peak and typical heat days for the multizone_office_simple_air.
+Finds the peak and typical heat days for the multizone_office_complex_air.
 This case needs to be deployed if using BOPTEST image.
 
 '''

--- a/testcases/multizone_office_complex_air/models/wrapped.mo
+++ b/testcases/multizone_office_complex_air/models/wrapped.mo
@@ -1,582 +1,657 @@
 model wrapped "Wrapped model"
-	// Input overwrite
-	Modelica.Blocks.Interfaces.RealInput hva_floor1_TSupAirSet_u(unit="K", min=285.15, max=313.15) "Supply air temperature setpoint for AHU";
-	Modelica.Blocks.Interfaces.BooleanInput hva_floor1_TSupAirSet_activate "Activation for Supply air temperature setpoint for AHU";
-	Modelica.Blocks.Interfaces.RealInput hva_floor1_dpSet_u(unit="Pa", min=50.0, max=410.0) "Supply duct pressure setpoint for AHU";
-	Modelica.Blocks.Interfaces.BooleanInput hva_floor1_dpSet_activate "Activation for Supply duct pressure setpoint for AHU";
-	Modelica.Blocks.Interfaces.RealInput hva_floor1_duaFanAirHanUni_cooCoi_yCoo_u(unit="1", min=0.0, max=1.0) "Cooling coil valve control signal for AHU";
-	Modelica.Blocks.Interfaces.BooleanInput hva_floor1_duaFanAirHanUni_cooCoi_yCoo_activate "Activation for Cooling coil valve control signal for AHU";
-	Modelica.Blocks.Interfaces.RealInput hva_floor1_duaFanAirHanUni_mixingBox_mixBox_yEA_u(unit="1", min=0.0, max=1.0) "Exhaust air damper position setpoint for AHU";
-	Modelica.Blocks.Interfaces.BooleanInput hva_floor1_duaFanAirHanUni_mixingBox_mixBox_yEA_activate "Activation for Exhaust air damper position setpoint for AHU";
-	Modelica.Blocks.Interfaces.RealInput hva_floor1_duaFanAirHanUni_mixingBox_mixBox_yOA_u(unit="1", min=0.0, max=1.0) "Outside air damper position setpoint for AHU";
-	Modelica.Blocks.Interfaces.BooleanInput hva_floor1_duaFanAirHanUni_mixingBox_mixBox_yOA_activate "Activation for Outside air damper position setpoint for AHU";
-	Modelica.Blocks.Interfaces.RealInput hva_floor1_duaFanAirHanUni_mixingBox_mixBox_yRet_u(unit="1", min=0.0, max=1.0) "Return air damper position setpoint for AHU";
-	Modelica.Blocks.Interfaces.BooleanInput hva_floor1_duaFanAirHanUni_mixingBox_mixBox_yRet_activate "Activation for Return air damper position setpoint for AHU";
-	Modelica.Blocks.Interfaces.RealInput hva_floor1_duaFanAirHanUni_oveSpeRetFan_u(unit="1", min=0.0, max=1.0) "AHU return fan speed control signal";
-	Modelica.Blocks.Interfaces.BooleanInput hva_floor1_duaFanAirHanUni_oveSpeRetFan_activate "Activation for AHU return fan speed control signal";
-	Modelica.Blocks.Interfaces.RealInput hva_floor1_duaFanAirHanUni_supFan_oveSpeSupFan_u(unit="1", min=0.0, max=1.0) "AHU supply fan speed control signal";
-	Modelica.Blocks.Interfaces.BooleanInput hva_floor1_duaFanAirHanUni_supFan_oveSpeSupFan_activate "Activation for AHU supply fan speed control signal";
-	Modelica.Blocks.Interfaces.RealInput hva_floor1_fivZonVAV_vAV1_oveZonLoc_yDam_u(unit="1", min=0.0, max=1.0) "Damper position setpoint for zone cor";
-	Modelica.Blocks.Interfaces.BooleanInput hva_floor1_fivZonVAV_vAV1_oveZonLoc_yDam_activate "Activation for Damper position setpoint for zone cor";
-	Modelica.Blocks.Interfaces.RealInput hva_floor1_fivZonVAV_vAV1_oveZonLoc_yReaHea_u(unit="1", min=0.0, max=1.0) "Reheat control signal for zone cor";
-	Modelica.Blocks.Interfaces.BooleanInput hva_floor1_fivZonVAV_vAV1_oveZonLoc_yReaHea_activate "Activation for Reheat control signal for zone cor";
-	Modelica.Blocks.Interfaces.RealInput hva_floor1_fivZonVAV_vAV2_oveZonLoc_yDam_u(unit="1", min=0.0, max=1.0) "Damper position setpoint for zone sou";
-	Modelica.Blocks.Interfaces.BooleanInput hva_floor1_fivZonVAV_vAV2_oveZonLoc_yDam_activate "Activation for Damper position setpoint for zone sou";
-	Modelica.Blocks.Interfaces.RealInput hva_floor1_fivZonVAV_vAV2_oveZonLoc_yReaHea_u(unit="1", min=0.0, max=1.0) "Reheat control signal for zone sou";
-	Modelica.Blocks.Interfaces.BooleanInput hva_floor1_fivZonVAV_vAV2_oveZonLoc_yReaHea_activate "Activation for Reheat control signal for zone sou";
-	Modelica.Blocks.Interfaces.RealInput hva_floor1_fivZonVAV_vAV3_oveZonLoc_yDam_u(unit="1", min=0.0, max=1.0) "Damper position setpoint for zone eas";
-	Modelica.Blocks.Interfaces.BooleanInput hva_floor1_fivZonVAV_vAV3_oveZonLoc_yDam_activate "Activation for Damper position setpoint for zone eas";
-	Modelica.Blocks.Interfaces.RealInput hva_floor1_fivZonVAV_vAV3_oveZonLoc_yReaHea_u(unit="1", min=0.0, max=1.0) "Reheat control signal for zone eas";
-	Modelica.Blocks.Interfaces.BooleanInput hva_floor1_fivZonVAV_vAV3_oveZonLoc_yReaHea_activate "Activation for Reheat control signal for zone eas";
-	Modelica.Blocks.Interfaces.RealInput hva_floor1_fivZonVAV_vAV4_oveZonLoc_yDam_u(unit="1", min=0.0, max=1.0) "Damper position setpoint for zone nor";
-	Modelica.Blocks.Interfaces.BooleanInput hva_floor1_fivZonVAV_vAV4_oveZonLoc_yDam_activate "Activation for Damper position setpoint for zone nor";
-	Modelica.Blocks.Interfaces.RealInput hva_floor1_fivZonVAV_vAV4_oveZonLoc_yReaHea_u(unit="1", min=0.0, max=1.0) "Reheat control signal for zone nor";
-	Modelica.Blocks.Interfaces.BooleanInput hva_floor1_fivZonVAV_vAV4_oveZonLoc_yReaHea_activate "Activation for Reheat control signal for zone nor";
-	Modelica.Blocks.Interfaces.RealInput hva_floor1_fivZonVAV_vAV5_oveZonLoc_yDam_u(unit="1", min=0.0, max=1.0) "Damper position setpoint for zone wes";
-	Modelica.Blocks.Interfaces.BooleanInput hva_floor1_fivZonVAV_vAV5_oveZonLoc_yDam_activate "Activation for Damper position setpoint for zone wes";
-	Modelica.Blocks.Interfaces.RealInput hva_floor1_fivZonVAV_vAV5_oveZonLoc_yReaHea_u(unit="1", min=0.0, max=1.0) "Reheat control signal for zone wes";
-	Modelica.Blocks.Interfaces.BooleanInput hva_floor1_fivZonVAV_vAV5_oveZonLoc_yReaHea_activate "Activation for Reheat control signal for zone wes";
-	Modelica.Blocks.Interfaces.RealInput hva_floor1_oveZonCor_TZonCooSet_u(unit="K", min=285.15, max=313.15) "Zone air temperature cooling setpoint for zone bot_floor_cor";
-	Modelica.Blocks.Interfaces.BooleanInput hva_floor1_oveZonCor_TZonCooSet_activate "Activation for Zone air temperature cooling setpoint for zone bot_floor_cor";
-	Modelica.Blocks.Interfaces.RealInput hva_floor1_oveZonCor_TZonHeaSet_u(unit="K", min=285.15, max=313.15) "Zone air temperature heating setpoint for zone bot_floor_cor";
-	Modelica.Blocks.Interfaces.BooleanInput hva_floor1_oveZonCor_TZonHeaSet_activate "Activation for Zone air temperature heating setpoint for zone bot_floor_cor";
-	Modelica.Blocks.Interfaces.RealInput hva_floor1_oveZonEas_TZonCooSet_u(unit="K", min=285.15, max=313.15) "Zone air temperature cooling setpoint for zone bot_floor_eas";
-	Modelica.Blocks.Interfaces.BooleanInput hva_floor1_oveZonEas_TZonCooSet_activate "Activation for Zone air temperature cooling setpoint for zone bot_floor_eas";
-	Modelica.Blocks.Interfaces.RealInput hva_floor1_oveZonEas_TZonHeaSet_u(unit="K", min=285.15, max=313.15) "Zone air temperature heating setpoint for zone bot_floor_eas";
-	Modelica.Blocks.Interfaces.BooleanInput hva_floor1_oveZonEas_TZonHeaSet_activate "Activation for Zone air temperature heating setpoint for zone bot_floor_eas";
-	Modelica.Blocks.Interfaces.RealInput hva_floor1_oveZonNor_TZonCooSet_u(unit="K", min=285.15, max=313.15) "Zone air temperature cooling setpoint for zone bot_floor_nor";
-	Modelica.Blocks.Interfaces.BooleanInput hva_floor1_oveZonNor_TZonCooSet_activate "Activation for Zone air temperature cooling setpoint for zone bot_floor_nor";
-	Modelica.Blocks.Interfaces.RealInput hva_floor1_oveZonNor_TZonHeaSet_u(unit="K", min=285.15, max=313.15) "Zone air temperature heating setpoint for zone bot_floor_nor";
-	Modelica.Blocks.Interfaces.BooleanInput hva_floor1_oveZonNor_TZonHeaSet_activate "Activation for Zone air temperature heating setpoint for zone bot_floor_nor";
-	Modelica.Blocks.Interfaces.RealInput hva_floor1_oveZonSou_TZonCooSet_u(unit="K", min=285.15, max=313.15) "Zone air temperature cooling setpoint for zone bot_floor_sou";
-	Modelica.Blocks.Interfaces.BooleanInput hva_floor1_oveZonSou_TZonCooSet_activate "Activation for Zone air temperature cooling setpoint for zone bot_floor_sou";
-	Modelica.Blocks.Interfaces.RealInput hva_floor1_oveZonSou_TZonHeaSet_u(unit="K", min=285.15, max=313.15) "Zone air temperature heating setpoint for zone bot_floor_sou";
-	Modelica.Blocks.Interfaces.BooleanInput hva_floor1_oveZonSou_TZonHeaSet_activate "Activation for Zone air temperature heating setpoint for zone bot_floor_sou";
-	Modelica.Blocks.Interfaces.RealInput hva_floor1_oveZonWes_TZonCooSet_u(unit="K", min=285.15, max=313.15) "Zone air temperature cooling setpoint for zone bot_floor_wes";
-	Modelica.Blocks.Interfaces.BooleanInput hva_floor1_oveZonWes_TZonCooSet_activate "Activation for Zone air temperature cooling setpoint for zone bot_floor_wes";
-	Modelica.Blocks.Interfaces.RealInput hva_floor1_oveZonWes_TZonHeaSet_u(unit="K", min=285.15, max=313.15) "Zone air temperature heating setpoint for zone bot_floor_wes";
-	Modelica.Blocks.Interfaces.BooleanInput hva_floor1_oveZonWes_TZonHeaSet_activate "Activation for Zone air temperature heating setpoint for zone bot_floor_wes";
-	Modelica.Blocks.Interfaces.RealInput hva_floor2_TSupAirSet_u(unit="K", min=285.15, max=313.15) "Supply air temperature setpoint for AHU";
-	Modelica.Blocks.Interfaces.BooleanInput hva_floor2_TSupAirSet_activate "Activation for Supply air temperature setpoint for AHU";
-	Modelica.Blocks.Interfaces.RealInput hva_floor2_dpSet_u(unit="Pa", min=50.0, max=410.0) "Supply duct pressure setpoint for AHU";
-	Modelica.Blocks.Interfaces.BooleanInput hva_floor2_dpSet_activate "Activation for Supply duct pressure setpoint for AHU";
-	Modelica.Blocks.Interfaces.RealInput hva_floor2_duaFanAirHanUni_cooCoi_yCoo_u(unit="1", min=0.0, max=1.0) "Cooling coil valve control signal for AHU";
-	Modelica.Blocks.Interfaces.BooleanInput hva_floor2_duaFanAirHanUni_cooCoi_yCoo_activate "Activation for Cooling coil valve control signal for AHU";
-	Modelica.Blocks.Interfaces.RealInput hva_floor2_duaFanAirHanUni_mixingBox_mixBox_yEA_u(unit="1", min=0.0, max=1.0) "Exhaust air damper position setpoint for AHU";
-	Modelica.Blocks.Interfaces.BooleanInput hva_floor2_duaFanAirHanUni_mixingBox_mixBox_yEA_activate "Activation for Exhaust air damper position setpoint for AHU";
-	Modelica.Blocks.Interfaces.RealInput hva_floor2_duaFanAirHanUni_mixingBox_mixBox_yOA_u(unit="1", min=0.0, max=1.0) "Outside air damper position setpoint for AHU";
-	Modelica.Blocks.Interfaces.BooleanInput hva_floor2_duaFanAirHanUni_mixingBox_mixBox_yOA_activate "Activation for Outside air damper position setpoint for AHU";
-	Modelica.Blocks.Interfaces.RealInput hva_floor2_duaFanAirHanUni_mixingBox_mixBox_yRet_u(unit="1", min=0.0, max=1.0) "Return air damper position setpoint for AHU";
-	Modelica.Blocks.Interfaces.BooleanInput hva_floor2_duaFanAirHanUni_mixingBox_mixBox_yRet_activate "Activation for Return air damper position setpoint for AHU";
-	Modelica.Blocks.Interfaces.RealInput hva_floor2_duaFanAirHanUni_oveSpeRetFan_u(unit="1", min=0.0, max=1.0) "AHU return fan speed control signal";
-	Modelica.Blocks.Interfaces.BooleanInput hva_floor2_duaFanAirHanUni_oveSpeRetFan_activate "Activation for AHU return fan speed control signal";
-	Modelica.Blocks.Interfaces.RealInput hva_floor2_duaFanAirHanUni_supFan_oveSpeSupFan_u(unit="1", min=0.0, max=1.0) "AHU supply fan speed control signal";
-	Modelica.Blocks.Interfaces.BooleanInput hva_floor2_duaFanAirHanUni_supFan_oveSpeSupFan_activate "Activation for AHU supply fan speed control signal";
-	Modelica.Blocks.Interfaces.RealInput hva_floor2_fivZonVAV_vAV1_oveZonLoc_yDam_u(unit="1", min=0.0, max=1.0) "Damper position setpoint for zone cor";
-	Modelica.Blocks.Interfaces.BooleanInput hva_floor2_fivZonVAV_vAV1_oveZonLoc_yDam_activate "Activation for Damper position setpoint for zone cor";
-	Modelica.Blocks.Interfaces.RealInput hva_floor2_fivZonVAV_vAV1_oveZonLoc_yReaHea_u(unit="1", min=0.0, max=1.0) "Reheat control signal for zone cor";
-	Modelica.Blocks.Interfaces.BooleanInput hva_floor2_fivZonVAV_vAV1_oveZonLoc_yReaHea_activate "Activation for Reheat control signal for zone cor";
-	Modelica.Blocks.Interfaces.RealInput hva_floor2_fivZonVAV_vAV2_oveZonLoc_yDam_u(unit="1", min=0.0, max=1.0) "Damper position setpoint for zone sou";
-	Modelica.Blocks.Interfaces.BooleanInput hva_floor2_fivZonVAV_vAV2_oveZonLoc_yDam_activate "Activation for Damper position setpoint for zone sou";
-	Modelica.Blocks.Interfaces.RealInput hva_floor2_fivZonVAV_vAV2_oveZonLoc_yReaHea_u(unit="1", min=0.0, max=1.0) "Reheat control signal for zone sou";
-	Modelica.Blocks.Interfaces.BooleanInput hva_floor2_fivZonVAV_vAV2_oveZonLoc_yReaHea_activate "Activation for Reheat control signal for zone sou";
-	Modelica.Blocks.Interfaces.RealInput hva_floor2_fivZonVAV_vAV3_oveZonLoc_yDam_u(unit="1", min=0.0, max=1.0) "Damper position setpoint for zone eas";
-	Modelica.Blocks.Interfaces.BooleanInput hva_floor2_fivZonVAV_vAV3_oveZonLoc_yDam_activate "Activation for Damper position setpoint for zone eas";
-	Modelica.Blocks.Interfaces.RealInput hva_floor2_fivZonVAV_vAV3_oveZonLoc_yReaHea_u(unit="1", min=0.0, max=1.0) "Reheat control signal for zone eas";
-	Modelica.Blocks.Interfaces.BooleanInput hva_floor2_fivZonVAV_vAV3_oveZonLoc_yReaHea_activate "Activation for Reheat control signal for zone eas";
-	Modelica.Blocks.Interfaces.RealInput hva_floor2_fivZonVAV_vAV4_oveZonLoc_yDam_u(unit="1", min=0.0, max=1.0) "Damper position setpoint for zone nor";
-	Modelica.Blocks.Interfaces.BooleanInput hva_floor2_fivZonVAV_vAV4_oveZonLoc_yDam_activate "Activation for Damper position setpoint for zone nor";
-	Modelica.Blocks.Interfaces.RealInput hva_floor2_fivZonVAV_vAV4_oveZonLoc_yReaHea_u(unit="1", min=0.0, max=1.0) "Reheat control signal for zone nor";
-	Modelica.Blocks.Interfaces.BooleanInput hva_floor2_fivZonVAV_vAV4_oveZonLoc_yReaHea_activate "Activation for Reheat control signal for zone nor";
-	Modelica.Blocks.Interfaces.RealInput hva_floor2_fivZonVAV_vAV5_oveZonLoc_yDam_u(unit="1", min=0.0, max=1.0) "Damper position setpoint for zone wes";
-	Modelica.Blocks.Interfaces.BooleanInput hva_floor2_fivZonVAV_vAV5_oveZonLoc_yDam_activate "Activation for Damper position setpoint for zone wes";
-	Modelica.Blocks.Interfaces.RealInput hva_floor2_fivZonVAV_vAV5_oveZonLoc_yReaHea_u(unit="1", min=0.0, max=1.0) "Reheat control signal for zone wes";
-	Modelica.Blocks.Interfaces.BooleanInput hva_floor2_fivZonVAV_vAV5_oveZonLoc_yReaHea_activate "Activation for Reheat control signal for zone wes";
-	Modelica.Blocks.Interfaces.RealInput hva_floor2_oveZonCor_TZonCooSet_u(unit="K", min=285.15, max=313.15) "Zone air temperature cooling setpoint for zone mid_floor_cor";
-	Modelica.Blocks.Interfaces.BooleanInput hva_floor2_oveZonCor_TZonCooSet_activate "Activation for Zone air temperature cooling setpoint for zone mid_floor_cor";
-	Modelica.Blocks.Interfaces.RealInput hva_floor2_oveZonCor_TZonHeaSet_u(unit="K", min=285.15, max=313.15) "Zone air temperature heating setpoint for zone mid_floor_cor";
-	Modelica.Blocks.Interfaces.BooleanInput hva_floor2_oveZonCor_TZonHeaSet_activate "Activation for Zone air temperature heating setpoint for zone mid_floor_cor";
-	Modelica.Blocks.Interfaces.RealInput hva_floor2_oveZonEas_TZonCooSet_u(unit="K", min=285.15, max=313.15) "Zone air temperature cooling setpoint for zone mid_floor_eas";
-	Modelica.Blocks.Interfaces.BooleanInput hva_floor2_oveZonEas_TZonCooSet_activate "Activation for Zone air temperature cooling setpoint for zone mid_floor_eas";
-	Modelica.Blocks.Interfaces.RealInput hva_floor2_oveZonEas_TZonHeaSet_u(unit="K", min=285.15, max=313.15) "Zone air temperature heating setpoint for zone mid_floor_eas";
-	Modelica.Blocks.Interfaces.BooleanInput hva_floor2_oveZonEas_TZonHeaSet_activate "Activation for Zone air temperature heating setpoint for zone mid_floor_eas";
-	Modelica.Blocks.Interfaces.RealInput hva_floor2_oveZonNor_TZonCooSet_u(unit="K", min=285.15, max=313.15) "Zone air temperature cooling setpoint for zone mid_floor_nor";
-	Modelica.Blocks.Interfaces.BooleanInput hva_floor2_oveZonNor_TZonCooSet_activate "Activation for Zone air temperature cooling setpoint for zone mid_floor_nor";
-	Modelica.Blocks.Interfaces.RealInput hva_floor2_oveZonNor_TZonHeaSet_u(unit="K", min=285.15, max=313.15) "Zone air temperature heating setpoint for zone mid_floor_nor";
-	Modelica.Blocks.Interfaces.BooleanInput hva_floor2_oveZonNor_TZonHeaSet_activate "Activation for Zone air temperature heating setpoint for zone mid_floor_nor";
-	Modelica.Blocks.Interfaces.RealInput hva_floor2_oveZonSou_TZonCooSet_u(unit="K", min=285.15, max=313.15) "Zone air temperature cooling setpoint for zone mid_floor_sou";
-	Modelica.Blocks.Interfaces.BooleanInput hva_floor2_oveZonSou_TZonCooSet_activate "Activation for Zone air temperature cooling setpoint for zone mid_floor_sou";
-	Modelica.Blocks.Interfaces.RealInput hva_floor2_oveZonSou_TZonHeaSet_u(unit="K", min=285.15, max=313.15) "Zone air temperature heating setpoint for zone mid_floor_sou";
-	Modelica.Blocks.Interfaces.BooleanInput hva_floor2_oveZonSou_TZonHeaSet_activate "Activation for Zone air temperature heating setpoint for zone mid_floor_sou";
-	Modelica.Blocks.Interfaces.RealInput hva_floor2_oveZonWes_TZonCooSet_u(unit="K", min=285.15, max=313.15) "Zone air temperature cooling setpoint for zone mid_floor_wes";
-	Modelica.Blocks.Interfaces.BooleanInput hva_floor2_oveZonWes_TZonCooSet_activate "Activation for Zone air temperature cooling setpoint for zone mid_floor_wes";
-	Modelica.Blocks.Interfaces.RealInput hva_floor2_oveZonWes_TZonHeaSet_u(unit="K", min=285.15, max=313.15) "Zone air temperature heating setpoint for zone mid_floor_wes";
-	Modelica.Blocks.Interfaces.BooleanInput hva_floor2_oveZonWes_TZonHeaSet_activate "Activation for Zone air temperature heating setpoint for zone mid_floor_wes";
-	Modelica.Blocks.Interfaces.RealInput hva_floor3_TSupAirSet_u(unit="K", min=285.15, max=313.15) "Supply air temperature setpoint for AHU";
-	Modelica.Blocks.Interfaces.BooleanInput hva_floor3_TSupAirSet_activate "Activation for Supply air temperature setpoint for AHU";
-	Modelica.Blocks.Interfaces.RealInput hva_floor3_dpSet_u(unit="Pa", min=50.0, max=410.0) "Supply duct pressure setpoint for AHU";
-	Modelica.Blocks.Interfaces.BooleanInput hva_floor3_dpSet_activate "Activation for Supply duct pressure setpoint for AHU";
-	Modelica.Blocks.Interfaces.RealInput hva_floor3_duaFanAirHanUni_cooCoi_yCoo_u(unit="1", min=0.0, max=1.0) "Cooling coil valve control signal for AHU";
-	Modelica.Blocks.Interfaces.BooleanInput hva_floor3_duaFanAirHanUni_cooCoi_yCoo_activate "Activation for Cooling coil valve control signal for AHU";
-	Modelica.Blocks.Interfaces.RealInput hva_floor3_duaFanAirHanUni_mixingBox_mixBox_yEA_u(unit="1", min=0.0, max=1.0) "Exhaust air damper position setpoint for AHU";
-	Modelica.Blocks.Interfaces.BooleanInput hva_floor3_duaFanAirHanUni_mixingBox_mixBox_yEA_activate "Activation for Exhaust air damper position setpoint for AHU";
-	Modelica.Blocks.Interfaces.RealInput hva_floor3_duaFanAirHanUni_mixingBox_mixBox_yOA_u(unit="1", min=0.0, max=1.0) "Outside air damper position setpoint for AHU";
-	Modelica.Blocks.Interfaces.BooleanInput hva_floor3_duaFanAirHanUni_mixingBox_mixBox_yOA_activate "Activation for Outside air damper position setpoint for AHU";
-	Modelica.Blocks.Interfaces.RealInput hva_floor3_duaFanAirHanUni_mixingBox_mixBox_yRet_u(unit="1", min=0.0, max=1.0) "Return air damper position setpoint for AHU";
-	Modelica.Blocks.Interfaces.BooleanInput hva_floor3_duaFanAirHanUni_mixingBox_mixBox_yRet_activate "Activation for Return air damper position setpoint for AHU";
-	Modelica.Blocks.Interfaces.RealInput hva_floor3_duaFanAirHanUni_oveSpeRetFan_u(unit="1", min=0.0, max=1.0) "AHU return fan speed control signal";
-	Modelica.Blocks.Interfaces.BooleanInput hva_floor3_duaFanAirHanUni_oveSpeRetFan_activate "Activation for AHU return fan speed control signal";
-	Modelica.Blocks.Interfaces.RealInput hva_floor3_duaFanAirHanUni_supFan_oveSpeSupFan_u(unit="1", min=0.0, max=1.0) "AHU supply fan speed control signal";
-	Modelica.Blocks.Interfaces.BooleanInput hva_floor3_duaFanAirHanUni_supFan_oveSpeSupFan_activate "Activation for AHU supply fan speed control signal";
-	Modelica.Blocks.Interfaces.RealInput hva_floor3_fivZonVAV_vAV1_oveZonLoc_yDam_u(unit="1", min=0.0, max=1.0) "Damper position setpoint for zone cor";
-	Modelica.Blocks.Interfaces.BooleanInput hva_floor3_fivZonVAV_vAV1_oveZonLoc_yDam_activate "Activation for Damper position setpoint for zone cor";
-	Modelica.Blocks.Interfaces.RealInput hva_floor3_fivZonVAV_vAV1_oveZonLoc_yReaHea_u(unit="1", min=0.0, max=1.0) "Reheat control signal for zone cor";
-	Modelica.Blocks.Interfaces.BooleanInput hva_floor3_fivZonVAV_vAV1_oveZonLoc_yReaHea_activate "Activation for Reheat control signal for zone cor";
-	Modelica.Blocks.Interfaces.RealInput hva_floor3_fivZonVAV_vAV2_oveZonLoc_yDam_u(unit="1", min=0.0, max=1.0) "Damper position setpoint for zone sou";
-	Modelica.Blocks.Interfaces.BooleanInput hva_floor3_fivZonVAV_vAV2_oveZonLoc_yDam_activate "Activation for Damper position setpoint for zone sou";
-	Modelica.Blocks.Interfaces.RealInput hva_floor3_fivZonVAV_vAV2_oveZonLoc_yReaHea_u(unit="1", min=0.0, max=1.0) "Reheat control signal for zone sou";
-	Modelica.Blocks.Interfaces.BooleanInput hva_floor3_fivZonVAV_vAV2_oveZonLoc_yReaHea_activate "Activation for Reheat control signal for zone sou";
-	Modelica.Blocks.Interfaces.RealInput hva_floor3_fivZonVAV_vAV3_oveZonLoc_yDam_u(unit="1", min=0.0, max=1.0) "Damper position setpoint for zone eas";
-	Modelica.Blocks.Interfaces.BooleanInput hva_floor3_fivZonVAV_vAV3_oveZonLoc_yDam_activate "Activation for Damper position setpoint for zone eas";
-	Modelica.Blocks.Interfaces.RealInput hva_floor3_fivZonVAV_vAV3_oveZonLoc_yReaHea_u(unit="1", min=0.0, max=1.0) "Reheat control signal for zone eas";
-	Modelica.Blocks.Interfaces.BooleanInput hva_floor3_fivZonVAV_vAV3_oveZonLoc_yReaHea_activate "Activation for Reheat control signal for zone eas";
-	Modelica.Blocks.Interfaces.RealInput hva_floor3_fivZonVAV_vAV4_oveZonLoc_yDam_u(unit="1", min=0.0, max=1.0) "Damper position setpoint for zone nor";
-	Modelica.Blocks.Interfaces.BooleanInput hva_floor3_fivZonVAV_vAV4_oveZonLoc_yDam_activate "Activation for Damper position setpoint for zone nor";
-	Modelica.Blocks.Interfaces.RealInput hva_floor3_fivZonVAV_vAV4_oveZonLoc_yReaHea_u(unit="1", min=0.0, max=1.0) "Reheat control signal for zone nor";
-	Modelica.Blocks.Interfaces.BooleanInput hva_floor3_fivZonVAV_vAV4_oveZonLoc_yReaHea_activate "Activation for Reheat control signal for zone nor";
-	Modelica.Blocks.Interfaces.RealInput hva_floor3_fivZonVAV_vAV5_oveZonLoc_yDam_u(unit="1", min=0.0, max=1.0) "Damper position setpoint for zone wes";
-	Modelica.Blocks.Interfaces.BooleanInput hva_floor3_fivZonVAV_vAV5_oveZonLoc_yDam_activate "Activation for Damper position setpoint for zone wes";
-	Modelica.Blocks.Interfaces.RealInput hva_floor3_fivZonVAV_vAV5_oveZonLoc_yReaHea_u(unit="1", min=0.0, max=1.0) "Reheat control signal for zone wes";
-	Modelica.Blocks.Interfaces.BooleanInput hva_floor3_fivZonVAV_vAV5_oveZonLoc_yReaHea_activate "Activation for Reheat control signal for zone wes";
-	Modelica.Blocks.Interfaces.RealInput hva_floor3_oveZonCor_TZonCooSet_u(unit="K", min=285.15, max=313.15) "Zone air temperature cooling setpoint for zone top_floor_cor";
-	Modelica.Blocks.Interfaces.BooleanInput hva_floor3_oveZonCor_TZonCooSet_activate "Activation for Zone air temperature cooling setpoint for zone top_floor_cor";
-	Modelica.Blocks.Interfaces.RealInput hva_floor3_oveZonCor_TZonHeaSet_u(unit="K", min=285.15, max=313.15) "Zone air temperature heating setpoint for zone top_floor_cor";
-	Modelica.Blocks.Interfaces.BooleanInput hva_floor3_oveZonCor_TZonHeaSet_activate "Activation for Zone air temperature heating setpoint for zone top_floor_cor";
-	Modelica.Blocks.Interfaces.RealInput hva_floor3_oveZonEas_TZonCooSet_u(unit="K", min=285.15, max=313.15) "Zone air temperature cooling setpoint for zone top_floor_eas";
-	Modelica.Blocks.Interfaces.BooleanInput hva_floor3_oveZonEas_TZonCooSet_activate "Activation for Zone air temperature cooling setpoint for zone top_floor_eas";
-	Modelica.Blocks.Interfaces.RealInput hva_floor3_oveZonEas_TZonHeaSet_u(unit="K", min=285.15, max=313.15) "Zone air temperature heating setpoint for zone top_floor_eas";
-	Modelica.Blocks.Interfaces.BooleanInput hva_floor3_oveZonEas_TZonHeaSet_activate "Activation for Zone air temperature heating setpoint for zone top_floor_eas";
-	Modelica.Blocks.Interfaces.RealInput hva_floor3_oveZonNor_TZonCooSet_u(unit="K", min=285.15, max=313.15) "Zone air temperature cooling setpoint for zone top_floor_nor";
-	Modelica.Blocks.Interfaces.BooleanInput hva_floor3_oveZonNor_TZonCooSet_activate "Activation for Zone air temperature cooling setpoint for zone top_floor_nor";
-	Modelica.Blocks.Interfaces.RealInput hva_floor3_oveZonNor_TZonHeaSet_u(unit="K", min=285.15, max=313.15) "Zone air temperature heating setpoint for zone top_floor_nor";
-	Modelica.Blocks.Interfaces.BooleanInput hva_floor3_oveZonNor_TZonHeaSet_activate "Activation for Zone air temperature heating setpoint for zone top_floor_nor";
-	Modelica.Blocks.Interfaces.RealInput hva_floor3_oveZonSou_TZonCooSet_u(unit="K", min=285.15, max=313.15) "Zone air temperature cooling setpoint for zone top_floor_sou";
-	Modelica.Blocks.Interfaces.BooleanInput hva_floor3_oveZonSou_TZonCooSet_activate "Activation for Zone air temperature cooling setpoint for zone top_floor_sou";
-	Modelica.Blocks.Interfaces.RealInput hva_floor3_oveZonSou_TZonHeaSet_u(unit="K", min=285.15, max=313.15) "Zone air temperature heating setpoint for zone top_floor_sou";
-	Modelica.Blocks.Interfaces.BooleanInput hva_floor3_oveZonSou_TZonHeaSet_activate "Activation for Zone air temperature heating setpoint for zone top_floor_sou";
-	Modelica.Blocks.Interfaces.RealInput hva_floor3_oveZonWes_TZonCooSet_u(unit="K", min=285.15, max=313.15) "Zone air temperature cooling setpoint for zone top_floor_wes";
-	Modelica.Blocks.Interfaces.BooleanInput hva_floor3_oveZonWes_TZonCooSet_activate "Activation for Zone air temperature cooling setpoint for zone top_floor_wes";
-	Modelica.Blocks.Interfaces.RealInput hva_floor3_oveZonWes_TZonHeaSet_u(unit="K", min=285.15, max=313.15) "Zone air temperature heating setpoint for zone top_floor_wes";
-	Modelica.Blocks.Interfaces.BooleanInput hva_floor3_oveZonWes_TZonHeaSet_activate "Activation for Zone air temperature heating setpoint for zone top_floor_wes";
-	Modelica.Blocks.Interfaces.RealInput hva_oveChiWatSys_TW_set_u(unit="K", min=278.15, max=288.15) "Chilled/hot water supply setpoint";
-	Modelica.Blocks.Interfaces.BooleanInput hva_oveChiWatSys_TW_set_activate "Activation for Chilled/hot water supply setpoint";
-	Modelica.Blocks.Interfaces.RealInput hva_oveChiWatSys_dp_set_u(unit="Pa", min=0.0, max=19130000.0) "Differential pressure setpoint";
-	Modelica.Blocks.Interfaces.BooleanInput hva_oveChiWatSys_dp_set_activate "Activation for Differential pressure setpoint";
-	Modelica.Blocks.Interfaces.RealInput hva_oveHotWatSys_TW_set_u(unit="K", min=291.15, max=353.15) "Chilled/hot water supply setpoint";
-	Modelica.Blocks.Interfaces.BooleanInput hva_oveHotWatSys_TW_set_activate "Activation for Chilled/hot water supply setpoint";
-	Modelica.Blocks.Interfaces.RealInput hva_oveHotWatSys_dp_set_u(unit="Pa", min=0.0, max=19130000.0) "Differential pressure setpoint";
-	Modelica.Blocks.Interfaces.BooleanInput hva_oveHotWatSys_dp_set_activate "Activation for Differential pressure setpoint";
-	// Out read
-	Modelica.Blocks.Interfaces.RealOutput hva_floor1_reaAhu_PFanTot_y(unit="W") = mod.hva.floor1.reaAhu.PFanTot.y "Total electrical power measurement of supply and return fans for AHU";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor1_reaAhu_TCooCoiRet_y(unit="K") = mod.hva.floor1.reaAhu.TCooCoiRet.y "Cooling coil return water temperature measurement for AHU";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor1_reaAhu_TCooCoiSup_y(unit="K") = mod.hva.floor1.reaAhu.TCooCoiSup.y "Cooling coil supply water temperature measurement for AHU";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor1_reaAhu_TMix_y(unit="K") = mod.hva.floor1.reaAhu.TMix.y "Mixed air temperature measurement for AHU";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor1_reaAhu_TRet_y(unit="K") = mod.hva.floor1.reaAhu.TRet.y "Return air temperature measurement for AHU";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor1_reaAhu_TSup_y(unit="K") = mod.hva.floor1.reaAhu.TSup.y "Supply air temperature measurement for AHU";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor1_reaAhu_TSup_set_y(unit="K") = mod.hva.floor1.reaAhu.TSup_set.y "Supply air temperature setpoint measurement for AHU";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor1_reaAhu_V_flow_OA_y(unit="m3/s") = mod.hva.floor1.reaAhu.V_flow_OA.y "Supply outdoor airflow rate measurement for AHU";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor1_reaAhu_V_flow_ret_y(unit="m3/s") = mod.hva.floor1.reaAhu.V_flow_ret.y "Return air flowrate measurement for AHU";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor1_reaAhu_V_flow_sup_y(unit="m3/s") = mod.hva.floor1.reaAhu.V_flow_sup.y "Supply air flowrate measurement for AHU";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor1_reaAhu_dp_sup_y(unit="Pa") = mod.hva.floor1.reaAhu.dp_sup.y "Discharge pressure of supply fan for AHU";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor1_reaAhu_occ_y(unit="1") = mod.hva.floor1.reaAhu.occ.y "Occupancy status (1 occupied, 0 unoccupied)";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor1_reaAhu_yCooVal_y(unit="1") = mod.hva.floor1.reaAhu.yCooVal.y "AHU cooling coil valve position measurement";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor1_reaAhu_yOA_y(unit="1") = mod.hva.floor1.reaAhu.yOA.y "AHU cooling coil valve position measurement";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor1_reaZonCor_TRoo_Coo_set_y(unit="K") = mod.hva.floor1.reaZonCor.TRoo_Coo_set.y "Zone temperature cooling setpoint for zonebot_floor_cor";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor1_reaZonCor_TRoo_Hea_set_y(unit="K") = mod.hva.floor1.reaZonCor.TRoo_Hea_set.y "Zone temperature heating setpoint for zone bot_floor_cor";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor1_reaZonCor_TSup_y(unit="K") = mod.hva.floor1.reaZonCor.TSup.y "Discharge air temperature to zone measurement for zone bot_floor_cor";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor1_reaZonCor_TZon_y(unit="K") = mod.hva.floor1.reaZonCor.TZon.y "Zone air temperature measurement for zone bot_floor_cor";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor1_reaZonCor_V_flow_y(unit="m3/s") = mod.hva.floor1.reaZonCor.V_flow.y "Discharge air flowrate to zone measurement for zone bot_floor_cor";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor1_reaZonCor_V_flow_set_y(unit="m3/s") = mod.hva.floor1.reaZonCor.V_flow_set.y "Airflow setpointbot_floor_cor";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor1_reaZonCor_yCoo_y(unit="1") = mod.hva.floor1.reaZonCor.yCoo.y "Cooling PID signal measurement for zone bot_floor_cor";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor1_reaZonCor_yDam_y(unit="1") = mod.hva.floor1.reaZonCor.yDam.y "Damper position measurement for zone bot_floor_cor";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor1_reaZonCor_yHea_y(unit="1") = mod.hva.floor1.reaZonCor.yHea.y "Heating PID signal measurement for zone bot_floor_cor";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor1_reaZonCor_yReheaVal_y(unit="1") = mod.hva.floor1.reaZonCor.yReheaVal.y "Reheat valve position measurement for zone bot_floor_cor";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor1_reaZonEas_TRoo_Coo_set_y(unit="K") = mod.hva.floor1.reaZonEas.TRoo_Coo_set.y "Zone temperature cooling setpoint for zonebot_floor_eas";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor1_reaZonEas_TRoo_Hea_set_y(unit="K") = mod.hva.floor1.reaZonEas.TRoo_Hea_set.y "Zone temperature heating setpoint for zone bot_floor_eas";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor1_reaZonEas_TSup_y(unit="K") = mod.hva.floor1.reaZonEas.TSup.y "Discharge air temperature to zone measurement for zone bot_floor_eas";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor1_reaZonEas_TZon_y(unit="K") = mod.hva.floor1.reaZonEas.TZon.y "Zone air temperature measurement for zone bot_floor_eas";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor1_reaZonEas_V_flow_y(unit="m3/s") = mod.hva.floor1.reaZonEas.V_flow.y "Discharge air flowrate to zone measurement for zone bot_floor_eas";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor1_reaZonEas_V_flow_set_y(unit="m3/s") = mod.hva.floor1.reaZonEas.V_flow_set.y "Airflow setpointbot_floor_eas";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor1_reaZonEas_yCoo_y(unit="1") = mod.hva.floor1.reaZonEas.yCoo.y "Cooling PID signal measurement for zone bot_floor_eas";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor1_reaZonEas_yDam_y(unit="1") = mod.hva.floor1.reaZonEas.yDam.y "Damper position measurement for zone bot_floor_eas";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor1_reaZonEas_yHea_y(unit="1") = mod.hva.floor1.reaZonEas.yHea.y "Heating PID signal measurement for zone bot_floor_eas";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor1_reaZonEas_yReheaVal_y(unit="1") = mod.hva.floor1.reaZonEas.yReheaVal.y "Reheat valve position measurement for zone bot_floor_eas";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor1_reaZonNor_TRoo_Coo_set_y(unit="K") = mod.hva.floor1.reaZonNor.TRoo_Coo_set.y "Zone temperature cooling setpoint for zonebot_floor_nor";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor1_reaZonNor_TRoo_Hea_set_y(unit="K") = mod.hva.floor1.reaZonNor.TRoo_Hea_set.y "Zone temperature heating setpoint for zone bot_floor_nor";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor1_reaZonNor_TSup_y(unit="K") = mod.hva.floor1.reaZonNor.TSup.y "Discharge air temperature to zone measurement for zone bot_floor_nor";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor1_reaZonNor_TZon_y(unit="K") = mod.hva.floor1.reaZonNor.TZon.y "Zone air temperature measurement for zone bot_floor_nor";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor1_reaZonNor_V_flow_y(unit="m3/s") = mod.hva.floor1.reaZonNor.V_flow.y "Discharge air flowrate to zone measurement for zone bot_floor_nor";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor1_reaZonNor_V_flow_set_y(unit="m3/s") = mod.hva.floor1.reaZonNor.V_flow_set.y "Airflow setpointbot_floor_nor";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor1_reaZonNor_yCoo_y(unit="1") = mod.hva.floor1.reaZonNor.yCoo.y "Cooling PID signal measurement for zone bot_floor_nor";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor1_reaZonNor_yDam_y(unit="1") = mod.hva.floor1.reaZonNor.yDam.y "Damper position measurement for zone bot_floor_nor";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor1_reaZonNor_yHea_y(unit="1") = mod.hva.floor1.reaZonNor.yHea.y "Heating PID signal measurement for zone bot_floor_nor";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor1_reaZonNor_yReheaVal_y(unit="1") = mod.hva.floor1.reaZonNor.yReheaVal.y "Reheat valve position measurement for zone bot_floor_nor";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor1_reaZonSou_TRoo_Coo_set_y(unit="K") = mod.hva.floor1.reaZonSou.TRoo_Coo_set.y "Zone temperature cooling setpoint for zonebot_floor_sou";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor1_reaZonSou_TRoo_Hea_set_y(unit="K") = mod.hva.floor1.reaZonSou.TRoo_Hea_set.y "Zone temperature heating setpoint for zone bot_floor_sou";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor1_reaZonSou_TSup_y(unit="K") = mod.hva.floor1.reaZonSou.TSup.y "Discharge air temperature to zone measurement for zone bot_floor_sou";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor1_reaZonSou_TZon_y(unit="K") = mod.hva.floor1.reaZonSou.TZon.y "Zone air temperature measurement for zone bot_floor_sou";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor1_reaZonSou_V_flow_y(unit="m3/s") = mod.hva.floor1.reaZonSou.V_flow.y "Discharge air flowrate to zone measurement for zone bot_floor_sou";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor1_reaZonSou_V_flow_set_y(unit="m3/s") = mod.hva.floor1.reaZonSou.V_flow_set.y "Airflow setpointbot_floor_sou";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor1_reaZonSou_yCoo_y(unit="1") = mod.hva.floor1.reaZonSou.yCoo.y "Cooling PID signal measurement for zone bot_floor_sou";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor1_reaZonSou_yDam_y(unit="1") = mod.hva.floor1.reaZonSou.yDam.y "Damper position measurement for zone bot_floor_sou";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor1_reaZonSou_yHea_y(unit="1") = mod.hva.floor1.reaZonSou.yHea.y "Heating PID signal measurement for zone bot_floor_sou";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor1_reaZonSou_yReheaVal_y(unit="1") = mod.hva.floor1.reaZonSou.yReheaVal.y "Reheat valve position measurement for zone bot_floor_sou";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor1_reaZonWes_TRoo_Coo_set_y(unit="K") = mod.hva.floor1.reaZonWes.TRoo_Coo_set.y "Zone temperature cooling setpoint for zonebot_floor_wes";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor1_reaZonWes_TRoo_Hea_set_y(unit="K") = mod.hva.floor1.reaZonWes.TRoo_Hea_set.y "Zone temperature heating setpoint for zone bot_floor_wes";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor1_reaZonWes_TSup_y(unit="K") = mod.hva.floor1.reaZonWes.TSup.y "Discharge air temperature to zone measurement for zone bot_floor_wes";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor1_reaZonWes_TZon_y(unit="K") = mod.hva.floor1.reaZonWes.TZon.y "Zone air temperature measurement for zone bot_floor_wes";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor1_reaZonWes_V_flow_y(unit="m3/s") = mod.hva.floor1.reaZonWes.V_flow.y "Discharge air flowrate to zone measurement for zone bot_floor_wes";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor1_reaZonWes_V_flow_set_y(unit="m3/s") = mod.hva.floor1.reaZonWes.V_flow_set.y "Airflow setpointbot_floor_wes";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor1_reaZonWes_yCoo_y(unit="1") = mod.hva.floor1.reaZonWes.yCoo.y "Cooling PID signal measurement for zone bot_floor_wes";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor1_reaZonWes_yDam_y(unit="1") = mod.hva.floor1.reaZonWes.yDam.y "Damper position measurement for zone bot_floor_wes";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor1_reaZonWes_yHea_y(unit="1") = mod.hva.floor1.reaZonWes.yHea.y "Heating PID signal measurement for zone bot_floor_wes";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor1_reaZonWes_yReheaVal_y(unit="1") = mod.hva.floor1.reaZonWes.yReheaVal.y "Reheat valve position measurement for zone bot_floor_wes";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor2_reaAhu_PFanTot_y(unit="W") = mod.hva.floor2.reaAhu.PFanTot.y "Total electrical power measurement of supply and return fans for AHU";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor2_reaAhu_TCooCoiRet_y(unit="K") = mod.hva.floor2.reaAhu.TCooCoiRet.y "Cooling coil return water temperature measurement for AHU";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor2_reaAhu_TCooCoiSup_y(unit="K") = mod.hva.floor2.reaAhu.TCooCoiSup.y "Cooling coil supply water temperature measurement for AHU";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor2_reaAhu_TMix_y(unit="K") = mod.hva.floor2.reaAhu.TMix.y "Mixed air temperature measurement for AHU";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor2_reaAhu_TRet_y(unit="K") = mod.hva.floor2.reaAhu.TRet.y "Return air temperature measurement for AHU";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor2_reaAhu_TSup_y(unit="K") = mod.hva.floor2.reaAhu.TSup.y "Supply air temperature measurement for AHU";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor2_reaAhu_TSup_set_y(unit="K") = mod.hva.floor2.reaAhu.TSup_set.y "Supply air temperature setpoint measurement for AHU";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor2_reaAhu_V_flow_OA_y(unit="m3/s") = mod.hva.floor2.reaAhu.V_flow_OA.y "Supply outdoor airflow rate measurement for AHU";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor2_reaAhu_V_flow_ret_y(unit="m3/s") = mod.hva.floor2.reaAhu.V_flow_ret.y "Return air flowrate measurement for AHU";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor2_reaAhu_V_flow_sup_y(unit="m3/s") = mod.hva.floor2.reaAhu.V_flow_sup.y "Supply air flowrate measurement for AHU";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor2_reaAhu_dp_sup_y(unit="Pa") = mod.hva.floor2.reaAhu.dp_sup.y "Discharge pressure of supply fan for AHU";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor2_reaAhu_occ_y(unit="1") = mod.hva.floor2.reaAhu.occ.y "Occupancy status (1 occupied, 0 unoccupied)";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor2_reaAhu_yCooVal_y(unit="1") = mod.hva.floor2.reaAhu.yCooVal.y "AHU cooling coil valve position measurement";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor2_reaAhu_yOA_y(unit="1") = mod.hva.floor2.reaAhu.yOA.y "AHU cooling coil valve position measurement";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor2_reaZonCor_TRoo_Coo_set_y(unit="K") = mod.hva.floor2.reaZonCor.TRoo_Coo_set.y "Zone temperature cooling setpoint for zonemid_floor_cor";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor2_reaZonCor_TRoo_Hea_set_y(unit="K") = mod.hva.floor2.reaZonCor.TRoo_Hea_set.y "Zone temperature heating setpoint for zone mid_floor_cor";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor2_reaZonCor_TSup_y(unit="K") = mod.hva.floor2.reaZonCor.TSup.y "Discharge air temperature to zone measurement for zone mid_floor_cor";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor2_reaZonCor_TZon_y(unit="K") = mod.hva.floor2.reaZonCor.TZon.y "Zone air temperature measurement for zone mid_floor_cor";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor2_reaZonCor_V_flow_y(unit="m3/s") = mod.hva.floor2.reaZonCor.V_flow.y "Discharge air flowrate to zone measurement for zone mid_floor_cor";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor2_reaZonCor_V_flow_set_y(unit="m3/s") = mod.hva.floor2.reaZonCor.V_flow_set.y "Airflow setpointmid_floor_cor";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor2_reaZonCor_yCoo_y(unit="1") = mod.hva.floor2.reaZonCor.yCoo.y "Cooling PID signal measurement for zone mid_floor_cor";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor2_reaZonCor_yDam_y(unit="1") = mod.hva.floor2.reaZonCor.yDam.y "Damper position measurement for zone mid_floor_cor";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor2_reaZonCor_yHea_y(unit="1") = mod.hva.floor2.reaZonCor.yHea.y "Heating PID signal measurement for zone mid_floor_cor";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor2_reaZonCor_yReheaVal_y(unit="1") = mod.hva.floor2.reaZonCor.yReheaVal.y "Reheat valve position measurement for zone mid_floor_cor";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor2_reaZonEas_TRoo_Coo_set_y(unit="K") = mod.hva.floor2.reaZonEas.TRoo_Coo_set.y "Zone temperature cooling setpoint for zonemid_floor_eas";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor2_reaZonEas_TRoo_Hea_set_y(unit="K") = mod.hva.floor2.reaZonEas.TRoo_Hea_set.y "Zone temperature heating setpoint for zone mid_floor_eas";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor2_reaZonEas_TSup_y(unit="K") = mod.hva.floor2.reaZonEas.TSup.y "Discharge air temperature to zone measurement for zone mid_floor_eas";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor2_reaZonEas_TZon_y(unit="K") = mod.hva.floor2.reaZonEas.TZon.y "Zone air temperature measurement for zone mid_floor_eas";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor2_reaZonEas_V_flow_y(unit="m3/s") = mod.hva.floor2.reaZonEas.V_flow.y "Discharge air flowrate to zone measurement for zone mid_floor_eas";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor2_reaZonEas_V_flow_set_y(unit="m3/s") = mod.hva.floor2.reaZonEas.V_flow_set.y "Airflow setpointmid_floor_eas";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor2_reaZonEas_yCoo_y(unit="1") = mod.hva.floor2.reaZonEas.yCoo.y "Cooling PID signal measurement for zone mid_floor_eas";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor2_reaZonEas_yDam_y(unit="1") = mod.hva.floor2.reaZonEas.yDam.y "Damper position measurement for zone mid_floor_eas";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor2_reaZonEas_yHea_y(unit="1") = mod.hva.floor2.reaZonEas.yHea.y "Heating PID signal measurement for zone mid_floor_eas";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor2_reaZonEas_yReheaVal_y(unit="1") = mod.hva.floor2.reaZonEas.yReheaVal.y "Reheat valve position measurement for zone mid_floor_eas";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor2_reaZonNor_TRoo_Coo_set_y(unit="K") = mod.hva.floor2.reaZonNor.TRoo_Coo_set.y "Zone temperature cooling setpoint for zonemid_floor_nor";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor2_reaZonNor_TRoo_Hea_set_y(unit="K") = mod.hva.floor2.reaZonNor.TRoo_Hea_set.y "Zone temperature heating setpoint for zone mid_floor_nor";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor2_reaZonNor_TSup_y(unit="K") = mod.hva.floor2.reaZonNor.TSup.y "Discharge air temperature to zone measurement for zone mid_floor_nor";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor2_reaZonNor_TZon_y(unit="K") = mod.hva.floor2.reaZonNor.TZon.y "Zone air temperature measurement for zone mid_floor_nor";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor2_reaZonNor_V_flow_y(unit="m3/s") = mod.hva.floor2.reaZonNor.V_flow.y "Discharge air flowrate to zone measurement for zone mid_floor_nor";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor2_reaZonNor_V_flow_set_y(unit="m3/s") = mod.hva.floor2.reaZonNor.V_flow_set.y "Airflow setpointmid_floor_nor";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor2_reaZonNor_yCoo_y(unit="1") = mod.hva.floor2.reaZonNor.yCoo.y "Cooling PID signal measurement for zone mid_floor_nor";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor2_reaZonNor_yDam_y(unit="1") = mod.hva.floor2.reaZonNor.yDam.y "Damper position measurement for zone mid_floor_nor";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor2_reaZonNor_yHea_y(unit="1") = mod.hva.floor2.reaZonNor.yHea.y "Heating PID signal measurement for zone mid_floor_nor";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor2_reaZonNor_yReheaVal_y(unit="1") = mod.hva.floor2.reaZonNor.yReheaVal.y "Reheat valve position measurement for zone mid_floor_nor";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor2_reaZonSou_TRoo_Coo_set_y(unit="K") = mod.hva.floor2.reaZonSou.TRoo_Coo_set.y "Zone temperature cooling setpoint for zonemid_floor_sou";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor2_reaZonSou_TRoo_Hea_set_y(unit="K") = mod.hva.floor2.reaZonSou.TRoo_Hea_set.y "Zone temperature heating setpoint for zone mid_floor_sou";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor2_reaZonSou_TSup_y(unit="K") = mod.hva.floor2.reaZonSou.TSup.y "Discharge air temperature to zone measurement for zone mid_floor_sou";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor2_reaZonSou_TZon_y(unit="K") = mod.hva.floor2.reaZonSou.TZon.y "Zone air temperature measurement for zone mid_floor_sou";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor2_reaZonSou_V_flow_y(unit="m3/s") = mod.hva.floor2.reaZonSou.V_flow.y "Discharge air flowrate to zone measurement for zone mid_floor_sou";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor2_reaZonSou_V_flow_set_y(unit="m3/s") = mod.hva.floor2.reaZonSou.V_flow_set.y "Airflow setpointmid_floor_sou";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor2_reaZonSou_yCoo_y(unit="1") = mod.hva.floor2.reaZonSou.yCoo.y "Cooling PID signal measurement for zone mid_floor_sou";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor2_reaZonSou_yDam_y(unit="1") = mod.hva.floor2.reaZonSou.yDam.y "Damper position measurement for zone mid_floor_sou";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor2_reaZonSou_yHea_y(unit="1") = mod.hva.floor2.reaZonSou.yHea.y "Heating PID signal measurement for zone mid_floor_sou";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor2_reaZonSou_yReheaVal_y(unit="1") = mod.hva.floor2.reaZonSou.yReheaVal.y "Reheat valve position measurement for zone mid_floor_sou";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor2_reaZonWes_TRoo_Coo_set_y(unit="K") = mod.hva.floor2.reaZonWes.TRoo_Coo_set.y "Zone temperature cooling setpoint for zonemid_floor_wes";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor2_reaZonWes_TRoo_Hea_set_y(unit="K") = mod.hva.floor2.reaZonWes.TRoo_Hea_set.y "Zone temperature heating setpoint for zone mid_floor_wes";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor2_reaZonWes_TSup_y(unit="K") = mod.hva.floor2.reaZonWes.TSup.y "Discharge air temperature to zone measurement for zone mid_floor_wes";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor2_reaZonWes_TZon_y(unit="K") = mod.hva.floor2.reaZonWes.TZon.y "Zone air temperature measurement for zone mid_floor_wes";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor2_reaZonWes_V_flow_y(unit="m3/s") = mod.hva.floor2.reaZonWes.V_flow.y "Discharge air flowrate to zone measurement for zone mid_floor_wes";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor2_reaZonWes_V_flow_set_y(unit="m3/s") = mod.hva.floor2.reaZonWes.V_flow_set.y "Airflow setpointmid_floor_wes";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor2_reaZonWes_yCoo_y(unit="1") = mod.hva.floor2.reaZonWes.yCoo.y "Cooling PID signal measurement for zone mid_floor_wes";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor2_reaZonWes_yDam_y(unit="1") = mod.hva.floor2.reaZonWes.yDam.y "Damper position measurement for zone mid_floor_wes";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor2_reaZonWes_yHea_y(unit="1") = mod.hva.floor2.reaZonWes.yHea.y "Heating PID signal measurement for zone mid_floor_wes";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor2_reaZonWes_yReheaVal_y(unit="1") = mod.hva.floor2.reaZonWes.yReheaVal.y "Reheat valve position measurement for zone mid_floor_wes";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor3_reaAhu_PFanTot_y(unit="W") = mod.hva.floor3.reaAhu.PFanTot.y "Total electrical power measurement of supply and return fans for AHU";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor3_reaAhu_TCooCoiRet_y(unit="K") = mod.hva.floor3.reaAhu.TCooCoiRet.y "Cooling coil return water temperature measurement for AHU";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor3_reaAhu_TCooCoiSup_y(unit="K") = mod.hva.floor3.reaAhu.TCooCoiSup.y "Cooling coil supply water temperature measurement for AHU";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor3_reaAhu_TMix_y(unit="K") = mod.hva.floor3.reaAhu.TMix.y "Mixed air temperature measurement for AHU";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor3_reaAhu_TRet_y(unit="K") = mod.hva.floor3.reaAhu.TRet.y "Return air temperature measurement for AHU";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor3_reaAhu_TSup_y(unit="K") = mod.hva.floor3.reaAhu.TSup.y "Supply air temperature measurement for AHU";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor3_reaAhu_TSup_set_y(unit="K") = mod.hva.floor3.reaAhu.TSup_set.y "Supply air temperature setpoint measurement for AHU";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor3_reaAhu_V_flow_OA_y(unit="m3/s") = mod.hva.floor3.reaAhu.V_flow_OA.y "Supply outdoor airflow rate measurement for AHU";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor3_reaAhu_V_flow_ret_y(unit="m3/s") = mod.hva.floor3.reaAhu.V_flow_ret.y "Return air flowrate measurement for AHU";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor3_reaAhu_V_flow_sup_y(unit="m3/s") = mod.hva.floor3.reaAhu.V_flow_sup.y "Supply air flowrate measurement for AHU";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor3_reaAhu_dp_sup_y(unit="Pa") = mod.hva.floor3.reaAhu.dp_sup.y "Discharge pressure of supply fan for AHU";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor3_reaAhu_occ_y(unit="1") = mod.hva.floor3.reaAhu.occ.y "Occupancy status (1 occupied, 0 unoccupied)";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor3_reaAhu_yCooVal_y(unit="1") = mod.hva.floor3.reaAhu.yCooVal.y "AHU cooling coil valve position measurement";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor3_reaAhu_yOA_y(unit="1") = mod.hva.floor3.reaAhu.yOA.y "AHU cooling coil valve position measurement";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor3_reaZonCor_TRoo_Coo_set_y(unit="K") = mod.hva.floor3.reaZonCor.TRoo_Coo_set.y "Zone temperature cooling setpoint for zonetop_floor_cor";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor3_reaZonCor_TRoo_Hea_set_y(unit="K") = mod.hva.floor3.reaZonCor.TRoo_Hea_set.y "Zone temperature heating setpoint for zone top_floor_cor";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor3_reaZonCor_TSup_y(unit="K") = mod.hva.floor3.reaZonCor.TSup.y "Discharge air temperature to zone measurement for zone top_floor_cor";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor3_reaZonCor_TZon_y(unit="K") = mod.hva.floor3.reaZonCor.TZon.y "Zone air temperature measurement for zone top_floor_cor";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor3_reaZonCor_V_flow_y(unit="m3/s") = mod.hva.floor3.reaZonCor.V_flow.y "Discharge air flowrate to zone measurement for zone top_floor_cor";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor3_reaZonCor_V_flow_set_y(unit="m3/s") = mod.hva.floor3.reaZonCor.V_flow_set.y "Airflow setpointtop_floor_cor";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor3_reaZonCor_yCoo_y(unit="1") = mod.hva.floor3.reaZonCor.yCoo.y "Cooling PID signal measurement for zone top_floor_cor";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor3_reaZonCor_yDam_y(unit="1") = mod.hva.floor3.reaZonCor.yDam.y "Damper position measurement for zone top_floor_cor";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor3_reaZonCor_yHea_y(unit="1") = mod.hva.floor3.reaZonCor.yHea.y "Heating PID signal measurement for zone top_floor_cor";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor3_reaZonCor_yReheaVal_y(unit="1") = mod.hva.floor3.reaZonCor.yReheaVal.y "Reheat valve position measurement for zone top_floor_cor";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor3_reaZonEas_TRoo_Coo_set_y(unit="K") = mod.hva.floor3.reaZonEas.TRoo_Coo_set.y "Zone temperature cooling setpoint for zonetop_floor_eas";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor3_reaZonEas_TRoo_Hea_set_y(unit="K") = mod.hva.floor3.reaZonEas.TRoo_Hea_set.y "Zone temperature heating setpoint for zone top_floor_eas";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor3_reaZonEas_TSup_y(unit="K") = mod.hva.floor3.reaZonEas.TSup.y "Discharge air temperature to zone measurement for zone top_floor_eas";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor3_reaZonEas_TZon_y(unit="K") = mod.hva.floor3.reaZonEas.TZon.y "Zone air temperature measurement for zone top_floor_eas";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor3_reaZonEas_V_flow_y(unit="m3/s") = mod.hva.floor3.reaZonEas.V_flow.y "Discharge air flowrate to zone measurement for zone top_floor_eas";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor3_reaZonEas_V_flow_set_y(unit="m3/s") = mod.hva.floor3.reaZonEas.V_flow_set.y "Airflow setpointtop_floor_eas";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor3_reaZonEas_yCoo_y(unit="1") = mod.hva.floor3.reaZonEas.yCoo.y "Cooling PID signal measurement for zone top_floor_eas";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor3_reaZonEas_yDam_y(unit="1") = mod.hva.floor3.reaZonEas.yDam.y "Damper position measurement for zone top_floor_eas";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor3_reaZonEas_yHea_y(unit="1") = mod.hva.floor3.reaZonEas.yHea.y "Heating PID signal measurement for zone top_floor_eas";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor3_reaZonEas_yReheaVal_y(unit="1") = mod.hva.floor3.reaZonEas.yReheaVal.y "Reheat valve position measurement for zone top_floor_eas";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor3_reaZonNor_TRoo_Coo_set_y(unit="K") = mod.hva.floor3.reaZonNor.TRoo_Coo_set.y "Zone temperature cooling setpoint for zonetop_floor_nor";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor3_reaZonNor_TRoo_Hea_set_y(unit="K") = mod.hva.floor3.reaZonNor.TRoo_Hea_set.y "Zone temperature heating setpoint for zone top_floor_nor";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor3_reaZonNor_TSup_y(unit="K") = mod.hva.floor3.reaZonNor.TSup.y "Discharge air temperature to zone measurement for zone top_floor_nor";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor3_reaZonNor_TZon_y(unit="K") = mod.hva.floor3.reaZonNor.TZon.y "Zone air temperature measurement for zone top_floor_nor";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor3_reaZonNor_V_flow_y(unit="m3/s") = mod.hva.floor3.reaZonNor.V_flow.y "Discharge air flowrate to zone measurement for zone top_floor_nor";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor3_reaZonNor_V_flow_set_y(unit="m3/s") = mod.hva.floor3.reaZonNor.V_flow_set.y "Airflow setpointtop_floor_nor";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor3_reaZonNor_yCoo_y(unit="1") = mod.hva.floor3.reaZonNor.yCoo.y "Cooling PID signal measurement for zone top_floor_nor";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor3_reaZonNor_yDam_y(unit="1") = mod.hva.floor3.reaZonNor.yDam.y "Damper position measurement for zone top_floor_nor";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor3_reaZonNor_yHea_y(unit="1") = mod.hva.floor3.reaZonNor.yHea.y "Heating PID signal measurement for zone top_floor_nor";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor3_reaZonNor_yReheaVal_y(unit="1") = mod.hva.floor3.reaZonNor.yReheaVal.y "Reheat valve position measurement for zone top_floor_nor";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor3_reaZonSou_TRoo_Coo_set_y(unit="K") = mod.hva.floor3.reaZonSou.TRoo_Coo_set.y "Zone temperature cooling setpoint for zonetop_floor_sou";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor3_reaZonSou_TRoo_Hea_set_y(unit="K") = mod.hva.floor3.reaZonSou.TRoo_Hea_set.y "Zone temperature heating setpoint for zone top_floor_sou";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor3_reaZonSou_TSup_y(unit="K") = mod.hva.floor3.reaZonSou.TSup.y "Discharge air temperature to zone measurement for zone top_floor_sou";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor3_reaZonSou_TZon_y(unit="K") = mod.hva.floor3.reaZonSou.TZon.y "Zone air temperature measurement for zone top_floor_sou";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor3_reaZonSou_V_flow_y(unit="m3/s") = mod.hva.floor3.reaZonSou.V_flow.y "Discharge air flowrate to zone measurement for zone top_floor_sou";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor3_reaZonSou_V_flow_set_y(unit="m3/s") = mod.hva.floor3.reaZonSou.V_flow_set.y "Airflow setpointtop_floor_sou";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor3_reaZonSou_yCoo_y(unit="1") = mod.hva.floor3.reaZonSou.yCoo.y "Cooling PID signal measurement for zone top_floor_sou";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor3_reaZonSou_yDam_y(unit="1") = mod.hva.floor3.reaZonSou.yDam.y "Damper position measurement for zone top_floor_sou";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor3_reaZonSou_yHea_y(unit="1") = mod.hva.floor3.reaZonSou.yHea.y "Heating PID signal measurement for zone top_floor_sou";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor3_reaZonSou_yReheaVal_y(unit="1") = mod.hva.floor3.reaZonSou.yReheaVal.y "Reheat valve position measurement for zone top_floor_sou";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor3_reaZonWes_TRoo_Coo_set_y(unit="K") = mod.hva.floor3.reaZonWes.TRoo_Coo_set.y "Zone temperature cooling setpoint for zonetop_floor_wes";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor3_reaZonWes_TRoo_Hea_set_y(unit="K") = mod.hva.floor3.reaZonWes.TRoo_Hea_set.y "Zone temperature heating setpoint for zone top_floor_wes";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor3_reaZonWes_TSup_y(unit="K") = mod.hva.floor3.reaZonWes.TSup.y "Discharge air temperature to zone measurement for zone top_floor_wes";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor3_reaZonWes_TZon_y(unit="K") = mod.hva.floor3.reaZonWes.TZon.y "Zone air temperature measurement for zone top_floor_wes";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor3_reaZonWes_V_flow_y(unit="m3/s") = mod.hva.floor3.reaZonWes.V_flow.y "Discharge air flowrate to zone measurement for zone top_floor_wes";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor3_reaZonWes_V_flow_set_y(unit="m3/s") = mod.hva.floor3.reaZonWes.V_flow_set.y "Airflow setpointtop_floor_wes";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor3_reaZonWes_yCoo_y(unit="1") = mod.hva.floor3.reaZonWes.yCoo.y "Cooling PID signal measurement for zone top_floor_wes";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor3_reaZonWes_yDam_y(unit="1") = mod.hva.floor3.reaZonWes.yDam.y "Damper position measurement for zone top_floor_wes";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor3_reaZonWes_yHea_y(unit="1") = mod.hva.floor3.reaZonWes.yHea.y "Heating PID signal measurement for zone top_floor_wes";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor3_reaZonWes_yReheaVal_y(unit="1") = mod.hva.floor3.reaZonWes.yReheaVal.y "Reheat valve position measurement for zone top_floor_wes";
-	Modelica.Blocks.Interfaces.RealOutput hva_reaChiWatSys_TW_y(unit="K") = mod.hva.reaChiWatSys.TW.y "Chilled water temperature measurement";
-	Modelica.Blocks.Interfaces.RealOutput hva_reaChiWatSys_dp_y(unit="K") = mod.hva.reaChiWatSys.dp.y "Differential pressure of chilled/hot water measurement";
-	Modelica.Blocks.Interfaces.RealOutput hva_reaChiWatSys_reaPChi_y(unit="W") = mod.hva.reaChiWatSys.reaPChi.y "Multiple chiller power consumption";
-	Modelica.Blocks.Interfaces.RealOutput hva_reaChiWatSys_reaPCooTow_y(unit="W") = mod.hva.reaChiWatSys.reaPCooTow.y "Multiple cooling tower power consumption";
-	Modelica.Blocks.Interfaces.RealOutput hva_reaChiWatSys_reaPPum_y(unit="W") = mod.hva.reaChiWatSys.reaPPum.y "Chilled water plant pump power consumption";
-	Modelica.Blocks.Interfaces.RealOutput hva_reaHotWatSys_TW_y(unit="K") = mod.hva.reaHotWatSys.TW.y "Chilled water temperature measurement";
-	Modelica.Blocks.Interfaces.RealOutput hva_reaHotWatSys_dp_y(unit="K") = mod.hva.reaHotWatSys.dp.y "Differential pressure of chilled/hot water measurement";
-	Modelica.Blocks.Interfaces.RealOutput hva_reaHotWatSys_reaPBoi_y(unit="W") = mod.hva.reaHotWatSys.reaPBoi.y "Multiple gas power consumption";
-	Modelica.Blocks.Interfaces.RealOutput hva_reaHotWatSys_reaPPum_y(unit="W") = mod.hva.reaHotWatSys.reaPPum.y "Chilled water plant pump power consumption";
-	Modelica.Blocks.Interfaces.RealOutput loaEnePlu_weaSta_reaWeaCeiHei_y(unit="m") = mod.loaEnePlu.weaSta.reaWeaCeiHei.y "Cloud cover ceiling height measurement";
-	Modelica.Blocks.Interfaces.RealOutput loaEnePlu_weaSta_reaWeaCloTim_y(unit="s") = mod.loaEnePlu.weaSta.reaWeaCloTim.y "Day number with units of seconds";
-	Modelica.Blocks.Interfaces.RealOutput loaEnePlu_weaSta_reaWeaHDifHor_y(unit="W/m2") = mod.loaEnePlu.weaSta.reaWeaHDifHor.y "Horizontal diffuse solar radiation measurement";
-	Modelica.Blocks.Interfaces.RealOutput loaEnePlu_weaSta_reaWeaHDirNor_y(unit="W/m2") = mod.loaEnePlu.weaSta.reaWeaHDirNor.y "Direct normal radiation measurement";
-	Modelica.Blocks.Interfaces.RealOutput loaEnePlu_weaSta_reaWeaHGloHor_y(unit="W/m2") = mod.loaEnePlu.weaSta.reaWeaHGloHor.y "Global horizontal solar irradiation measurement";
-	Modelica.Blocks.Interfaces.RealOutput loaEnePlu_weaSta_reaWeaHHorIR_y(unit="W/m2") = mod.loaEnePlu.weaSta.reaWeaHHorIR.y "Horizontal infrared irradiation measurement";
-	Modelica.Blocks.Interfaces.RealOutput loaEnePlu_weaSta_reaWeaLat_y(unit="rad") = mod.loaEnePlu.weaSta.reaWeaLat.y "Latitude of the location";
-	Modelica.Blocks.Interfaces.RealOutput loaEnePlu_weaSta_reaWeaLon_y(unit="rad") = mod.loaEnePlu.weaSta.reaWeaLon.y "Longitude of the location";
-	Modelica.Blocks.Interfaces.RealOutput loaEnePlu_weaSta_reaWeaNOpa_y(unit="1") = mod.loaEnePlu.weaSta.reaWeaNOpa.y "Opaque sky cover measurement";
-	Modelica.Blocks.Interfaces.RealOutput loaEnePlu_weaSta_reaWeaNTot_y(unit="1") = mod.loaEnePlu.weaSta.reaWeaNTot.y "Sky cover measurement";
-	Modelica.Blocks.Interfaces.RealOutput loaEnePlu_weaSta_reaWeaPAtm_y(unit="Pa") = mod.loaEnePlu.weaSta.reaWeaPAtm.y "Atmospheric pressure measurement";
-	Modelica.Blocks.Interfaces.RealOutput loaEnePlu_weaSta_reaWeaRelHum_y(unit="1") = mod.loaEnePlu.weaSta.reaWeaRelHum.y "Outside relative humidity measurement";
-	Modelica.Blocks.Interfaces.RealOutput loaEnePlu_weaSta_reaWeaSolAlt_y(unit="rad") = mod.loaEnePlu.weaSta.reaWeaSolAlt.y "Solar altitude angle measurement";
-	Modelica.Blocks.Interfaces.RealOutput loaEnePlu_weaSta_reaWeaSolDec_y(unit="rad") = mod.loaEnePlu.weaSta.reaWeaSolDec.y "Solar declination angle measurement";
-	Modelica.Blocks.Interfaces.RealOutput loaEnePlu_weaSta_reaWeaSolHouAng_y(unit="rad") = mod.loaEnePlu.weaSta.reaWeaSolHouAng.y "Solar hour angle measurement";
-	Modelica.Blocks.Interfaces.RealOutput loaEnePlu_weaSta_reaWeaSolTim_y(unit="s") = mod.loaEnePlu.weaSta.reaWeaSolTim.y "Solar time";
-	Modelica.Blocks.Interfaces.RealOutput loaEnePlu_weaSta_reaWeaSolZen_y(unit="rad") = mod.loaEnePlu.weaSta.reaWeaSolZen.y "Solar zenith angle measurement";
-	Modelica.Blocks.Interfaces.RealOutput loaEnePlu_weaSta_reaWeaTBlaSky_y(unit="K") = mod.loaEnePlu.weaSta.reaWeaTBlaSky.y "Black-body sky temperature measurement";
-	Modelica.Blocks.Interfaces.RealOutput loaEnePlu_weaSta_reaWeaTDewPoi_y(unit="K") = mod.loaEnePlu.weaSta.reaWeaTDewPoi.y "Dew point temperature measurement";
-	Modelica.Blocks.Interfaces.RealOutput loaEnePlu_weaSta_reaWeaTDryBul_y(unit="K") = mod.loaEnePlu.weaSta.reaWeaTDryBul.y "Outside drybulb temperature measurement";
-	Modelica.Blocks.Interfaces.RealOutput loaEnePlu_weaSta_reaWeaTWetBul_y(unit="K") = mod.loaEnePlu.weaSta.reaWeaTWetBul.y "Wet bulb temperature measurement";
-	Modelica.Blocks.Interfaces.RealOutput loaEnePlu_weaSta_reaWeaWinDir_y(unit="rad") = mod.loaEnePlu.weaSta.reaWeaWinDir.y "Wind direction measurement";
-	Modelica.Blocks.Interfaces.RealOutput loaEnePlu_weaSta_reaWeaWinSpe_y(unit="m/s") = mod.loaEnePlu.weaSta.reaWeaWinSpe.y "Wind speed measurement";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor1_TSupAirSet_y(unit="K") = mod.hva.floor1.TSupAirSet.y "Supply air temperature setpoint for AHU";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor1_dpSet_y(unit="Pa") = mod.hva.floor1.dpSet.y "Supply duct pressure setpoint for AHU";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor1_duaFanAirHanUni_cooCoi_yCoo_y(unit="1") = mod.hva.floor1.duaFanAirHanUni.cooCoi.yCoo.y "Cooling coil valve control signal for AHU";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor1_duaFanAirHanUni_mixingBox_mixBox_yEA_y(unit="1") = mod.hva.floor1.duaFanAirHanUni.mixingBox.mixBox.yEA.y "Exhaust air damper position setpoint for AHU";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor1_duaFanAirHanUni_mixingBox_mixBox_yOA_y(unit="1") = mod.hva.floor1.duaFanAirHanUni.mixingBox.mixBox.yOA.y "Outside air damper position setpoint for AHU";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor1_duaFanAirHanUni_mixingBox_mixBox_yRet_y(unit="1") = mod.hva.floor1.duaFanAirHanUni.mixingBox.mixBox.yRet.y "Return air damper position setpoint for AHU";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor1_duaFanAirHanUni_oveSpeRetFan_y(unit="1") = mod.hva.floor1.duaFanAirHanUni.oveSpeRetFan.y "AHU return fan speed control signal";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor1_duaFanAirHanUni_supFan_oveSpeSupFan_y(unit="1") = mod.hva.floor1.duaFanAirHanUni.supFan.oveSpeSupFan.y "AHU supply fan speed control signal";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor1_fivZonVAV_vAV1_oveZonLoc_yDam_y(unit="1") = mod.hva.floor1.fivZonVAV.vAV1.oveZonLoc.yDam.y "Damper position setpoint for zone cor";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor1_fivZonVAV_vAV1_oveZonLoc_yReaHea_y(unit="1") = mod.hva.floor1.fivZonVAV.vAV1.oveZonLoc.yReaHea.y "Reheat control signal for zone cor";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor1_fivZonVAV_vAV2_oveZonLoc_yDam_y(unit="1") = mod.hva.floor1.fivZonVAV.vAV2.oveZonLoc.yDam.y "Damper position setpoint for zone sou";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor1_fivZonVAV_vAV2_oveZonLoc_yReaHea_y(unit="1") = mod.hva.floor1.fivZonVAV.vAV2.oveZonLoc.yReaHea.y "Reheat control signal for zone sou";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor1_fivZonVAV_vAV3_oveZonLoc_yDam_y(unit="1") = mod.hva.floor1.fivZonVAV.vAV3.oveZonLoc.yDam.y "Damper position setpoint for zone eas";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor1_fivZonVAV_vAV3_oveZonLoc_yReaHea_y(unit="1") = mod.hva.floor1.fivZonVAV.vAV3.oveZonLoc.yReaHea.y "Reheat control signal for zone eas";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor1_fivZonVAV_vAV4_oveZonLoc_yDam_y(unit="1") = mod.hva.floor1.fivZonVAV.vAV4.oveZonLoc.yDam.y "Damper position setpoint for zone nor";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor1_fivZonVAV_vAV4_oveZonLoc_yReaHea_y(unit="1") = mod.hva.floor1.fivZonVAV.vAV4.oveZonLoc.yReaHea.y "Reheat control signal for zone nor";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor1_fivZonVAV_vAV5_oveZonLoc_yDam_y(unit="1") = mod.hva.floor1.fivZonVAV.vAV5.oveZonLoc.yDam.y "Damper position setpoint for zone wes";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor1_fivZonVAV_vAV5_oveZonLoc_yReaHea_y(unit="1") = mod.hva.floor1.fivZonVAV.vAV5.oveZonLoc.yReaHea.y "Reheat control signal for zone wes";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor1_oveZonCor_TZonCooSet_y(unit="K") = mod.hva.floor1.oveZonCor.TZonCooSet.y "Zone air temperature cooling setpoint for zone bot_floor_cor";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor1_oveZonCor_TZonHeaSet_y(unit="K") = mod.hva.floor1.oveZonCor.TZonHeaSet.y "Zone air temperature heating setpoint for zone bot_floor_cor";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor1_oveZonEas_TZonCooSet_y(unit="K") = mod.hva.floor1.oveZonEas.TZonCooSet.y "Zone air temperature cooling setpoint for zone bot_floor_eas";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor1_oveZonEas_TZonHeaSet_y(unit="K") = mod.hva.floor1.oveZonEas.TZonHeaSet.y "Zone air temperature heating setpoint for zone bot_floor_eas";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor1_oveZonNor_TZonCooSet_y(unit="K") = mod.hva.floor1.oveZonNor.TZonCooSet.y "Zone air temperature cooling setpoint for zone bot_floor_nor";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor1_oveZonNor_TZonHeaSet_y(unit="K") = mod.hva.floor1.oveZonNor.TZonHeaSet.y "Zone air temperature heating setpoint for zone bot_floor_nor";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor1_oveZonSou_TZonCooSet_y(unit="K") = mod.hva.floor1.oveZonSou.TZonCooSet.y "Zone air temperature cooling setpoint for zone bot_floor_sou";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor1_oveZonSou_TZonHeaSet_y(unit="K") = mod.hva.floor1.oveZonSou.TZonHeaSet.y "Zone air temperature heating setpoint for zone bot_floor_sou";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor1_oveZonWes_TZonCooSet_y(unit="K") = mod.hva.floor1.oveZonWes.TZonCooSet.y "Zone air temperature cooling setpoint for zone bot_floor_wes";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor1_oveZonWes_TZonHeaSet_y(unit="K") = mod.hva.floor1.oveZonWes.TZonHeaSet.y "Zone air temperature heating setpoint for zone bot_floor_wes";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor2_TSupAirSet_y(unit="K") = mod.hva.floor2.TSupAirSet.y "Supply air temperature setpoint for AHU";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor2_dpSet_y(unit="Pa") = mod.hva.floor2.dpSet.y "Supply duct pressure setpoint for AHU";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor2_duaFanAirHanUni_cooCoi_yCoo_y(unit="1") = mod.hva.floor2.duaFanAirHanUni.cooCoi.yCoo.y "Cooling coil valve control signal for AHU";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor2_duaFanAirHanUni_mixingBox_mixBox_yEA_y(unit="1") = mod.hva.floor2.duaFanAirHanUni.mixingBox.mixBox.yEA.y "Exhaust air damper position setpoint for AHU";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor2_duaFanAirHanUni_mixingBox_mixBox_yOA_y(unit="1") = mod.hva.floor2.duaFanAirHanUni.mixingBox.mixBox.yOA.y "Outside air damper position setpoint for AHU";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor2_duaFanAirHanUni_mixingBox_mixBox_yRet_y(unit="1") = mod.hva.floor2.duaFanAirHanUni.mixingBox.mixBox.yRet.y "Return air damper position setpoint for AHU";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor2_duaFanAirHanUni_oveSpeRetFan_y(unit="1") = mod.hva.floor2.duaFanAirHanUni.oveSpeRetFan.y "AHU return fan speed control signal";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor2_duaFanAirHanUni_supFan_oveSpeSupFan_y(unit="1") = mod.hva.floor2.duaFanAirHanUni.supFan.oveSpeSupFan.y "AHU supply fan speed control signal";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor2_fivZonVAV_vAV1_oveZonLoc_yDam_y(unit="1") = mod.hva.floor2.fivZonVAV.vAV1.oveZonLoc.yDam.y "Damper position setpoint for zone cor";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor2_fivZonVAV_vAV1_oveZonLoc_yReaHea_y(unit="1") = mod.hva.floor2.fivZonVAV.vAV1.oveZonLoc.yReaHea.y "Reheat control signal for zone cor";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor2_fivZonVAV_vAV2_oveZonLoc_yDam_y(unit="1") = mod.hva.floor2.fivZonVAV.vAV2.oveZonLoc.yDam.y "Damper position setpoint for zone sou";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor2_fivZonVAV_vAV2_oveZonLoc_yReaHea_y(unit="1") = mod.hva.floor2.fivZonVAV.vAV2.oveZonLoc.yReaHea.y "Reheat control signal for zone sou";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor2_fivZonVAV_vAV3_oveZonLoc_yDam_y(unit="1") = mod.hva.floor2.fivZonVAV.vAV3.oveZonLoc.yDam.y "Damper position setpoint for zone eas";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor2_fivZonVAV_vAV3_oveZonLoc_yReaHea_y(unit="1") = mod.hva.floor2.fivZonVAV.vAV3.oveZonLoc.yReaHea.y "Reheat control signal for zone eas";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor2_fivZonVAV_vAV4_oveZonLoc_yDam_y(unit="1") = mod.hva.floor2.fivZonVAV.vAV4.oveZonLoc.yDam.y "Damper position setpoint for zone nor";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor2_fivZonVAV_vAV4_oveZonLoc_yReaHea_y(unit="1") = mod.hva.floor2.fivZonVAV.vAV4.oveZonLoc.yReaHea.y "Reheat control signal for zone nor";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor2_fivZonVAV_vAV5_oveZonLoc_yDam_y(unit="1") = mod.hva.floor2.fivZonVAV.vAV5.oveZonLoc.yDam.y "Damper position setpoint for zone wes";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor2_fivZonVAV_vAV5_oveZonLoc_yReaHea_y(unit="1") = mod.hva.floor2.fivZonVAV.vAV5.oveZonLoc.yReaHea.y "Reheat control signal for zone wes";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor2_oveZonCor_TZonCooSet_y(unit="K") = mod.hva.floor2.oveZonCor.TZonCooSet.y "Zone air temperature cooling setpoint for zone mid_floor_cor";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor2_oveZonCor_TZonHeaSet_y(unit="K") = mod.hva.floor2.oveZonCor.TZonHeaSet.y "Zone air temperature heating setpoint for zone mid_floor_cor";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor2_oveZonEas_TZonCooSet_y(unit="K") = mod.hva.floor2.oveZonEas.TZonCooSet.y "Zone air temperature cooling setpoint for zone mid_floor_eas";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor2_oveZonEas_TZonHeaSet_y(unit="K") = mod.hva.floor2.oveZonEas.TZonHeaSet.y "Zone air temperature heating setpoint for zone mid_floor_eas";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor2_oveZonNor_TZonCooSet_y(unit="K") = mod.hva.floor2.oveZonNor.TZonCooSet.y "Zone air temperature cooling setpoint for zone mid_floor_nor";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor2_oveZonNor_TZonHeaSet_y(unit="K") = mod.hva.floor2.oveZonNor.TZonHeaSet.y "Zone air temperature heating setpoint for zone mid_floor_nor";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor2_oveZonSou_TZonCooSet_y(unit="K") = mod.hva.floor2.oveZonSou.TZonCooSet.y "Zone air temperature cooling setpoint for zone mid_floor_sou";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor2_oveZonSou_TZonHeaSet_y(unit="K") = mod.hva.floor2.oveZonSou.TZonHeaSet.y "Zone air temperature heating setpoint for zone mid_floor_sou";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor2_oveZonWes_TZonCooSet_y(unit="K") = mod.hva.floor2.oveZonWes.TZonCooSet.y "Zone air temperature cooling setpoint for zone mid_floor_wes";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor2_oveZonWes_TZonHeaSet_y(unit="K") = mod.hva.floor2.oveZonWes.TZonHeaSet.y "Zone air temperature heating setpoint for zone mid_floor_wes";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor3_TSupAirSet_y(unit="K") = mod.hva.floor3.TSupAirSet.y "Supply air temperature setpoint for AHU";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor3_dpSet_y(unit="Pa") = mod.hva.floor3.dpSet.y "Supply duct pressure setpoint for AHU";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor3_duaFanAirHanUni_cooCoi_yCoo_y(unit="1") = mod.hva.floor3.duaFanAirHanUni.cooCoi.yCoo.y "Cooling coil valve control signal for AHU";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor3_duaFanAirHanUni_mixingBox_mixBox_yEA_y(unit="1") = mod.hva.floor3.duaFanAirHanUni.mixingBox.mixBox.yEA.y "Exhaust air damper position setpoint for AHU";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor3_duaFanAirHanUni_mixingBox_mixBox_yOA_y(unit="1") = mod.hva.floor3.duaFanAirHanUni.mixingBox.mixBox.yOA.y "Outside air damper position setpoint for AHU";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor3_duaFanAirHanUni_mixingBox_mixBox_yRet_y(unit="1") = mod.hva.floor3.duaFanAirHanUni.mixingBox.mixBox.yRet.y "Return air damper position setpoint for AHU";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor3_duaFanAirHanUni_oveSpeRetFan_y(unit="1") = mod.hva.floor3.duaFanAirHanUni.oveSpeRetFan.y "AHU return fan speed control signal";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor3_duaFanAirHanUni_supFan_oveSpeSupFan_y(unit="1") = mod.hva.floor3.duaFanAirHanUni.supFan.oveSpeSupFan.y "AHU supply fan speed control signal";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor3_fivZonVAV_vAV1_oveZonLoc_yDam_y(unit="1") = mod.hva.floor3.fivZonVAV.vAV1.oveZonLoc.yDam.y "Damper position setpoint for zone cor";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor3_fivZonVAV_vAV1_oveZonLoc_yReaHea_y(unit="1") = mod.hva.floor3.fivZonVAV.vAV1.oveZonLoc.yReaHea.y "Reheat control signal for zone cor";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor3_fivZonVAV_vAV2_oveZonLoc_yDam_y(unit="1") = mod.hva.floor3.fivZonVAV.vAV2.oveZonLoc.yDam.y "Damper position setpoint for zone sou";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor3_fivZonVAV_vAV2_oveZonLoc_yReaHea_y(unit="1") = mod.hva.floor3.fivZonVAV.vAV2.oveZonLoc.yReaHea.y "Reheat control signal for zone sou";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor3_fivZonVAV_vAV3_oveZonLoc_yDam_y(unit="1") = mod.hva.floor3.fivZonVAV.vAV3.oveZonLoc.yDam.y "Damper position setpoint for zone eas";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor3_fivZonVAV_vAV3_oveZonLoc_yReaHea_y(unit="1") = mod.hva.floor3.fivZonVAV.vAV3.oveZonLoc.yReaHea.y "Reheat control signal for zone eas";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor3_fivZonVAV_vAV4_oveZonLoc_yDam_y(unit="1") = mod.hva.floor3.fivZonVAV.vAV4.oveZonLoc.yDam.y "Damper position setpoint for zone nor";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor3_fivZonVAV_vAV4_oveZonLoc_yReaHea_y(unit="1") = mod.hva.floor3.fivZonVAV.vAV4.oveZonLoc.yReaHea.y "Reheat control signal for zone nor";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor3_fivZonVAV_vAV5_oveZonLoc_yDam_y(unit="1") = mod.hva.floor3.fivZonVAV.vAV5.oveZonLoc.yDam.y "Damper position setpoint for zone wes";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor3_fivZonVAV_vAV5_oveZonLoc_yReaHea_y(unit="1") = mod.hva.floor3.fivZonVAV.vAV5.oveZonLoc.yReaHea.y "Reheat control signal for zone wes";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor3_oveZonCor_TZonCooSet_y(unit="K") = mod.hva.floor3.oveZonCor.TZonCooSet.y "Zone air temperature cooling setpoint for zone top_floor_cor";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor3_oveZonCor_TZonHeaSet_y(unit="K") = mod.hva.floor3.oveZonCor.TZonHeaSet.y "Zone air temperature heating setpoint for zone top_floor_cor";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor3_oveZonEas_TZonCooSet_y(unit="K") = mod.hva.floor3.oveZonEas.TZonCooSet.y "Zone air temperature cooling setpoint for zone top_floor_eas";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor3_oveZonEas_TZonHeaSet_y(unit="K") = mod.hva.floor3.oveZonEas.TZonHeaSet.y "Zone air temperature heating setpoint for zone top_floor_eas";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor3_oveZonNor_TZonCooSet_y(unit="K") = mod.hva.floor3.oveZonNor.TZonCooSet.y "Zone air temperature cooling setpoint for zone top_floor_nor";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor3_oveZonNor_TZonHeaSet_y(unit="K") = mod.hva.floor3.oveZonNor.TZonHeaSet.y "Zone air temperature heating setpoint for zone top_floor_nor";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor3_oveZonSou_TZonCooSet_y(unit="K") = mod.hva.floor3.oveZonSou.TZonCooSet.y "Zone air temperature cooling setpoint for zone top_floor_sou";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor3_oveZonSou_TZonHeaSet_y(unit="K") = mod.hva.floor3.oveZonSou.TZonHeaSet.y "Zone air temperature heating setpoint for zone top_floor_sou";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor3_oveZonWes_TZonCooSet_y(unit="K") = mod.hva.floor3.oveZonWes.TZonCooSet.y "Zone air temperature cooling setpoint for zone top_floor_wes";
-	Modelica.Blocks.Interfaces.RealOutput hva_floor3_oveZonWes_TZonHeaSet_y(unit="K") = mod.hva.floor3.oveZonWes.TZonHeaSet.y "Zone air temperature heating setpoint for zone top_floor_wes";
-	Modelica.Blocks.Interfaces.RealOutput hva_oveChiWatSys_TW_set_y(unit="K") = mod.hva.oveChiWatSys.TW_set.y "Chilled/hot water supply setpoint";
-	Modelica.Blocks.Interfaces.RealOutput hva_oveChiWatSys_dp_set_y(unit="Pa") = mod.hva.oveChiWatSys.dp_set.y "Differential pressure setpoint";
-	Modelica.Blocks.Interfaces.RealOutput hva_oveHotWatSys_TW_set_y(unit="K") = mod.hva.oveHotWatSys.TW_set.y "Chilled/hot water supply setpoint";
-	Modelica.Blocks.Interfaces.RealOutput hva_oveHotWatSys_dp_set_y(unit="Pa") = mod.hva.oveHotWatSys.dp_set.y "Differential pressure setpoint";
-	// Original model
-	MultizoneOfficeComplexAir.TestCases.TestCase mod(
-		hva.floor1.TSupAirSet(uExt(y=hva_floor1_TSupAirSet_u),activate(y=hva_floor1_TSupAirSet_activate)),
-		hva.floor1.dpSet(uExt(y=hva_floor1_dpSet_u),activate(y=hva_floor1_dpSet_activate)),
-		hva.floor1.duaFanAirHanUni.cooCoi.yCoo(uExt(y=hva_floor1_duaFanAirHanUni_cooCoi_yCoo_u),activate(y=hva_floor1_duaFanAirHanUni_cooCoi_yCoo_activate)),
-		hva.floor1.duaFanAirHanUni.mixingBox.mixBox.yEA(uExt(y=hva_floor1_duaFanAirHanUni_mixingBox_mixBox_yEA_u),activate(y=hva_floor1_duaFanAirHanUni_mixingBox_mixBox_yEA_activate)),
-		hva.floor1.duaFanAirHanUni.mixingBox.mixBox.yOA(uExt(y=hva_floor1_duaFanAirHanUni_mixingBox_mixBox_yOA_u),activate(y=hva_floor1_duaFanAirHanUni_mixingBox_mixBox_yOA_activate)),
-		hva.floor1.duaFanAirHanUni.mixingBox.mixBox.yRet(uExt(y=hva_floor1_duaFanAirHanUni_mixingBox_mixBox_yRet_u),activate(y=hva_floor1_duaFanAirHanUni_mixingBox_mixBox_yRet_activate)),
-		hva.floor1.duaFanAirHanUni.oveSpeRetFan(uExt(y=hva_floor1_duaFanAirHanUni_oveSpeRetFan_u),activate(y=hva_floor1_duaFanAirHanUni_oveSpeRetFan_activate)),
-		hva.floor1.duaFanAirHanUni.supFan.oveSpeSupFan(uExt(y=hva_floor1_duaFanAirHanUni_supFan_oveSpeSupFan_u),activate(y=hva_floor1_duaFanAirHanUni_supFan_oveSpeSupFan_activate)),
-		hva.floor1.fivZonVAV.vAV1.oveZonLoc.yDam(uExt(y=hva_floor1_fivZonVAV_vAV1_oveZonLoc_yDam_u),activate(y=hva_floor1_fivZonVAV_vAV1_oveZonLoc_yDam_activate)),
-		hva.floor1.fivZonVAV.vAV1.oveZonLoc.yReaHea(uExt(y=hva_floor1_fivZonVAV_vAV1_oveZonLoc_yReaHea_u),activate(y=hva_floor1_fivZonVAV_vAV1_oveZonLoc_yReaHea_activate)),
-		hva.floor1.fivZonVAV.vAV2.oveZonLoc.yDam(uExt(y=hva_floor1_fivZonVAV_vAV2_oveZonLoc_yDam_u),activate(y=hva_floor1_fivZonVAV_vAV2_oveZonLoc_yDam_activate)),
-		hva.floor1.fivZonVAV.vAV2.oveZonLoc.yReaHea(uExt(y=hva_floor1_fivZonVAV_vAV2_oveZonLoc_yReaHea_u),activate(y=hva_floor1_fivZonVAV_vAV2_oveZonLoc_yReaHea_activate)),
-		hva.floor1.fivZonVAV.vAV3.oveZonLoc.yDam(uExt(y=hva_floor1_fivZonVAV_vAV3_oveZonLoc_yDam_u),activate(y=hva_floor1_fivZonVAV_vAV3_oveZonLoc_yDam_activate)),
-		hva.floor1.fivZonVAV.vAV3.oveZonLoc.yReaHea(uExt(y=hva_floor1_fivZonVAV_vAV3_oveZonLoc_yReaHea_u),activate(y=hva_floor1_fivZonVAV_vAV3_oveZonLoc_yReaHea_activate)),
-		hva.floor1.fivZonVAV.vAV4.oveZonLoc.yDam(uExt(y=hva_floor1_fivZonVAV_vAV4_oveZonLoc_yDam_u),activate(y=hva_floor1_fivZonVAV_vAV4_oveZonLoc_yDam_activate)),
-		hva.floor1.fivZonVAV.vAV4.oveZonLoc.yReaHea(uExt(y=hva_floor1_fivZonVAV_vAV4_oveZonLoc_yReaHea_u),activate(y=hva_floor1_fivZonVAV_vAV4_oveZonLoc_yReaHea_activate)),
-		hva.floor1.fivZonVAV.vAV5.oveZonLoc.yDam(uExt(y=hva_floor1_fivZonVAV_vAV5_oveZonLoc_yDam_u),activate(y=hva_floor1_fivZonVAV_vAV5_oveZonLoc_yDam_activate)),
-		hva.floor1.fivZonVAV.vAV5.oveZonLoc.yReaHea(uExt(y=hva_floor1_fivZonVAV_vAV5_oveZonLoc_yReaHea_u),activate(y=hva_floor1_fivZonVAV_vAV5_oveZonLoc_yReaHea_activate)),
-		hva.floor1.oveZonCor.TZonCooSet(uExt(y=hva_floor1_oveZonCor_TZonCooSet_u),activate(y=hva_floor1_oveZonCor_TZonCooSet_activate)),
-		hva.floor1.oveZonCor.TZonHeaSet(uExt(y=hva_floor1_oveZonCor_TZonHeaSet_u),activate(y=hva_floor1_oveZonCor_TZonHeaSet_activate)),
-		hva.floor1.oveZonEas.TZonCooSet(uExt(y=hva_floor1_oveZonEas_TZonCooSet_u),activate(y=hva_floor1_oveZonEas_TZonCooSet_activate)),
-		hva.floor1.oveZonEas.TZonHeaSet(uExt(y=hva_floor1_oveZonEas_TZonHeaSet_u),activate(y=hva_floor1_oveZonEas_TZonHeaSet_activate)),
-		hva.floor1.oveZonNor.TZonCooSet(uExt(y=hva_floor1_oveZonNor_TZonCooSet_u),activate(y=hva_floor1_oveZonNor_TZonCooSet_activate)),
-		hva.floor1.oveZonNor.TZonHeaSet(uExt(y=hva_floor1_oveZonNor_TZonHeaSet_u),activate(y=hva_floor1_oveZonNor_TZonHeaSet_activate)),
-		hva.floor1.oveZonSou.TZonCooSet(uExt(y=hva_floor1_oveZonSou_TZonCooSet_u),activate(y=hva_floor1_oveZonSou_TZonCooSet_activate)),
-		hva.floor1.oveZonSou.TZonHeaSet(uExt(y=hva_floor1_oveZonSou_TZonHeaSet_u),activate(y=hva_floor1_oveZonSou_TZonHeaSet_activate)),
-		hva.floor1.oveZonWes.TZonCooSet(uExt(y=hva_floor1_oveZonWes_TZonCooSet_u),activate(y=hva_floor1_oveZonWes_TZonCooSet_activate)),
-		hva.floor1.oveZonWes.TZonHeaSet(uExt(y=hva_floor1_oveZonWes_TZonHeaSet_u),activate(y=hva_floor1_oveZonWes_TZonHeaSet_activate)),
-		hva.floor2.TSupAirSet(uExt(y=hva_floor2_TSupAirSet_u),activate(y=hva_floor2_TSupAirSet_activate)),
-		hva.floor2.dpSet(uExt(y=hva_floor2_dpSet_u),activate(y=hva_floor2_dpSet_activate)),
-		hva.floor2.duaFanAirHanUni.cooCoi.yCoo(uExt(y=hva_floor2_duaFanAirHanUni_cooCoi_yCoo_u),activate(y=hva_floor2_duaFanAirHanUni_cooCoi_yCoo_activate)),
-		hva.floor2.duaFanAirHanUni.mixingBox.mixBox.yEA(uExt(y=hva_floor2_duaFanAirHanUni_mixingBox_mixBox_yEA_u),activate(y=hva_floor2_duaFanAirHanUni_mixingBox_mixBox_yEA_activate)),
-		hva.floor2.duaFanAirHanUni.mixingBox.mixBox.yOA(uExt(y=hva_floor2_duaFanAirHanUni_mixingBox_mixBox_yOA_u),activate(y=hva_floor2_duaFanAirHanUni_mixingBox_mixBox_yOA_activate)),
-		hva.floor2.duaFanAirHanUni.mixingBox.mixBox.yRet(uExt(y=hva_floor2_duaFanAirHanUni_mixingBox_mixBox_yRet_u),activate(y=hva_floor2_duaFanAirHanUni_mixingBox_mixBox_yRet_activate)),
-		hva.floor2.duaFanAirHanUni.oveSpeRetFan(uExt(y=hva_floor2_duaFanAirHanUni_oveSpeRetFan_u),activate(y=hva_floor2_duaFanAirHanUni_oveSpeRetFan_activate)),
-		hva.floor2.duaFanAirHanUni.supFan.oveSpeSupFan(uExt(y=hva_floor2_duaFanAirHanUni_supFan_oveSpeSupFan_u),activate(y=hva_floor2_duaFanAirHanUni_supFan_oveSpeSupFan_activate)),
-		hva.floor2.fivZonVAV.vAV1.oveZonLoc.yDam(uExt(y=hva_floor2_fivZonVAV_vAV1_oveZonLoc_yDam_u),activate(y=hva_floor2_fivZonVAV_vAV1_oveZonLoc_yDam_activate)),
-		hva.floor2.fivZonVAV.vAV1.oveZonLoc.yReaHea(uExt(y=hva_floor2_fivZonVAV_vAV1_oveZonLoc_yReaHea_u),activate(y=hva_floor2_fivZonVAV_vAV1_oveZonLoc_yReaHea_activate)),
-		hva.floor2.fivZonVAV.vAV2.oveZonLoc.yDam(uExt(y=hva_floor2_fivZonVAV_vAV2_oveZonLoc_yDam_u),activate(y=hva_floor2_fivZonVAV_vAV2_oveZonLoc_yDam_activate)),
-		hva.floor2.fivZonVAV.vAV2.oveZonLoc.yReaHea(uExt(y=hva_floor2_fivZonVAV_vAV2_oveZonLoc_yReaHea_u),activate(y=hva_floor2_fivZonVAV_vAV2_oveZonLoc_yReaHea_activate)),
-		hva.floor2.fivZonVAV.vAV3.oveZonLoc.yDam(uExt(y=hva_floor2_fivZonVAV_vAV3_oveZonLoc_yDam_u),activate(y=hva_floor2_fivZonVAV_vAV3_oveZonLoc_yDam_activate)),
-		hva.floor2.fivZonVAV.vAV3.oveZonLoc.yReaHea(uExt(y=hva_floor2_fivZonVAV_vAV3_oveZonLoc_yReaHea_u),activate(y=hva_floor2_fivZonVAV_vAV3_oveZonLoc_yReaHea_activate)),
-		hva.floor2.fivZonVAV.vAV4.oveZonLoc.yDam(uExt(y=hva_floor2_fivZonVAV_vAV4_oveZonLoc_yDam_u),activate(y=hva_floor2_fivZonVAV_vAV4_oveZonLoc_yDam_activate)),
-		hva.floor2.fivZonVAV.vAV4.oveZonLoc.yReaHea(uExt(y=hva_floor2_fivZonVAV_vAV4_oveZonLoc_yReaHea_u),activate(y=hva_floor2_fivZonVAV_vAV4_oveZonLoc_yReaHea_activate)),
-		hva.floor2.fivZonVAV.vAV5.oveZonLoc.yDam(uExt(y=hva_floor2_fivZonVAV_vAV5_oveZonLoc_yDam_u),activate(y=hva_floor2_fivZonVAV_vAV5_oveZonLoc_yDam_activate)),
-		hva.floor2.fivZonVAV.vAV5.oveZonLoc.yReaHea(uExt(y=hva_floor2_fivZonVAV_vAV5_oveZonLoc_yReaHea_u),activate(y=hva_floor2_fivZonVAV_vAV5_oveZonLoc_yReaHea_activate)),
-		hva.floor2.oveZonCor.TZonCooSet(uExt(y=hva_floor2_oveZonCor_TZonCooSet_u),activate(y=hva_floor2_oveZonCor_TZonCooSet_activate)),
-		hva.floor2.oveZonCor.TZonHeaSet(uExt(y=hva_floor2_oveZonCor_TZonHeaSet_u),activate(y=hva_floor2_oveZonCor_TZonHeaSet_activate)),
-		hva.floor2.oveZonEas.TZonCooSet(uExt(y=hva_floor2_oveZonEas_TZonCooSet_u),activate(y=hva_floor2_oveZonEas_TZonCooSet_activate)),
-		hva.floor2.oveZonEas.TZonHeaSet(uExt(y=hva_floor2_oveZonEas_TZonHeaSet_u),activate(y=hva_floor2_oveZonEas_TZonHeaSet_activate)),
-		hva.floor2.oveZonNor.TZonCooSet(uExt(y=hva_floor2_oveZonNor_TZonCooSet_u),activate(y=hva_floor2_oveZonNor_TZonCooSet_activate)),
-		hva.floor2.oveZonNor.TZonHeaSet(uExt(y=hva_floor2_oveZonNor_TZonHeaSet_u),activate(y=hva_floor2_oveZonNor_TZonHeaSet_activate)),
-		hva.floor2.oveZonSou.TZonCooSet(uExt(y=hva_floor2_oveZonSou_TZonCooSet_u),activate(y=hva_floor2_oveZonSou_TZonCooSet_activate)),
-		hva.floor2.oveZonSou.TZonHeaSet(uExt(y=hva_floor2_oveZonSou_TZonHeaSet_u),activate(y=hva_floor2_oveZonSou_TZonHeaSet_activate)),
-		hva.floor2.oveZonWes.TZonCooSet(uExt(y=hva_floor2_oveZonWes_TZonCooSet_u),activate(y=hva_floor2_oveZonWes_TZonCooSet_activate)),
-		hva.floor2.oveZonWes.TZonHeaSet(uExt(y=hva_floor2_oveZonWes_TZonHeaSet_u),activate(y=hva_floor2_oveZonWes_TZonHeaSet_activate)),
-		hva.floor3.TSupAirSet(uExt(y=hva_floor3_TSupAirSet_u),activate(y=hva_floor3_TSupAirSet_activate)),
-		hva.floor3.dpSet(uExt(y=hva_floor3_dpSet_u),activate(y=hva_floor3_dpSet_activate)),
-		hva.floor3.duaFanAirHanUni.cooCoi.yCoo(uExt(y=hva_floor3_duaFanAirHanUni_cooCoi_yCoo_u),activate(y=hva_floor3_duaFanAirHanUni_cooCoi_yCoo_activate)),
-		hva.floor3.duaFanAirHanUni.mixingBox.mixBox.yEA(uExt(y=hva_floor3_duaFanAirHanUni_mixingBox_mixBox_yEA_u),activate(y=hva_floor3_duaFanAirHanUni_mixingBox_mixBox_yEA_activate)),
-		hva.floor3.duaFanAirHanUni.mixingBox.mixBox.yOA(uExt(y=hva_floor3_duaFanAirHanUni_mixingBox_mixBox_yOA_u),activate(y=hva_floor3_duaFanAirHanUni_mixingBox_mixBox_yOA_activate)),
-		hva.floor3.duaFanAirHanUni.mixingBox.mixBox.yRet(uExt(y=hva_floor3_duaFanAirHanUni_mixingBox_mixBox_yRet_u),activate(y=hva_floor3_duaFanAirHanUni_mixingBox_mixBox_yRet_activate)),
-		hva.floor3.duaFanAirHanUni.oveSpeRetFan(uExt(y=hva_floor3_duaFanAirHanUni_oveSpeRetFan_u),activate(y=hva_floor3_duaFanAirHanUni_oveSpeRetFan_activate)),
-		hva.floor3.duaFanAirHanUni.supFan.oveSpeSupFan(uExt(y=hva_floor3_duaFanAirHanUni_supFan_oveSpeSupFan_u),activate(y=hva_floor3_duaFanAirHanUni_supFan_oveSpeSupFan_activate)),
-		hva.floor3.fivZonVAV.vAV1.oveZonLoc.yDam(uExt(y=hva_floor3_fivZonVAV_vAV1_oveZonLoc_yDam_u),activate(y=hva_floor3_fivZonVAV_vAV1_oveZonLoc_yDam_activate)),
-		hva.floor3.fivZonVAV.vAV1.oveZonLoc.yReaHea(uExt(y=hva_floor3_fivZonVAV_vAV1_oveZonLoc_yReaHea_u),activate(y=hva_floor3_fivZonVAV_vAV1_oveZonLoc_yReaHea_activate)),
-		hva.floor3.fivZonVAV.vAV2.oveZonLoc.yDam(uExt(y=hva_floor3_fivZonVAV_vAV2_oveZonLoc_yDam_u),activate(y=hva_floor3_fivZonVAV_vAV2_oveZonLoc_yDam_activate)),
-		hva.floor3.fivZonVAV.vAV2.oveZonLoc.yReaHea(uExt(y=hva_floor3_fivZonVAV_vAV2_oveZonLoc_yReaHea_u),activate(y=hva_floor3_fivZonVAV_vAV2_oveZonLoc_yReaHea_activate)),
-		hva.floor3.fivZonVAV.vAV3.oveZonLoc.yDam(uExt(y=hva_floor3_fivZonVAV_vAV3_oveZonLoc_yDam_u),activate(y=hva_floor3_fivZonVAV_vAV3_oveZonLoc_yDam_activate)),
-		hva.floor3.fivZonVAV.vAV3.oveZonLoc.yReaHea(uExt(y=hva_floor3_fivZonVAV_vAV3_oveZonLoc_yReaHea_u),activate(y=hva_floor3_fivZonVAV_vAV3_oveZonLoc_yReaHea_activate)),
-		hva.floor3.fivZonVAV.vAV4.oveZonLoc.yDam(uExt(y=hva_floor3_fivZonVAV_vAV4_oveZonLoc_yDam_u),activate(y=hva_floor3_fivZonVAV_vAV4_oveZonLoc_yDam_activate)),
-		hva.floor3.fivZonVAV.vAV4.oveZonLoc.yReaHea(uExt(y=hva_floor3_fivZonVAV_vAV4_oveZonLoc_yReaHea_u),activate(y=hva_floor3_fivZonVAV_vAV4_oveZonLoc_yReaHea_activate)),
-		hva.floor3.fivZonVAV.vAV5.oveZonLoc.yDam(uExt(y=hva_floor3_fivZonVAV_vAV5_oveZonLoc_yDam_u),activate(y=hva_floor3_fivZonVAV_vAV5_oveZonLoc_yDam_activate)),
-		hva.floor3.fivZonVAV.vAV5.oveZonLoc.yReaHea(uExt(y=hva_floor3_fivZonVAV_vAV5_oveZonLoc_yReaHea_u),activate(y=hva_floor3_fivZonVAV_vAV5_oveZonLoc_yReaHea_activate)),
-		hva.floor3.oveZonCor.TZonCooSet(uExt(y=hva_floor3_oveZonCor_TZonCooSet_u),activate(y=hva_floor3_oveZonCor_TZonCooSet_activate)),
-		hva.floor3.oveZonCor.TZonHeaSet(uExt(y=hva_floor3_oveZonCor_TZonHeaSet_u),activate(y=hva_floor3_oveZonCor_TZonHeaSet_activate)),
-		hva.floor3.oveZonEas.TZonCooSet(uExt(y=hva_floor3_oveZonEas_TZonCooSet_u),activate(y=hva_floor3_oveZonEas_TZonCooSet_activate)),
-		hva.floor3.oveZonEas.TZonHeaSet(uExt(y=hva_floor3_oveZonEas_TZonHeaSet_u),activate(y=hva_floor3_oveZonEas_TZonHeaSet_activate)),
-		hva.floor3.oveZonNor.TZonCooSet(uExt(y=hva_floor3_oveZonNor_TZonCooSet_u),activate(y=hva_floor3_oveZonNor_TZonCooSet_activate)),
-		hva.floor3.oveZonNor.TZonHeaSet(uExt(y=hva_floor3_oveZonNor_TZonHeaSet_u),activate(y=hva_floor3_oveZonNor_TZonHeaSet_activate)),
-		hva.floor3.oveZonSou.TZonCooSet(uExt(y=hva_floor3_oveZonSou_TZonCooSet_u),activate(y=hva_floor3_oveZonSou_TZonCooSet_activate)),
-		hva.floor3.oveZonSou.TZonHeaSet(uExt(y=hva_floor3_oveZonSou_TZonHeaSet_u),activate(y=hva_floor3_oveZonSou_TZonHeaSet_activate)),
-		hva.floor3.oveZonWes.TZonCooSet(uExt(y=hva_floor3_oveZonWes_TZonCooSet_u),activate(y=hva_floor3_oveZonWes_TZonCooSet_activate)),
-		hva.floor3.oveZonWes.TZonHeaSet(uExt(y=hva_floor3_oveZonWes_TZonHeaSet_u),activate(y=hva_floor3_oveZonWes_TZonHeaSet_activate)),
-		hva.oveChiWatSys.TW_set(uExt(y=hva_oveChiWatSys_TW_set_u),activate(y=hva_oveChiWatSys_TW_set_activate)),
-		hva.oveChiWatSys.dp_set(uExt(y=hva_oveChiWatSys_dp_set_u),activate(y=hva_oveChiWatSys_dp_set_activate)),
-		hva.oveHotWatSys.TW_set(uExt(y=hva_oveHotWatSys_TW_set_u),activate(y=hva_oveHotWatSys_TW_set_activate)),
-		hva.oveHotWatSys.dp_set(uExt(y=hva_oveHotWatSys_dp_set_u),activate(y=hva_oveHotWatSys_dp_set_activate))) "Original model with overwrites";
+ // Input overwrite
+ Modelica.Blocks.Interfaces.RealInput hva_floor1_TSupAirSet_u(unit="K", min=285.15, max=313.15) "Supply air temperature setpoint for AHU";
+ Modelica.Blocks.Interfaces.BooleanInput hva_floor1_TSupAirSet_activate "Activation for Supply air temperature setpoint for AHU";
+ Modelica.Blocks.Interfaces.RealInput hva_floor1_dpSet_u(unit="Pa", min=50.0, max=410.0) "Supply duct pressure setpoint for AHU";
+ Modelica.Blocks.Interfaces.BooleanInput hva_floor1_dpSet_activate "Activation for Supply duct pressure setpoint for AHU";
+ Modelica.Blocks.Interfaces.RealInput hva_floor1_duaFanAirHanUni_cooCoi_yCoo_u(unit="1", min=0.0, max=1.0) "Cooling coil valve control signal for AHU";
+ Modelica.Blocks.Interfaces.BooleanInput hva_floor1_duaFanAirHanUni_cooCoi_yCoo_activate "Activation for Cooling coil valve control signal for AHU";
+ Modelica.Blocks.Interfaces.RealInput hva_floor1_duaFanAirHanUni_mixingBox_mixBox_yEA_u(unit="1", min=0.0, max=1.0) "Exhaust air damper position setpoint for AHU";
+ Modelica.Blocks.Interfaces.BooleanInput hva_floor1_duaFanAirHanUni_mixingBox_mixBox_yEA_activate "Activation for Exhaust air damper position setpoint for AHU";
+ Modelica.Blocks.Interfaces.RealInput hva_floor1_duaFanAirHanUni_mixingBox_mixBox_yOA_u(unit="1", min=0.0, max=1.0) "Outside air damper position setpoint for AHU";
+ Modelica.Blocks.Interfaces.BooleanInput hva_floor1_duaFanAirHanUni_mixingBox_mixBox_yOA_activate "Activation for Outside air damper position setpoint for AHU";
+ Modelica.Blocks.Interfaces.RealInput hva_floor1_duaFanAirHanUni_mixingBox_mixBox_yRet_u(unit="1", min=0.0, max=1.0) "Return air damper position setpoint for AHU";
+ Modelica.Blocks.Interfaces.BooleanInput hva_floor1_duaFanAirHanUni_mixingBox_mixBox_yRet_activate "Activation for Return air damper position setpoint for AHU";
+ Modelica.Blocks.Interfaces.RealInput hva_floor1_duaFanAirHanUni_oveSpeRetFan_u(unit="1", min=0.0, max=1.0) "AHU return fan speed control signal";
+ Modelica.Blocks.Interfaces.BooleanInput hva_floor1_duaFanAirHanUni_oveSpeRetFan_activate "Activation for AHU return fan speed control signal";
+ Modelica.Blocks.Interfaces.RealInput hva_floor1_duaFanAirHanUni_supFan_oveSpeSupFan_u(unit="1", min=0.0, max=1.0) "AHU supply fan speed control signal";
+ Modelica.Blocks.Interfaces.BooleanInput hva_floor1_duaFanAirHanUni_supFan_oveSpeSupFan_activate "Activation for AHU supply fan speed control signal";
+ Modelica.Blocks.Interfaces.RealInput hva_floor1_fivZonVAV_vAV1_oveZonLoc_yDam_u(unit="1", min=0.0, max=1.0) "Damper position setpoint for zone cor";
+ Modelica.Blocks.Interfaces.BooleanInput hva_floor1_fivZonVAV_vAV1_oveZonLoc_yDam_activate "Activation for Damper position setpoint for zone cor";
+ Modelica.Blocks.Interfaces.RealInput hva_floor1_fivZonVAV_vAV1_oveZonLoc_yReaHea_u(unit="1", min=0.0, max=1.0) "Reheat control signal for zone cor";
+ Modelica.Blocks.Interfaces.BooleanInput hva_floor1_fivZonVAV_vAV1_oveZonLoc_yReaHea_activate "Activation for Reheat control signal for zone cor";
+ Modelica.Blocks.Interfaces.RealInput hva_floor1_fivZonVAV_vAV2_oveZonLoc_yDam_u(unit="1", min=0.0, max=1.0) "Damper position setpoint for zone sou";
+ Modelica.Blocks.Interfaces.BooleanInput hva_floor1_fivZonVAV_vAV2_oveZonLoc_yDam_activate "Activation for Damper position setpoint for zone sou";
+ Modelica.Blocks.Interfaces.RealInput hva_floor1_fivZonVAV_vAV2_oveZonLoc_yReaHea_u(unit="1", min=0.0, max=1.0) "Reheat control signal for zone sou";
+ Modelica.Blocks.Interfaces.BooleanInput hva_floor1_fivZonVAV_vAV2_oveZonLoc_yReaHea_activate "Activation for Reheat control signal for zone sou";
+ Modelica.Blocks.Interfaces.RealInput hva_floor1_fivZonVAV_vAV3_oveZonLoc_yDam_u(unit="1", min=0.0, max=1.0) "Damper position setpoint for zone eas";
+ Modelica.Blocks.Interfaces.BooleanInput hva_floor1_fivZonVAV_vAV3_oveZonLoc_yDam_activate "Activation for Damper position setpoint for zone eas";
+ Modelica.Blocks.Interfaces.RealInput hva_floor1_fivZonVAV_vAV3_oveZonLoc_yReaHea_u(unit="1", min=0.0, max=1.0) "Reheat control signal for zone eas";
+ Modelica.Blocks.Interfaces.BooleanInput hva_floor1_fivZonVAV_vAV3_oveZonLoc_yReaHea_activate "Activation for Reheat control signal for zone eas";
+ Modelica.Blocks.Interfaces.RealInput hva_floor1_fivZonVAV_vAV4_oveZonLoc_yDam_u(unit="1", min=0.0, max=1.0) "Damper position setpoint for zone nor";
+ Modelica.Blocks.Interfaces.BooleanInput hva_floor1_fivZonVAV_vAV4_oveZonLoc_yDam_activate "Activation for Damper position setpoint for zone nor";
+ Modelica.Blocks.Interfaces.RealInput hva_floor1_fivZonVAV_vAV4_oveZonLoc_yReaHea_u(unit="1", min=0.0, max=1.0) "Reheat control signal for zone nor";
+ Modelica.Blocks.Interfaces.BooleanInput hva_floor1_fivZonVAV_vAV4_oveZonLoc_yReaHea_activate "Activation for Reheat control signal for zone nor";
+ Modelica.Blocks.Interfaces.RealInput hva_floor1_fivZonVAV_vAV5_oveZonLoc_yDam_u(unit="1", min=0.0, max=1.0) "Damper position setpoint for zone wes";
+ Modelica.Blocks.Interfaces.BooleanInput hva_floor1_fivZonVAV_vAV5_oveZonLoc_yDam_activate "Activation for Damper position setpoint for zone wes";
+ Modelica.Blocks.Interfaces.RealInput hva_floor1_fivZonVAV_vAV5_oveZonLoc_yReaHea_u(unit="1", min=0.0, max=1.0) "Reheat control signal for zone wes";
+ Modelica.Blocks.Interfaces.BooleanInput hva_floor1_fivZonVAV_vAV5_oveZonLoc_yReaHea_activate "Activation for Reheat control signal for zone wes";
+ Modelica.Blocks.Interfaces.RealInput hva_floor1_oveZonCor_TZonCooSet_u(unit="K", min=285.15, max=313.15) "Zone air temperature cooling setpoint for zone bot_floor_cor";
+ Modelica.Blocks.Interfaces.BooleanInput hva_floor1_oveZonCor_TZonCooSet_activate "Activation for Zone air temperature cooling setpoint for zone bot_floor_cor";
+ Modelica.Blocks.Interfaces.RealInput hva_floor1_oveZonCor_TZonHeaSet_u(unit="K", min=285.15, max=313.15) "Zone air temperature heating setpoint for zone bot_floor_cor";
+ Modelica.Blocks.Interfaces.BooleanInput hva_floor1_oveZonCor_TZonHeaSet_activate "Activation for Zone air temperature heating setpoint for zone bot_floor_cor";
+ Modelica.Blocks.Interfaces.RealInput hva_floor1_oveZonEas_TZonCooSet_u(unit="K", min=285.15, max=313.15) "Zone air temperature cooling setpoint for zone bot_floor_eas";
+ Modelica.Blocks.Interfaces.BooleanInput hva_floor1_oveZonEas_TZonCooSet_activate "Activation for Zone air temperature cooling setpoint for zone bot_floor_eas";
+ Modelica.Blocks.Interfaces.RealInput hva_floor1_oveZonEas_TZonHeaSet_u(unit="K", min=285.15, max=313.15) "Zone air temperature heating setpoint for zone bot_floor_eas";
+ Modelica.Blocks.Interfaces.BooleanInput hva_floor1_oveZonEas_TZonHeaSet_activate "Activation for Zone air temperature heating setpoint for zone bot_floor_eas";
+ Modelica.Blocks.Interfaces.RealInput hva_floor1_oveZonNor_TZonCooSet_u(unit="K", min=285.15, max=313.15) "Zone air temperature cooling setpoint for zone bot_floor_nor";
+ Modelica.Blocks.Interfaces.BooleanInput hva_floor1_oveZonNor_TZonCooSet_activate "Activation for Zone air temperature cooling setpoint for zone bot_floor_nor";
+ Modelica.Blocks.Interfaces.RealInput hva_floor1_oveZonNor_TZonHeaSet_u(unit="K", min=285.15, max=313.15) "Zone air temperature heating setpoint for zone bot_floor_nor";
+ Modelica.Blocks.Interfaces.BooleanInput hva_floor1_oveZonNor_TZonHeaSet_activate "Activation for Zone air temperature heating setpoint for zone bot_floor_nor";
+ Modelica.Blocks.Interfaces.RealInput hva_floor1_oveZonSou_TZonCooSet_u(unit="K", min=285.15, max=313.15) "Zone air temperature cooling setpoint for zone bot_floor_sou";
+ Modelica.Blocks.Interfaces.BooleanInput hva_floor1_oveZonSou_TZonCooSet_activate "Activation for Zone air temperature cooling setpoint for zone bot_floor_sou";
+ Modelica.Blocks.Interfaces.RealInput hva_floor1_oveZonSou_TZonHeaSet_u(unit="K", min=285.15, max=313.15) "Zone air temperature heating setpoint for zone bot_floor_sou";
+ Modelica.Blocks.Interfaces.BooleanInput hva_floor1_oveZonSou_TZonHeaSet_activate "Activation for Zone air temperature heating setpoint for zone bot_floor_sou";
+ Modelica.Blocks.Interfaces.RealInput hva_floor1_oveZonWes_TZonCooSet_u(unit="K", min=285.15, max=313.15) "Zone air temperature cooling setpoint for zone bot_floor_wes";
+ Modelica.Blocks.Interfaces.BooleanInput hva_floor1_oveZonWes_TZonCooSet_activate "Activation for Zone air temperature cooling setpoint for zone bot_floor_wes";
+ Modelica.Blocks.Interfaces.RealInput hva_floor1_oveZonWes_TZonHeaSet_u(unit="K", min=285.15, max=313.15) "Zone air temperature heating setpoint for zone bot_floor_wes";
+ Modelica.Blocks.Interfaces.BooleanInput hva_floor1_oveZonWes_TZonHeaSet_activate "Activation for Zone air temperature heating setpoint for zone bot_floor_wes";
+ Modelica.Blocks.Interfaces.RealInput hva_floor2_TSupAirSet_u(unit="K", min=285.15, max=313.15) "Supply air temperature setpoint for AHU";
+ Modelica.Blocks.Interfaces.BooleanInput hva_floor2_TSupAirSet_activate "Activation for Supply air temperature setpoint for AHU";
+ Modelica.Blocks.Interfaces.RealInput hva_floor2_dpSet_u(unit="Pa", min=50.0, max=410.0) "Supply duct pressure setpoint for AHU";
+ Modelica.Blocks.Interfaces.BooleanInput hva_floor2_dpSet_activate "Activation for Supply duct pressure setpoint for AHU";
+ Modelica.Blocks.Interfaces.RealInput hva_floor2_duaFanAirHanUni_cooCoi_yCoo_u(unit="1", min=0.0, max=1.0) "Cooling coil valve control signal for AHU";
+ Modelica.Blocks.Interfaces.BooleanInput hva_floor2_duaFanAirHanUni_cooCoi_yCoo_activate "Activation for Cooling coil valve control signal for AHU";
+ Modelica.Blocks.Interfaces.RealInput hva_floor2_duaFanAirHanUni_mixingBox_mixBox_yEA_u(unit="1", min=0.0, max=1.0) "Exhaust air damper position setpoint for AHU";
+ Modelica.Blocks.Interfaces.BooleanInput hva_floor2_duaFanAirHanUni_mixingBox_mixBox_yEA_activate "Activation for Exhaust air damper position setpoint for AHU";
+ Modelica.Blocks.Interfaces.RealInput hva_floor2_duaFanAirHanUni_mixingBox_mixBox_yOA_u(unit="1", min=0.0, max=1.0) "Outside air damper position setpoint for AHU";
+ Modelica.Blocks.Interfaces.BooleanInput hva_floor2_duaFanAirHanUni_mixingBox_mixBox_yOA_activate "Activation for Outside air damper position setpoint for AHU";
+ Modelica.Blocks.Interfaces.RealInput hva_floor2_duaFanAirHanUni_mixingBox_mixBox_yRet_u(unit="1", min=0.0, max=1.0) "Return air damper position setpoint for AHU";
+ Modelica.Blocks.Interfaces.BooleanInput hva_floor2_duaFanAirHanUni_mixingBox_mixBox_yRet_activate "Activation for Return air damper position setpoint for AHU";
+ Modelica.Blocks.Interfaces.RealInput hva_floor2_duaFanAirHanUni_oveSpeRetFan_u(unit="1", min=0.0, max=1.0) "AHU return fan speed control signal";
+ Modelica.Blocks.Interfaces.BooleanInput hva_floor2_duaFanAirHanUni_oveSpeRetFan_activate "Activation for AHU return fan speed control signal";
+ Modelica.Blocks.Interfaces.RealInput hva_floor2_duaFanAirHanUni_supFan_oveSpeSupFan_u(unit="1", min=0.0, max=1.0) "AHU supply fan speed control signal";
+ Modelica.Blocks.Interfaces.BooleanInput hva_floor2_duaFanAirHanUni_supFan_oveSpeSupFan_activate "Activation for AHU supply fan speed control signal";
+ Modelica.Blocks.Interfaces.RealInput hva_floor2_fivZonVAV_vAV1_oveZonLoc_yDam_u(unit="1", min=0.0, max=1.0) "Damper position setpoint for zone cor";
+ Modelica.Blocks.Interfaces.BooleanInput hva_floor2_fivZonVAV_vAV1_oveZonLoc_yDam_activate "Activation for Damper position setpoint for zone cor";
+ Modelica.Blocks.Interfaces.RealInput hva_floor2_fivZonVAV_vAV1_oveZonLoc_yReaHea_u(unit="1", min=0.0, max=1.0) "Reheat control signal for zone cor";
+ Modelica.Blocks.Interfaces.BooleanInput hva_floor2_fivZonVAV_vAV1_oveZonLoc_yReaHea_activate "Activation for Reheat control signal for zone cor";
+ Modelica.Blocks.Interfaces.RealInput hva_floor2_fivZonVAV_vAV2_oveZonLoc_yDam_u(unit="1", min=0.0, max=1.0) "Damper position setpoint for zone sou";
+ Modelica.Blocks.Interfaces.BooleanInput hva_floor2_fivZonVAV_vAV2_oveZonLoc_yDam_activate "Activation for Damper position setpoint for zone sou";
+ Modelica.Blocks.Interfaces.RealInput hva_floor2_fivZonVAV_vAV2_oveZonLoc_yReaHea_u(unit="1", min=0.0, max=1.0) "Reheat control signal for zone sou";
+ Modelica.Blocks.Interfaces.BooleanInput hva_floor2_fivZonVAV_vAV2_oveZonLoc_yReaHea_activate "Activation for Reheat control signal for zone sou";
+ Modelica.Blocks.Interfaces.RealInput hva_floor2_fivZonVAV_vAV3_oveZonLoc_yDam_u(unit="1", min=0.0, max=1.0) "Damper position setpoint for zone eas";
+ Modelica.Blocks.Interfaces.BooleanInput hva_floor2_fivZonVAV_vAV3_oveZonLoc_yDam_activate "Activation for Damper position setpoint for zone eas";
+ Modelica.Blocks.Interfaces.RealInput hva_floor2_fivZonVAV_vAV3_oveZonLoc_yReaHea_u(unit="1", min=0.0, max=1.0) "Reheat control signal for zone eas";
+ Modelica.Blocks.Interfaces.BooleanInput hva_floor2_fivZonVAV_vAV3_oveZonLoc_yReaHea_activate "Activation for Reheat control signal for zone eas";
+ Modelica.Blocks.Interfaces.RealInput hva_floor2_fivZonVAV_vAV4_oveZonLoc_yDam_u(unit="1", min=0.0, max=1.0) "Damper position setpoint for zone nor";
+ Modelica.Blocks.Interfaces.BooleanInput hva_floor2_fivZonVAV_vAV4_oveZonLoc_yDam_activate "Activation for Damper position setpoint for zone nor";
+ Modelica.Blocks.Interfaces.RealInput hva_floor2_fivZonVAV_vAV4_oveZonLoc_yReaHea_u(unit="1", min=0.0, max=1.0) "Reheat control signal for zone nor";
+ Modelica.Blocks.Interfaces.BooleanInput hva_floor2_fivZonVAV_vAV4_oveZonLoc_yReaHea_activate "Activation for Reheat control signal for zone nor";
+ Modelica.Blocks.Interfaces.RealInput hva_floor2_fivZonVAV_vAV5_oveZonLoc_yDam_u(unit="1", min=0.0, max=1.0) "Damper position setpoint for zone wes";
+ Modelica.Blocks.Interfaces.BooleanInput hva_floor2_fivZonVAV_vAV5_oveZonLoc_yDam_activate "Activation for Damper position setpoint for zone wes";
+ Modelica.Blocks.Interfaces.RealInput hva_floor2_fivZonVAV_vAV5_oveZonLoc_yReaHea_u(unit="1", min=0.0, max=1.0) "Reheat control signal for zone wes";
+ Modelica.Blocks.Interfaces.BooleanInput hva_floor2_fivZonVAV_vAV5_oveZonLoc_yReaHea_activate "Activation for Reheat control signal for zone wes";
+ Modelica.Blocks.Interfaces.RealInput hva_floor2_oveZonCor_TZonCooSet_u(unit="K", min=285.15, max=313.15) "Zone air temperature cooling setpoint for zone mid_floor_cor";
+ Modelica.Blocks.Interfaces.BooleanInput hva_floor2_oveZonCor_TZonCooSet_activate "Activation for Zone air temperature cooling setpoint for zone mid_floor_cor";
+ Modelica.Blocks.Interfaces.RealInput hva_floor2_oveZonCor_TZonHeaSet_u(unit="K", min=285.15, max=313.15) "Zone air temperature heating setpoint for zone mid_floor_cor";
+ Modelica.Blocks.Interfaces.BooleanInput hva_floor2_oveZonCor_TZonHeaSet_activate "Activation for Zone air temperature heating setpoint for zone mid_floor_cor";
+ Modelica.Blocks.Interfaces.RealInput hva_floor2_oveZonEas_TZonCooSet_u(unit="K", min=285.15, max=313.15) "Zone air temperature cooling setpoint for zone mid_floor_eas";
+ Modelica.Blocks.Interfaces.BooleanInput hva_floor2_oveZonEas_TZonCooSet_activate "Activation for Zone air temperature cooling setpoint for zone mid_floor_eas";
+ Modelica.Blocks.Interfaces.RealInput hva_floor2_oveZonEas_TZonHeaSet_u(unit="K", min=285.15, max=313.15) "Zone air temperature heating setpoint for zone mid_floor_eas";
+ Modelica.Blocks.Interfaces.BooleanInput hva_floor2_oveZonEas_TZonHeaSet_activate "Activation for Zone air temperature heating setpoint for zone mid_floor_eas";
+ Modelica.Blocks.Interfaces.RealInput hva_floor2_oveZonNor_TZonCooSet_u(unit="K", min=285.15, max=313.15) "Zone air temperature cooling setpoint for zone mid_floor_nor";
+ Modelica.Blocks.Interfaces.BooleanInput hva_floor2_oveZonNor_TZonCooSet_activate "Activation for Zone air temperature cooling setpoint for zone mid_floor_nor";
+ Modelica.Blocks.Interfaces.RealInput hva_floor2_oveZonNor_TZonHeaSet_u(unit="K", min=285.15, max=313.15) "Zone air temperature heating setpoint for zone mid_floor_nor";
+ Modelica.Blocks.Interfaces.BooleanInput hva_floor2_oveZonNor_TZonHeaSet_activate "Activation for Zone air temperature heating setpoint for zone mid_floor_nor";
+ Modelica.Blocks.Interfaces.RealInput hva_floor2_oveZonSou_TZonCooSet_u(unit="K", min=285.15, max=313.15) "Zone air temperature cooling setpoint for zone mid_floor_sou";
+ Modelica.Blocks.Interfaces.BooleanInput hva_floor2_oveZonSou_TZonCooSet_activate "Activation for Zone air temperature cooling setpoint for zone mid_floor_sou";
+ Modelica.Blocks.Interfaces.RealInput hva_floor2_oveZonSou_TZonHeaSet_u(unit="K", min=285.15, max=313.15) "Zone air temperature heating setpoint for zone mid_floor_sou";
+ Modelica.Blocks.Interfaces.BooleanInput hva_floor2_oveZonSou_TZonHeaSet_activate "Activation for Zone air temperature heating setpoint for zone mid_floor_sou";
+ Modelica.Blocks.Interfaces.RealInput hva_floor2_oveZonWes_TZonCooSet_u(unit="K", min=285.15, max=313.15) "Zone air temperature cooling setpoint for zone mid_floor_wes";
+ Modelica.Blocks.Interfaces.BooleanInput hva_floor2_oveZonWes_TZonCooSet_activate "Activation for Zone air temperature cooling setpoint for zone mid_floor_wes";
+ Modelica.Blocks.Interfaces.RealInput hva_floor2_oveZonWes_TZonHeaSet_u(unit="K", min=285.15, max=313.15) "Zone air temperature heating setpoint for zone mid_floor_wes";
+ Modelica.Blocks.Interfaces.BooleanInput hva_floor2_oveZonWes_TZonHeaSet_activate "Activation for Zone air temperature heating setpoint for zone mid_floor_wes";
+ Modelica.Blocks.Interfaces.RealInput hva_floor3_TSupAirSet_u(unit="K", min=285.15, max=313.15) "Supply air temperature setpoint for AHU";
+ Modelica.Blocks.Interfaces.BooleanInput hva_floor3_TSupAirSet_activate "Activation for Supply air temperature setpoint for AHU";
+ Modelica.Blocks.Interfaces.RealInput hva_floor3_dpSet_u(unit="Pa", min=50.0, max=410.0) "Supply duct pressure setpoint for AHU";
+ Modelica.Blocks.Interfaces.BooleanInput hva_floor3_dpSet_activate "Activation for Supply duct pressure setpoint for AHU";
+ Modelica.Blocks.Interfaces.RealInput hva_floor3_duaFanAirHanUni_cooCoi_yCoo_u(unit="1", min=0.0, max=1.0) "Cooling coil valve control signal for AHU";
+ Modelica.Blocks.Interfaces.BooleanInput hva_floor3_duaFanAirHanUni_cooCoi_yCoo_activate "Activation for Cooling coil valve control signal for AHU";
+ Modelica.Blocks.Interfaces.RealInput hva_floor3_duaFanAirHanUni_mixingBox_mixBox_yEA_u(unit="1", min=0.0, max=1.0) "Exhaust air damper position setpoint for AHU";
+ Modelica.Blocks.Interfaces.BooleanInput hva_floor3_duaFanAirHanUni_mixingBox_mixBox_yEA_activate "Activation for Exhaust air damper position setpoint for AHU";
+ Modelica.Blocks.Interfaces.RealInput hva_floor3_duaFanAirHanUni_mixingBox_mixBox_yOA_u(unit="1", min=0.0, max=1.0) "Outside air damper position setpoint for AHU";
+ Modelica.Blocks.Interfaces.BooleanInput hva_floor3_duaFanAirHanUni_mixingBox_mixBox_yOA_activate "Activation for Outside air damper position setpoint for AHU";
+ Modelica.Blocks.Interfaces.RealInput hva_floor3_duaFanAirHanUni_mixingBox_mixBox_yRet_u(unit="1", min=0.0, max=1.0) "Return air damper position setpoint for AHU";
+ Modelica.Blocks.Interfaces.BooleanInput hva_floor3_duaFanAirHanUni_mixingBox_mixBox_yRet_activate "Activation for Return air damper position setpoint for AHU";
+ Modelica.Blocks.Interfaces.RealInput hva_floor3_duaFanAirHanUni_oveSpeRetFan_u(unit="1", min=0.0, max=1.0) "AHU return fan speed control signal";
+ Modelica.Blocks.Interfaces.BooleanInput hva_floor3_duaFanAirHanUni_oveSpeRetFan_activate "Activation for AHU return fan speed control signal";
+ Modelica.Blocks.Interfaces.RealInput hva_floor3_duaFanAirHanUni_supFan_oveSpeSupFan_u(unit="1", min=0.0, max=1.0) "AHU supply fan speed control signal";
+ Modelica.Blocks.Interfaces.BooleanInput hva_floor3_duaFanAirHanUni_supFan_oveSpeSupFan_activate "Activation for AHU supply fan speed control signal";
+ Modelica.Blocks.Interfaces.RealInput hva_floor3_fivZonVAV_vAV1_oveZonLoc_yDam_u(unit="1", min=0.0, max=1.0) "Damper position setpoint for zone cor";
+ Modelica.Blocks.Interfaces.BooleanInput hva_floor3_fivZonVAV_vAV1_oveZonLoc_yDam_activate "Activation for Damper position setpoint for zone cor";
+ Modelica.Blocks.Interfaces.RealInput hva_floor3_fivZonVAV_vAV1_oveZonLoc_yReaHea_u(unit="1", min=0.0, max=1.0) "Reheat control signal for zone cor";
+ Modelica.Blocks.Interfaces.BooleanInput hva_floor3_fivZonVAV_vAV1_oveZonLoc_yReaHea_activate "Activation for Reheat control signal for zone cor";
+ Modelica.Blocks.Interfaces.RealInput hva_floor3_fivZonVAV_vAV2_oveZonLoc_yDam_u(unit="1", min=0.0, max=1.0) "Damper position setpoint for zone sou";
+ Modelica.Blocks.Interfaces.BooleanInput hva_floor3_fivZonVAV_vAV2_oveZonLoc_yDam_activate "Activation for Damper position setpoint for zone sou";
+ Modelica.Blocks.Interfaces.RealInput hva_floor3_fivZonVAV_vAV2_oveZonLoc_yReaHea_u(unit="1", min=0.0, max=1.0) "Reheat control signal for zone sou";
+ Modelica.Blocks.Interfaces.BooleanInput hva_floor3_fivZonVAV_vAV2_oveZonLoc_yReaHea_activate "Activation for Reheat control signal for zone sou";
+ Modelica.Blocks.Interfaces.RealInput hva_floor3_fivZonVAV_vAV3_oveZonLoc_yDam_u(unit="1", min=0.0, max=1.0) "Damper position setpoint for zone eas";
+ Modelica.Blocks.Interfaces.BooleanInput hva_floor3_fivZonVAV_vAV3_oveZonLoc_yDam_activate "Activation for Damper position setpoint for zone eas";
+ Modelica.Blocks.Interfaces.RealInput hva_floor3_fivZonVAV_vAV3_oveZonLoc_yReaHea_u(unit="1", min=0.0, max=1.0) "Reheat control signal for zone eas";
+ Modelica.Blocks.Interfaces.BooleanInput hva_floor3_fivZonVAV_vAV3_oveZonLoc_yReaHea_activate "Activation for Reheat control signal for zone eas";
+ Modelica.Blocks.Interfaces.RealInput hva_floor3_fivZonVAV_vAV4_oveZonLoc_yDam_u(unit="1", min=0.0, max=1.0) "Damper position setpoint for zone nor";
+ Modelica.Blocks.Interfaces.BooleanInput hva_floor3_fivZonVAV_vAV4_oveZonLoc_yDam_activate "Activation for Damper position setpoint for zone nor";
+ Modelica.Blocks.Interfaces.RealInput hva_floor3_fivZonVAV_vAV4_oveZonLoc_yReaHea_u(unit="1", min=0.0, max=1.0) "Reheat control signal for zone nor";
+ Modelica.Blocks.Interfaces.BooleanInput hva_floor3_fivZonVAV_vAV4_oveZonLoc_yReaHea_activate "Activation for Reheat control signal for zone nor";
+ Modelica.Blocks.Interfaces.RealInput hva_floor3_fivZonVAV_vAV5_oveZonLoc_yDam_u(unit="1", min=0.0, max=1.0) "Damper position setpoint for zone wes";
+ Modelica.Blocks.Interfaces.BooleanInput hva_floor3_fivZonVAV_vAV5_oveZonLoc_yDam_activate "Activation for Damper position setpoint for zone wes";
+ Modelica.Blocks.Interfaces.RealInput hva_floor3_fivZonVAV_vAV5_oveZonLoc_yReaHea_u(unit="1", min=0.0, max=1.0) "Reheat control signal for zone wes";
+ Modelica.Blocks.Interfaces.BooleanInput hva_floor3_fivZonVAV_vAV5_oveZonLoc_yReaHea_activate "Activation for Reheat control signal for zone wes";
+ Modelica.Blocks.Interfaces.RealInput hva_floor3_oveZonCor_TZonCooSet_u(unit="K", min=285.15, max=313.15) "Zone air temperature cooling setpoint for zone top_floor_cor";
+ Modelica.Blocks.Interfaces.BooleanInput hva_floor3_oveZonCor_TZonCooSet_activate "Activation for Zone air temperature cooling setpoint for zone top_floor_cor";
+ Modelica.Blocks.Interfaces.RealInput hva_floor3_oveZonCor_TZonHeaSet_u(unit="K", min=285.15, max=313.15) "Zone air temperature heating setpoint for zone top_floor_cor";
+ Modelica.Blocks.Interfaces.BooleanInput hva_floor3_oveZonCor_TZonHeaSet_activate "Activation for Zone air temperature heating setpoint for zone top_floor_cor";
+ Modelica.Blocks.Interfaces.RealInput hva_floor3_oveZonEas_TZonCooSet_u(unit="K", min=285.15, max=313.15) "Zone air temperature cooling setpoint for zone top_floor_eas";
+ Modelica.Blocks.Interfaces.BooleanInput hva_floor3_oveZonEas_TZonCooSet_activate "Activation for Zone air temperature cooling setpoint for zone top_floor_eas";
+ Modelica.Blocks.Interfaces.RealInput hva_floor3_oveZonEas_TZonHeaSet_u(unit="K", min=285.15, max=313.15) "Zone air temperature heating setpoint for zone top_floor_eas";
+ Modelica.Blocks.Interfaces.BooleanInput hva_floor3_oveZonEas_TZonHeaSet_activate "Activation for Zone air temperature heating setpoint for zone top_floor_eas";
+ Modelica.Blocks.Interfaces.RealInput hva_floor3_oveZonNor_TZonCooSet_u(unit="K", min=285.15, max=313.15) "Zone air temperature cooling setpoint for zone top_floor_nor";
+ Modelica.Blocks.Interfaces.BooleanInput hva_floor3_oveZonNor_TZonCooSet_activate "Activation for Zone air temperature cooling setpoint for zone top_floor_nor";
+ Modelica.Blocks.Interfaces.RealInput hva_floor3_oveZonNor_TZonHeaSet_u(unit="K", min=285.15, max=313.15) "Zone air temperature heating setpoint for zone top_floor_nor";
+ Modelica.Blocks.Interfaces.BooleanInput hva_floor3_oveZonNor_TZonHeaSet_activate "Activation for Zone air temperature heating setpoint for zone top_floor_nor";
+ Modelica.Blocks.Interfaces.RealInput hva_floor3_oveZonSou_TZonCooSet_u(unit="K", min=285.15, max=313.15) "Zone air temperature cooling setpoint for zone top_floor_sou";
+ Modelica.Blocks.Interfaces.BooleanInput hva_floor3_oveZonSou_TZonCooSet_activate "Activation for Zone air temperature cooling setpoint for zone top_floor_sou";
+ Modelica.Blocks.Interfaces.RealInput hva_floor3_oveZonSou_TZonHeaSet_u(unit="K", min=285.15, max=313.15) "Zone air temperature heating setpoint for zone top_floor_sou";
+ Modelica.Blocks.Interfaces.BooleanInput hva_floor3_oveZonSou_TZonHeaSet_activate "Activation for Zone air temperature heating setpoint for zone top_floor_sou";
+ Modelica.Blocks.Interfaces.RealInput hva_floor3_oveZonWes_TZonCooSet_u(unit="K", min=285.15, max=313.15) "Zone air temperature cooling setpoint for zone top_floor_wes";
+ Modelica.Blocks.Interfaces.BooleanInput hva_floor3_oveZonWes_TZonCooSet_activate "Activation for Zone air temperature cooling setpoint for zone top_floor_wes";
+ Modelica.Blocks.Interfaces.RealInput hva_floor3_oveZonWes_TZonHeaSet_u(unit="K", min=285.15, max=313.15) "Zone air temperature heating setpoint for zone top_floor_wes";
+ Modelica.Blocks.Interfaces.BooleanInput hva_floor3_oveZonWes_TZonHeaSet_activate "Activation for Zone air temperature heating setpoint for zone top_floor_wes";
+ Modelica.Blocks.Interfaces.RealInput hva_oveChiWatSys_TW_set_u(unit="K", min=278.15, max=288.15) "Chilled/hot water supply setpoint";
+ Modelica.Blocks.Interfaces.BooleanInput hva_oveChiWatSys_TW_set_activate "Activation for Chilled/hot water supply setpoint";
+ Modelica.Blocks.Interfaces.RealInput hva_oveChiWatSys_dp_set_u(unit="Pa", min=0.0, max=19130000.0) "Differential pressure setpoint";
+ Modelica.Blocks.Interfaces.BooleanInput hva_oveChiWatSys_dp_set_activate "Activation for Differential pressure setpoint";
+ Modelica.Blocks.Interfaces.RealInput hva_oveHotWatSys_TW_set_u(unit="K", min=291.15, max=353.15) "Chilled/hot water supply setpoint";
+ Modelica.Blocks.Interfaces.BooleanInput hva_oveHotWatSys_TW_set_activate "Activation for Chilled/hot water supply setpoint";
+ Modelica.Blocks.Interfaces.RealInput hva_oveHotWatSys_dp_set_u(unit="Pa", min=0.0, max=19130000.0) "Differential pressure setpoint";
+ Modelica.Blocks.Interfaces.BooleanInput hva_oveHotWatSys_dp_set_activate "Activation for Differential pressure setpoint";
+ // Out read
+ Modelica.Blocks.Interfaces.RealOutput hva_floor1_reaAhu_PFanTot_y(unit="W") = mod.hva.floor1.reaAhu.PFanTot.y "Total electrical power measurement of supply and return fans for AHU";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor1_reaAhu_TCooCoiRet_y(unit="K") = mod.hva.floor1.reaAhu.TCooCoiRet.y "Cooling coil return water temperature measurement for AHU";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor1_reaAhu_TCooCoiSup_y(unit="K") = mod.hva.floor1.reaAhu.TCooCoiSup.y "Cooling coil supply water temperature measurement for AHU";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor1_reaAhu_TMix_y(unit="K") = mod.hva.floor1.reaAhu.TMix.y "Mixed air temperature measurement for AHU";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor1_reaAhu_TRet_y(unit="K") = mod.hva.floor1.reaAhu.TRet.y "Return air temperature measurement for AHU";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor1_reaAhu_TSup_y(unit="K") = mod.hva.floor1.reaAhu.TSup.y "Supply air temperature measurement for AHU";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor1_reaAhu_TSup_set_y(unit="K") = mod.hva.floor1.reaAhu.TSup_set.y "Supply air temperature setpoint measurement for AHU";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor1_reaAhu_V_flow_OA_y(unit="m3/s") = mod.hva.floor1.reaAhu.V_flow_OA.y "Supply outdoor airflow rate measurement for AHU";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor1_reaAhu_V_flow_ret_y(unit="m3/s") = mod.hva.floor1.reaAhu.V_flow_ret.y "Return air flowrate measurement for AHU";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor1_reaAhu_V_flow_sup_y(unit="m3/s") = mod.hva.floor1.reaAhu.V_flow_sup.y "Supply air flowrate measurement for AHU";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor1_reaAhu_dp_sup_y(unit="Pa") = mod.hva.floor1.reaAhu.dp_sup.y "Discharge pressure of supply fan for AHU";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor1_reaAhu_occ_y(unit="1") = mod.hva.floor1.reaAhu.occ.y "Occupancy status (1 occupied, 0 unoccupied)";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor1_reaAhu_yCooVal_y(unit="1") = mod.hva.floor1.reaAhu.yCooVal.y "AHU cooling coil valve position measurement";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor1_reaAhu_yOA_y(unit="1") = mod.hva.floor1.reaAhu.yOA.y "AHU cooling coil valve position measurement";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor1_reaAhu_CO2_AHUSup_y(unit="ppm") = mod.hva.floor1.reaAhu.CO2_AHUSup.y "AHU CO2 measurement for supply air";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor1_reaAhu_CO2_AHUFre_y(unit="ppm") = mod.hva.floor1.reaAhu.CO2_AHUFre.y "AHU CO2 measurement for fresh air";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor1_reaAhu_CO2_AHURet_y(unit="ppm") = mod.hva.floor1.reaAhu.CO2_AHURet.y "AHU CO2 measurement for return air";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor1_reaZonCor_TRoo_Coo_set_y(unit="K") = mod.hva.floor1.reaZonCor.TRoo_Coo_set.y "Zone temperature cooling setpoint for zonebot_floor_cor";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor1_reaZonCor_TRoo_Hea_set_y(unit="K") = mod.hva.floor1.reaZonCor.TRoo_Hea_set.y "Zone temperature heating setpoint for zone bot_floor_cor";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor1_reaZonCor_TSup_y(unit="K") = mod.hva.floor1.reaZonCor.TSup.y "Discharge air temperature to zone measurement for zone bot_floor_cor";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor1_reaZonCor_TZon_y(unit="K") = mod.hva.floor1.reaZonCor.TZon.y "Zone air temperature measurement for zone bot_floor_cor";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor1_reaZonCor_V_flow_y(unit="m3/s") = mod.hva.floor1.reaZonCor.V_flow.y "Discharge air flowrate to zone measurement for zone bot_floor_cor";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor1_reaZonCor_V_flow_set_y(unit="m3/s") = mod.hva.floor1.reaZonCor.V_flow_set.y "Airflow setpointbot_floor_cor";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor1_reaZonCor_yCoo_y(unit="1") = mod.hva.floor1.reaZonCor.yCoo.y "Cooling PID signal measurement for zone bot_floor_cor";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor1_reaZonCor_yDam_y(unit="1") = mod.hva.floor1.reaZonCor.yDam.y "Damper position measurement for zone bot_floor_cor";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor1_reaZonCor_yHea_y(unit="1") = mod.hva.floor1.reaZonCor.yHea.y "Heating PID signal measurement for zone bot_floor_cor";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor1_reaZonCor_yReheaVal_y(unit="1") = mod.hva.floor1.reaZonCor.yReheaVal.y "Reheat valve position measurement for zone bot_floor_cor";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor1_reaZonCor_CO2Zon_y(unit="ppm") = mod.hva.floor1.reaZonCor.CO2Zon.y "Zone air CO2 measurement for zone bot_floor_cor";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor1_reaZonEas_TRoo_Coo_set_y(unit="K") = mod.hva.floor1.reaZonEas.TRoo_Coo_set.y "Zone temperature cooling setpoint for zonebot_floor_eas";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor1_reaZonEas_TRoo_Hea_set_y(unit="K") = mod.hva.floor1.reaZonEas.TRoo_Hea_set.y "Zone temperature heating setpoint for zone bot_floor_eas";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor1_reaZonEas_TSup_y(unit="K") = mod.hva.floor1.reaZonEas.TSup.y "Discharge air temperature to zone measurement for zone bot_floor_eas";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor1_reaZonEas_TZon_y(unit="K") = mod.hva.floor1.reaZonEas.TZon.y "Zone air temperature measurement for zone bot_floor_eas";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor1_reaZonEas_V_flow_y(unit="m3/s") = mod.hva.floor1.reaZonEas.V_flow.y "Discharge air flowrate to zone measurement for zone bot_floor_eas";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor1_reaZonEas_V_flow_set_y(unit="m3/s") = mod.hva.floor1.reaZonEas.V_flow_set.y "Airflow setpointbot_floor_eas";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor1_reaZonEas_yCoo_y(unit="1") = mod.hva.floor1.reaZonEas.yCoo.y "Cooling PID signal measurement for zone bot_floor_eas";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor1_reaZonEas_yDam_y(unit="1") = mod.hva.floor1.reaZonEas.yDam.y "Damper position measurement for zone bot_floor_eas";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor1_reaZonEas_yHea_y(unit="1") = mod.hva.floor1.reaZonEas.yHea.y "Heating PID signal measurement for zone bot_floor_eas";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor1_reaZonEas_yReheaVal_y(unit="1") = mod.hva.floor1.reaZonEas.yReheaVal.y "Reheat valve position measurement for zone bot_floor_eas";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor1_reaZonEas_CO2Zon_y(unit="ppm") = mod.hva.floor1.reaZonEas.CO2Zon.y "Zone air CO2 measurement for zone bot_floor_eas";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor1_reaZonNor_TRoo_Coo_set_y(unit="K") = mod.hva.floor1.reaZonNor.TRoo_Coo_set.y "Zone temperature cooling setpoint for zonebot_floor_nor";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor1_reaZonNor_TRoo_Hea_set_y(unit="K") = mod.hva.floor1.reaZonNor.TRoo_Hea_set.y "Zone temperature heating setpoint for zone bot_floor_nor";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor1_reaZonNor_TSup_y(unit="K") = mod.hva.floor1.reaZonNor.TSup.y "Discharge air temperature to zone measurement for zone bot_floor_nor";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor1_reaZonNor_TZon_y(unit="K") = mod.hva.floor1.reaZonNor.TZon.y "Zone air temperature measurement for zone bot_floor_nor";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor1_reaZonNor_V_flow_y(unit="m3/s") = mod.hva.floor1.reaZonNor.V_flow.y "Discharge air flowrate to zone measurement for zone bot_floor_nor";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor1_reaZonNor_V_flow_set_y(unit="m3/s") = mod.hva.floor1.reaZonNor.V_flow_set.y "Airflow setpointbot_floor_nor";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor1_reaZonNor_yCoo_y(unit="1") = mod.hva.floor1.reaZonNor.yCoo.y "Cooling PID signal measurement for zone bot_floor_nor";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor1_reaZonNor_yDam_y(unit="1") = mod.hva.floor1.reaZonNor.yDam.y "Damper position measurement for zone bot_floor_nor";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor1_reaZonNor_yHea_y(unit="1") = mod.hva.floor1.reaZonNor.yHea.y "Heating PID signal measurement for zone bot_floor_nor";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor1_reaZonNor_yReheaVal_y(unit="1") = mod.hva.floor1.reaZonNor.yReheaVal.y "Reheat valve position measurement for zone bot_floor_nor";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor1_reaZonNor_CO2Zon_y(unit="ppm") = mod.hva.floor1.reaZonNor.CO2Zon.y "Zone air CO2 measurement for zone bot_floor_nor";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor1_reaZonSou_TRoo_Coo_set_y(unit="K") = mod.hva.floor1.reaZonSou.TRoo_Coo_set.y "Zone temperature cooling setpoint for zonebot_floor_sou";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor1_reaZonSou_TRoo_Hea_set_y(unit="K") = mod.hva.floor1.reaZonSou.TRoo_Hea_set.y "Zone temperature heating setpoint for zone bot_floor_sou";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor1_reaZonSou_TSup_y(unit="K") = mod.hva.floor1.reaZonSou.TSup.y "Discharge air temperature to zone measurement for zone bot_floor_sou";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor1_reaZonSou_TZon_y(unit="K") = mod.hva.floor1.reaZonSou.TZon.y "Zone air temperature measurement for zone bot_floor_sou";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor1_reaZonSou_V_flow_y(unit="m3/s") = mod.hva.floor1.reaZonSou.V_flow.y "Discharge air flowrate to zone measurement for zone bot_floor_sou";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor1_reaZonSou_V_flow_set_y(unit="m3/s") = mod.hva.floor1.reaZonSou.V_flow_set.y "Airflow setpointbot_floor_sou";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor1_reaZonSou_yCoo_y(unit="1") = mod.hva.floor1.reaZonSou.yCoo.y "Cooling PID signal measurement for zone bot_floor_sou";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor1_reaZonSou_yDam_y(unit="1") = mod.hva.floor1.reaZonSou.yDam.y "Damper position measurement for zone bot_floor_sou";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor1_reaZonSou_yHea_y(unit="1") = mod.hva.floor1.reaZonSou.yHea.y "Heating PID signal measurement for zone bot_floor_sou";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor1_reaZonSou_yReheaVal_y(unit="1") = mod.hva.floor1.reaZonSou.yReheaVal.y "Reheat valve position measurement for zone bot_floor_sou";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor1_reaZonSou_CO2Zon_y(unit="ppm") = mod.hva.floor1.reaZonSou.CO2Zon.y "Zone air CO2 measurement for zone bot_floor_sou";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor1_reaZonWes_TRoo_Coo_set_y(unit="K") = mod.hva.floor1.reaZonWes.TRoo_Coo_set.y "Zone temperature cooling setpoint for zonebot_floor_wes";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor1_reaZonWes_TRoo_Hea_set_y(unit="K") = mod.hva.floor1.reaZonWes.TRoo_Hea_set.y "Zone temperature heating setpoint for zone bot_floor_wes";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor1_reaZonWes_TSup_y(unit="K") = mod.hva.floor1.reaZonWes.TSup.y "Discharge air temperature to zone measurement for zone bot_floor_wes";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor1_reaZonWes_TZon_y(unit="K") = mod.hva.floor1.reaZonWes.TZon.y "Zone air temperature measurement for zone bot_floor_wes";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor1_reaZonWes_V_flow_y(unit="m3/s") = mod.hva.floor1.reaZonWes.V_flow.y "Discharge air flowrate to zone measurement for zone bot_floor_wes";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor1_reaZonWes_V_flow_set_y(unit="m3/s") = mod.hva.floor1.reaZonWes.V_flow_set.y "Airflow setpointbot_floor_wes";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor1_reaZonWes_yCoo_y(unit="1") = mod.hva.floor1.reaZonWes.yCoo.y "Cooling PID signal measurement for zone bot_floor_wes";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor1_reaZonWes_yDam_y(unit="1") = mod.hva.floor1.reaZonWes.yDam.y "Damper position measurement for zone bot_floor_wes";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor1_reaZonWes_yHea_y(unit="1") = mod.hva.floor1.reaZonWes.yHea.y "Heating PID signal measurement for zone bot_floor_wes";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor1_reaZonWes_yReheaVal_y(unit="1") = mod.hva.floor1.reaZonWes.yReheaVal.y "Reheat valve position measurement for zone bot_floor_wes";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor1_reaZonWes_CO2Zon_y(unit="ppm") = mod.hva.floor1.reaZonWes.CO2Zon.y "Zone air CO2 measurement for zone bot_floor_wes";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor2_reaAhu_PFanTot_y(unit="W") = mod.hva.floor2.reaAhu.PFanTot.y "Total electrical power measurement of supply and return fans for AHU";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor2_reaAhu_TCooCoiRet_y(unit="K") = mod.hva.floor2.reaAhu.TCooCoiRet.y "Cooling coil return water temperature measurement for AHU";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor2_reaAhu_TCooCoiSup_y(unit="K") = mod.hva.floor2.reaAhu.TCooCoiSup.y "Cooling coil supply water temperature measurement for AHU";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor2_reaAhu_TMix_y(unit="K") = mod.hva.floor2.reaAhu.TMix.y "Mixed air temperature measurement for AHU";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor2_reaAhu_TRet_y(unit="K") = mod.hva.floor2.reaAhu.TRet.y "Return air temperature measurement for AHU";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor2_reaAhu_TSup_y(unit="K") = mod.hva.floor2.reaAhu.TSup.y "Supply air temperature measurement for AHU";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor2_reaAhu_TSup_set_y(unit="K") = mod.hva.floor2.reaAhu.TSup_set.y "Supply air temperature setpoint measurement for AHU";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor2_reaAhu_V_flow_OA_y(unit="m3/s") = mod.hva.floor2.reaAhu.V_flow_OA.y "Supply outdoor airflow rate measurement for AHU";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor2_reaAhu_V_flow_ret_y(unit="m3/s") = mod.hva.floor2.reaAhu.V_flow_ret.y "Return air flowrate measurement for AHU";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor2_reaAhu_V_flow_sup_y(unit="m3/s") = mod.hva.floor2.reaAhu.V_flow_sup.y "Supply air flowrate measurement for AHU";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor2_reaAhu_dp_sup_y(unit="Pa") = mod.hva.floor2.reaAhu.dp_sup.y "Discharge pressure of supply fan for AHU";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor2_reaAhu_occ_y(unit="1") = mod.hva.floor2.reaAhu.occ.y "Occupancy status (1 occupied, 0 unoccupied)";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor2_reaAhu_yCooVal_y(unit="1") = mod.hva.floor2.reaAhu.yCooVal.y "AHU cooling coil valve position measurement";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor2_reaAhu_yOA_y(unit="1") = mod.hva.floor2.reaAhu.yOA.y "AHU cooling coil valve position measurement";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor2_reaAhu_CO2_AHUSup_y(unit="ppm") = mod.hva.floor2.reaAhu.CO2_AHUSup.y "AHU CO2 measurement for supply air";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor2_reaAhu_CO2_AHUFre_y(unit="ppm") = mod.hva.floor2.reaAhu.CO2_AHUFre.y "AHU CO2 measurement for fresh air";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor2_reaAhu_CO2_AHURet_y(unit="ppm") = mod.hva.floor2.reaAhu.CO2_AHURet.y "AHU CO2 measurement for return air";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor2_reaZonCor_TRoo_Coo_set_y(unit="K") = mod.hva.floor2.reaZonCor.TRoo_Coo_set.y "Zone temperature cooling setpoint for zonemid_floor_cor";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor2_reaZonCor_TRoo_Hea_set_y(unit="K") = mod.hva.floor2.reaZonCor.TRoo_Hea_set.y "Zone temperature heating setpoint for zone mid_floor_cor";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor2_reaZonCor_TSup_y(unit="K") = mod.hva.floor2.reaZonCor.TSup.y "Discharge air temperature to zone measurement for zone mid_floor_cor";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor2_reaZonCor_TZon_y(unit="K") = mod.hva.floor2.reaZonCor.TZon.y "Zone air temperature measurement for zone mid_floor_cor";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor2_reaZonCor_V_flow_y(unit="m3/s") = mod.hva.floor2.reaZonCor.V_flow.y "Discharge air flowrate to zone measurement for zone mid_floor_cor";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor2_reaZonCor_V_flow_set_y(unit="m3/s") = mod.hva.floor2.reaZonCor.V_flow_set.y "Airflow setpointmid_floor_cor";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor2_reaZonCor_yCoo_y(unit="1") = mod.hva.floor2.reaZonCor.yCoo.y "Cooling PID signal measurement for zone mid_floor_cor";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor2_reaZonCor_yDam_y(unit="1") = mod.hva.floor2.reaZonCor.yDam.y "Damper position measurement for zone mid_floor_cor";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor2_reaZonCor_yHea_y(unit="1") = mod.hva.floor2.reaZonCor.yHea.y "Heating PID signal measurement for zone mid_floor_cor";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor2_reaZonCor_yReheaVal_y(unit="1") = mod.hva.floor2.reaZonCor.yReheaVal.y "Reheat valve position measurement for zone mid_floor_cor";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor2_reaZonCor_CO2Zon_y(unit="ppm") = mod.hva.floor2.reaZonCor.CO2Zon.y "Zone air CO2 measurement for zone bot_floor_cor";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor2_reaZonEas_TRoo_Coo_set_y(unit="K") = mod.hva.floor2.reaZonEas.TRoo_Coo_set.y "Zone temperature cooling setpoint for zonemid_floor_eas";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor2_reaZonEas_TRoo_Hea_set_y(unit="K") = mod.hva.floor2.reaZonEas.TRoo_Hea_set.y "Zone temperature heating setpoint for zone mid_floor_eas";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor2_reaZonEas_TSup_y(unit="K") = mod.hva.floor2.reaZonEas.TSup.y "Discharge air temperature to zone measurement for zone mid_floor_eas";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor2_reaZonEas_TZon_y(unit="K") = mod.hva.floor2.reaZonEas.TZon.y "Zone air temperature measurement for zone mid_floor_eas";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor2_reaZonEas_V_flow_y(unit="m3/s") = mod.hva.floor2.reaZonEas.V_flow.y "Discharge air flowrate to zone measurement for zone mid_floor_eas";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor2_reaZonEas_V_flow_set_y(unit="m3/s") = mod.hva.floor2.reaZonEas.V_flow_set.y "Airflow setpointmid_floor_eas";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor2_reaZonEas_yCoo_y(unit="1") = mod.hva.floor2.reaZonEas.yCoo.y "Cooling PID signal measurement for zone mid_floor_eas";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor2_reaZonEas_yDam_y(unit="1") = mod.hva.floor2.reaZonEas.yDam.y "Damper position measurement for zone mid_floor_eas";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor2_reaZonEas_yHea_y(unit="1") = mod.hva.floor2.reaZonEas.yHea.y "Heating PID signal measurement for zone mid_floor_eas";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor2_reaZonEas_yReheaVal_y(unit="1") = mod.hva.floor2.reaZonEas.yReheaVal.y "Reheat valve position measurement for zone mid_floor_eas";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor2_reaZonEas_CO2Zon_y(unit="ppm") = mod.hva.floor2.reaZonEas.CO2Zon.y "Zone air CO2 measurement for zone bot_floor_eas";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor2_reaZonNor_TRoo_Coo_set_y(unit="K") = mod.hva.floor2.reaZonNor.TRoo_Coo_set.y "Zone temperature cooling setpoint for zonemid_floor_nor";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor2_reaZonNor_TRoo_Hea_set_y(unit="K") = mod.hva.floor2.reaZonNor.TRoo_Hea_set.y "Zone temperature heating setpoint for zone mid_floor_nor";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor2_reaZonNor_TSup_y(unit="K") = mod.hva.floor2.reaZonNor.TSup.y "Discharge air temperature to zone measurement for zone mid_floor_nor";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor2_reaZonNor_TZon_y(unit="K") = mod.hva.floor2.reaZonNor.TZon.y "Zone air temperature measurement for zone mid_floor_nor";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor2_reaZonNor_V_flow_y(unit="m3/s") = mod.hva.floor2.reaZonNor.V_flow.y "Discharge air flowrate to zone measurement for zone mid_floor_nor";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor2_reaZonNor_V_flow_set_y(unit="m3/s") = mod.hva.floor2.reaZonNor.V_flow_set.y "Airflow setpointmid_floor_nor";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor2_reaZonNor_yCoo_y(unit="1") = mod.hva.floor2.reaZonNor.yCoo.y "Cooling PID signal measurement for zone mid_floor_nor";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor2_reaZonNor_yDam_y(unit="1") = mod.hva.floor2.reaZonNor.yDam.y "Damper position measurement for zone mid_floor_nor";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor2_reaZonNor_yHea_y(unit="1") = mod.hva.floor2.reaZonNor.yHea.y "Heating PID signal measurement for zone mid_floor_nor";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor2_reaZonNor_yReheaVal_y(unit="1") = mod.hva.floor2.reaZonNor.yReheaVal.y "Reheat valve position measurement for zone mid_floor_nor";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor2_reaZonNor_CO2Zon_y(unit="ppm") = mod.hva.floor2.reaZonNor.CO2Zon.y "Zone air CO2 measurement for zone bot_floor_nor";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor2_reaZonSou_TRoo_Coo_set_y(unit="K") = mod.hva.floor2.reaZonSou.TRoo_Coo_set.y "Zone temperature cooling setpoint for zonemid_floor_sou";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor2_reaZonSou_TRoo_Hea_set_y(unit="K") = mod.hva.floor2.reaZonSou.TRoo_Hea_set.y "Zone temperature heating setpoint for zone mid_floor_sou";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor2_reaZonSou_TSup_y(unit="K") = mod.hva.floor2.reaZonSou.TSup.y "Discharge air temperature to zone measurement for zone mid_floor_sou";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor2_reaZonSou_TZon_y(unit="K") = mod.hva.floor2.reaZonSou.TZon.y "Zone air temperature measurement for zone mid_floor_sou";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor2_reaZonSou_V_flow_y(unit="m3/s") = mod.hva.floor2.reaZonSou.V_flow.y "Discharge air flowrate to zone measurement for zone mid_floor_sou";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor2_reaZonSou_V_flow_set_y(unit="m3/s") = mod.hva.floor2.reaZonSou.V_flow_set.y "Airflow setpointmid_floor_sou";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor2_reaZonSou_yCoo_y(unit="1") = mod.hva.floor2.reaZonSou.yCoo.y "Cooling PID signal measurement for zone mid_floor_sou";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor2_reaZonSou_yDam_y(unit="1") = mod.hva.floor2.reaZonSou.yDam.y "Damper position measurement for zone mid_floor_sou";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor2_reaZonSou_yHea_y(unit="1") = mod.hva.floor2.reaZonSou.yHea.y "Heating PID signal measurement for zone mid_floor_sou";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor2_reaZonSou_yReheaVal_y(unit="1") = mod.hva.floor2.reaZonSou.yReheaVal.y "Reheat valve position measurement for zone mid_floor_sou";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor2_reaZonSou_CO2Zon_y(unit="ppm") = mod.hva.floor2.reaZonSou.CO2Zon.y "Zone air CO2 measurement for zone bot_floor_sou";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor2_reaZonWes_TRoo_Coo_set_y(unit="K") = mod.hva.floor2.reaZonWes.TRoo_Coo_set.y "Zone temperature cooling setpoint for zonemid_floor_wes";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor2_reaZonWes_TRoo_Hea_set_y(unit="K") = mod.hva.floor2.reaZonWes.TRoo_Hea_set.y "Zone temperature heating setpoint for zone mid_floor_wes";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor2_reaZonWes_TSup_y(unit="K") = mod.hva.floor2.reaZonWes.TSup.y "Discharge air temperature to zone measurement for zone mid_floor_wes";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor2_reaZonWes_TZon_y(unit="K") = mod.hva.floor2.reaZonWes.TZon.y "Zone air temperature measurement for zone mid_floor_wes";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor2_reaZonWes_V_flow_y(unit="m3/s") = mod.hva.floor2.reaZonWes.V_flow.y "Discharge air flowrate to zone measurement for zone mid_floor_wes";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor2_reaZonWes_V_flow_set_y(unit="m3/s") = mod.hva.floor2.reaZonWes.V_flow_set.y "Airflow setpointmid_floor_wes";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor2_reaZonWes_yCoo_y(unit="1") = mod.hva.floor2.reaZonWes.yCoo.y "Cooling PID signal measurement for zone mid_floor_wes";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor2_reaZonWes_yDam_y(unit="1") = mod.hva.floor2.reaZonWes.yDam.y "Damper position measurement for zone mid_floor_wes";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor2_reaZonWes_yHea_y(unit="1") = mod.hva.floor2.reaZonWes.yHea.y "Heating PID signal measurement for zone mid_floor_wes";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor2_reaZonWes_yReheaVal_y(unit="1") = mod.hva.floor2.reaZonWes.yReheaVal.y "Reheat valve position measurement for zone mid_floor_wes";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor2_reaZonWes_CO2Zon_y(unit="ppm") = mod.hva.floor2.reaZonWes.CO2Zon.y "Zone air CO2 measurement for zone bot_floor_wes";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor3_reaAhu_PFanTot_y(unit="W") = mod.hva.floor3.reaAhu.PFanTot.y "Total electrical power measurement of supply and return fans for AHU";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor3_reaAhu_TCooCoiRet_y(unit="K") = mod.hva.floor3.reaAhu.TCooCoiRet.y "Cooling coil return water temperature measurement for AHU";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor3_reaAhu_TCooCoiSup_y(unit="K") = mod.hva.floor3.reaAhu.TCooCoiSup.y "Cooling coil supply water temperature measurement for AHU";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor3_reaAhu_TMix_y(unit="K") = mod.hva.floor3.reaAhu.TMix.y "Mixed air temperature measurement for AHU";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor3_reaAhu_TRet_y(unit="K") = mod.hva.floor3.reaAhu.TRet.y "Return air temperature measurement for AHU";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor3_reaAhu_TSup_y(unit="K") = mod.hva.floor3.reaAhu.TSup.y "Supply air temperature measurement for AHU";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor3_reaAhu_TSup_set_y(unit="K") = mod.hva.floor3.reaAhu.TSup_set.y "Supply air temperature setpoint measurement for AHU";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor3_reaAhu_V_flow_OA_y(unit="m3/s") = mod.hva.floor3.reaAhu.V_flow_OA.y "Supply outdoor airflow rate measurement for AHU";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor3_reaAhu_V_flow_ret_y(unit="m3/s") = mod.hva.floor3.reaAhu.V_flow_ret.y "Return air flowrate measurement for AHU";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor3_reaAhu_V_flow_sup_y(unit="m3/s") = mod.hva.floor3.reaAhu.V_flow_sup.y "Supply air flowrate measurement for AHU";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor3_reaAhu_dp_sup_y(unit="Pa") = mod.hva.floor3.reaAhu.dp_sup.y "Discharge pressure of supply fan for AHU";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor3_reaAhu_occ_y(unit="1") = mod.hva.floor3.reaAhu.occ.y "Occupancy status (1 occupied, 0 unoccupied)";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor3_reaAhu_yCooVal_y(unit="1") = mod.hva.floor3.reaAhu.yCooVal.y "AHU cooling coil valve position measurement";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor3_reaAhu_yOA_y(unit="1") = mod.hva.floor3.reaAhu.yOA.y "AHU cooling coil valve position measurement";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor3_reaAhu_CO2_AHUSup_y(unit="ppm") = mod.hva.floor3.reaAhu.CO2_AHUSup.y "AHU CO2 measurement for supply air";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor3_reaAhu_CO2_AHUFre_y(unit="ppm") = mod.hva.floor3.reaAhu.CO2_AHUFre.y "AHU CO2 measurement for fresh air";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor3_reaAhu_CO2_AHURet_y(unit="ppm") = mod.hva.floor3.reaAhu.CO2_AHURet.y "AHU CO2 measurement for return air";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor3_reaZonCor_TRoo_Coo_set_y(unit="K") = mod.hva.floor3.reaZonCor.TRoo_Coo_set.y "Zone temperature cooling setpoint for zonetop_floor_cor";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor3_reaZonCor_TRoo_Hea_set_y(unit="K") = mod.hva.floor3.reaZonCor.TRoo_Hea_set.y "Zone temperature heating setpoint for zone top_floor_cor";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor3_reaZonCor_TSup_y(unit="K") = mod.hva.floor3.reaZonCor.TSup.y "Discharge air temperature to zone measurement for zone top_floor_cor";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor3_reaZonCor_TZon_y(unit="K") = mod.hva.floor3.reaZonCor.TZon.y "Zone air temperature measurement for zone top_floor_cor";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor3_reaZonCor_V_flow_y(unit="m3/s") = mod.hva.floor3.reaZonCor.V_flow.y "Discharge air flowrate to zone measurement for zone top_floor_cor";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor3_reaZonCor_V_flow_set_y(unit="m3/s") = mod.hva.floor3.reaZonCor.V_flow_set.y "Airflow setpointtop_floor_cor";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor3_reaZonCor_yCoo_y(unit="1") = mod.hva.floor3.reaZonCor.yCoo.y "Cooling PID signal measurement for zone top_floor_cor";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor3_reaZonCor_yDam_y(unit="1") = mod.hva.floor3.reaZonCor.yDam.y "Damper position measurement for zone top_floor_cor";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor3_reaZonCor_yHea_y(unit="1") = mod.hva.floor3.reaZonCor.yHea.y "Heating PID signal measurement for zone top_floor_cor";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor3_reaZonCor_yReheaVal_y(unit="1") = mod.hva.floor3.reaZonCor.yReheaVal.y "Reheat valve position measurement for zone top_floor_cor";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor3_reaZonCor_CO2Zon_y(unit="ppm") = mod.hva.floor3.reaZonCor.CO2Zon.y "Zone air CO2 measurement for zone bot_floor_cor";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor3_reaZonEas_TRoo_Coo_set_y(unit="K") = mod.hva.floor3.reaZonEas.TRoo_Coo_set.y "Zone temperature cooling setpoint for zonetop_floor_eas";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor3_reaZonEas_TRoo_Hea_set_y(unit="K") = mod.hva.floor3.reaZonEas.TRoo_Hea_set.y "Zone temperature heating setpoint for zone top_floor_eas";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor3_reaZonEas_TSup_y(unit="K") = mod.hva.floor3.reaZonEas.TSup.y "Discharge air temperature to zone measurement for zone top_floor_eas";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor3_reaZonEas_TZon_y(unit="K") = mod.hva.floor3.reaZonEas.TZon.y "Zone air temperature measurement for zone top_floor_eas";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor3_reaZonEas_V_flow_y(unit="m3/s") = mod.hva.floor3.reaZonEas.V_flow.y "Discharge air flowrate to zone measurement for zone top_floor_eas";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor3_reaZonEas_V_flow_set_y(unit="m3/s") = mod.hva.floor3.reaZonEas.V_flow_set.y "Airflow setpointtop_floor_eas";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor3_reaZonEas_yCoo_y(unit="1") = mod.hva.floor3.reaZonEas.yCoo.y "Cooling PID signal measurement for zone top_floor_eas";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor3_reaZonEas_yDam_y(unit="1") = mod.hva.floor3.reaZonEas.yDam.y "Damper position measurement for zone top_floor_eas";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor3_reaZonEas_yHea_y(unit="1") = mod.hva.floor3.reaZonEas.yHea.y "Heating PID signal measurement for zone top_floor_eas";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor3_reaZonEas_yReheaVal_y(unit="1") = mod.hva.floor3.reaZonEas.yReheaVal.y "Reheat valve position measurement for zone top_floor_eas";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor3_reaZonEas_CO2Zon_y(unit="ppm") = mod.hva.floor3.reaZonEas.CO2Zon.y "Zone air CO2 measurement for zone bot_floor_eas";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor3_reaZonNor_TRoo_Coo_set_y(unit="K") = mod.hva.floor3.reaZonNor.TRoo_Coo_set.y "Zone temperature cooling setpoint for zonetop_floor_nor";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor3_reaZonNor_TRoo_Hea_set_y(unit="K") = mod.hva.floor3.reaZonNor.TRoo_Hea_set.y "Zone temperature heating setpoint for zone top_floor_nor";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor3_reaZonNor_TSup_y(unit="K") = mod.hva.floor3.reaZonNor.TSup.y "Discharge air temperature to zone measurement for zone top_floor_nor";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor3_reaZonNor_TZon_y(unit="K") = mod.hva.floor3.reaZonNor.TZon.y "Zone air temperature measurement for zone top_floor_nor";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor3_reaZonNor_V_flow_y(unit="m3/s") = mod.hva.floor3.reaZonNor.V_flow.y "Discharge air flowrate to zone measurement for zone top_floor_nor";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor3_reaZonNor_V_flow_set_y(unit="m3/s") = mod.hva.floor3.reaZonNor.V_flow_set.y "Airflow setpointtop_floor_nor";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor3_reaZonNor_yCoo_y(unit="1") = mod.hva.floor3.reaZonNor.yCoo.y "Cooling PID signal measurement for zone top_floor_nor";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor3_reaZonNor_yDam_y(unit="1") = mod.hva.floor3.reaZonNor.yDam.y "Damper position measurement for zone top_floor_nor";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor3_reaZonNor_yHea_y(unit="1") = mod.hva.floor3.reaZonNor.yHea.y "Heating PID signal measurement for zone top_floor_nor";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor3_reaZonNor_yReheaVal_y(unit="1") = mod.hva.floor3.reaZonNor.yReheaVal.y "Reheat valve position measurement for zone top_floor_nor";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor3_reaZonNor_CO2Zon_y(unit="ppm") = mod.hva.floor3.reaZonNor.CO2Zon.y "Zone air CO2 measurement for zone bot_floor_nor";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor3_reaZonSou_TRoo_Coo_set_y(unit="K") = mod.hva.floor3.reaZonSou.TRoo_Coo_set.y "Zone temperature cooling setpoint for zonetop_floor_sou";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor3_reaZonSou_TRoo_Hea_set_y(unit="K") = mod.hva.floor3.reaZonSou.TRoo_Hea_set.y "Zone temperature heating setpoint for zone top_floor_sou";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor3_reaZonSou_TSup_y(unit="K") = mod.hva.floor3.reaZonSou.TSup.y "Discharge air temperature to zone measurement for zone top_floor_sou";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor3_reaZonSou_TZon_y(unit="K") = mod.hva.floor3.reaZonSou.TZon.y "Zone air temperature measurement for zone top_floor_sou";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor3_reaZonSou_V_flow_y(unit="m3/s") = mod.hva.floor3.reaZonSou.V_flow.y "Discharge air flowrate to zone measurement for zone top_floor_sou";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor3_reaZonSou_V_flow_set_y(unit="m3/s") = mod.hva.floor3.reaZonSou.V_flow_set.y "Airflow setpointtop_floor_sou";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor3_reaZonSou_yCoo_y(unit="1") = mod.hva.floor3.reaZonSou.yCoo.y "Cooling PID signal measurement for zone top_floor_sou";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor3_reaZonSou_yDam_y(unit="1") = mod.hva.floor3.reaZonSou.yDam.y "Damper position measurement for zone top_floor_sou";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor3_reaZonSou_yHea_y(unit="1") = mod.hva.floor3.reaZonSou.yHea.y "Heating PID signal measurement for zone top_floor_sou";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor3_reaZonSou_yReheaVal_y(unit="1") = mod.hva.floor3.reaZonSou.yReheaVal.y "Reheat valve position measurement for zone top_floor_sou";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor3_reaZonSou_CO2Zon_y(unit="ppm") = mod.hva.floor3.reaZonSou.CO2Zon.y "Zone air CO2 measurement for zone bot_floor_sou";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor3_reaZonWes_TRoo_Coo_set_y(unit="K") = mod.hva.floor3.reaZonWes.TRoo_Coo_set.y "Zone temperature cooling setpoint for zonetop_floor_wes";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor3_reaZonWes_TRoo_Hea_set_y(unit="K") = mod.hva.floor3.reaZonWes.TRoo_Hea_set.y "Zone temperature heating setpoint for zone top_floor_wes";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor3_reaZonWes_TSup_y(unit="K") = mod.hva.floor3.reaZonWes.TSup.y "Discharge air temperature to zone measurement for zone top_floor_wes";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor3_reaZonWes_TZon_y(unit="K") = mod.hva.floor3.reaZonWes.TZon.y "Zone air temperature measurement for zone top_floor_wes";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor3_reaZonWes_V_flow_y(unit="m3/s") = mod.hva.floor3.reaZonWes.V_flow.y "Discharge air flowrate to zone measurement for zone top_floor_wes";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor3_reaZonWes_V_flow_set_y(unit="m3/s") = mod.hva.floor3.reaZonWes.V_flow_set.y "Airflow setpointtop_floor_wes";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor3_reaZonWes_yCoo_y(unit="1") = mod.hva.floor3.reaZonWes.yCoo.y "Cooling PID signal measurement for zone top_floor_wes";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor3_reaZonWes_yDam_y(unit="1") = mod.hva.floor3.reaZonWes.yDam.y "Damper position measurement for zone top_floor_wes";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor3_reaZonWes_yHea_y(unit="1") = mod.hva.floor3.reaZonWes.yHea.y "Heating PID signal measurement for zone top_floor_wes";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor3_reaZonWes_yReheaVal_y(unit="1") = mod.hva.floor3.reaZonWes.yReheaVal.y "Reheat valve position measurement for zone top_floor_wes";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor3_reaZonWes_CO2Zon_y(unit="ppm") = mod.hva.floor3.reaZonWes.CO2Zon.y "Zone air CO2 measurement for zone bot_floor_wes";
+ Modelica.Blocks.Interfaces.RealOutput hva_reaChiWatSys_TW_y(unit="K") = mod.hva.reaChiWatSys.TW.y "Chilled water temperature measurement";
+ Modelica.Blocks.Interfaces.RealOutput hva_reaChiWatSys_dp_y(unit="K") = mod.hva.reaChiWatSys.dp.y "Differential pressure of chilled/hot water measurement";
+ Modelica.Blocks.Interfaces.RealOutput hva_reaChiWatSys_reaPChi_y(unit="W") = mod.hva.reaChiWatSys.reaPChi.y "Multiple chiller power consumption";
+ Modelica.Blocks.Interfaces.RealOutput hva_reaChiWatSys_reaPCooTow_y(unit="W") = mod.hva.reaChiWatSys.reaPCooTow.y "Multiple cooling tower power consumption";
+ Modelica.Blocks.Interfaces.RealOutput hva_reaChiWatSys_reaPPum_y(unit="W") = mod.hva.reaChiWatSys.reaPPum.y "Chilled water plant pump power consumption";
+ Modelica.Blocks.Interfaces.RealOutput hva_reaHotWatSys_TW_y(unit="K") = mod.hva.reaHotWatSys.TW.y "Chilled water temperature measurement";
+ Modelica.Blocks.Interfaces.RealOutput hva_reaHotWatSys_dp_y(unit="K") = mod.hva.reaHotWatSys.dp.y "Differential pressure of chilled/hot water measurement";
+ Modelica.Blocks.Interfaces.RealOutput hva_reaHotWatSys_reaPBoi_y(unit="W") = mod.hva.reaHotWatSys.reaPBoi.y "Multiple gas power consumption";
+ Modelica.Blocks.Interfaces.RealOutput hva_reaHotWatSys_reaPPum_y(unit="W") = mod.hva.reaHotWatSys.reaPPum.y "Chilled water plant pump power consumption";
+ Modelica.Blocks.Interfaces.RealOutput loaEnePlu_weaSta_reaWeaCeiHei_y(unit="m") = mod.loaEnePlu.weaSta.reaWeaCeiHei.y "Cloud cover ceiling height measurement";
+ Modelica.Blocks.Interfaces.RealOutput loaEnePlu_weaSta_reaWeaCloTim_y(unit="s") = mod.loaEnePlu.weaSta.reaWeaCloTim.y "Day number with units of seconds";
+ Modelica.Blocks.Interfaces.RealOutput loaEnePlu_weaSta_reaWeaHDifHor_y(unit="W/m2") = mod.loaEnePlu.weaSta.reaWeaHDifHor.y "Horizontal diffuse solar radiation measurement";
+ Modelica.Blocks.Interfaces.RealOutput loaEnePlu_weaSta_reaWeaHDirNor_y(unit="W/m2") = mod.loaEnePlu.weaSta.reaWeaHDirNor.y "Direct normal radiation measurement";
+ Modelica.Blocks.Interfaces.RealOutput loaEnePlu_weaSta_reaWeaHGloHor_y(unit="W/m2") = mod.loaEnePlu.weaSta.reaWeaHGloHor.y "Global horizontal solar irradiation measurement";
+ Modelica.Blocks.Interfaces.RealOutput loaEnePlu_weaSta_reaWeaHHorIR_y(unit="W/m2") = mod.loaEnePlu.weaSta.reaWeaHHorIR.y "Horizontal infrared irradiation measurement";
+ Modelica.Blocks.Interfaces.RealOutput loaEnePlu_weaSta_reaWeaLat_y(unit="rad") = mod.loaEnePlu.weaSta.reaWeaLat.y "Latitude of the location";
+ Modelica.Blocks.Interfaces.RealOutput loaEnePlu_weaSta_reaWeaLon_y(unit="rad") = mod.loaEnePlu.weaSta.reaWeaLon.y "Longitude of the location";
+ Modelica.Blocks.Interfaces.RealOutput loaEnePlu_weaSta_reaWeaNOpa_y(unit="1") = mod.loaEnePlu.weaSta.reaWeaNOpa.y "Opaque sky cover measurement";
+ Modelica.Blocks.Interfaces.RealOutput loaEnePlu_weaSta_reaWeaNTot_y(unit="1") = mod.loaEnePlu.weaSta.reaWeaNTot.y "Sky cover measurement";
+ Modelica.Blocks.Interfaces.RealOutput loaEnePlu_weaSta_reaWeaPAtm_y(unit="Pa") = mod.loaEnePlu.weaSta.reaWeaPAtm.y "Atmospheric pressure measurement";
+ Modelica.Blocks.Interfaces.RealOutput loaEnePlu_weaSta_reaWeaRelHum_y(unit="1") = mod.loaEnePlu.weaSta.reaWeaRelHum.y "Outside relative humidity measurement";
+ Modelica.Blocks.Interfaces.RealOutput loaEnePlu_weaSta_reaWeaSolAlt_y(unit="rad") = mod.loaEnePlu.weaSta.reaWeaSolAlt.y "Solar altitude angle measurement";
+ Modelica.Blocks.Interfaces.RealOutput loaEnePlu_weaSta_reaWeaSolDec_y(unit="rad") = mod.loaEnePlu.weaSta.reaWeaSolDec.y "Solar declination angle measurement";
+ Modelica.Blocks.Interfaces.RealOutput loaEnePlu_weaSta_reaWeaSolHouAng_y(unit="rad") = mod.loaEnePlu.weaSta.reaWeaSolHouAng.y "Solar hour angle measurement";
+ Modelica.Blocks.Interfaces.RealOutput loaEnePlu_weaSta_reaWeaSolTim_y(unit="s") = mod.loaEnePlu.weaSta.reaWeaSolTim.y "Solar time";
+ Modelica.Blocks.Interfaces.RealOutput loaEnePlu_weaSta_reaWeaSolZen_y(unit="rad") = mod.loaEnePlu.weaSta.reaWeaSolZen.y "Solar zenith angle measurement";
+ Modelica.Blocks.Interfaces.RealOutput loaEnePlu_weaSta_reaWeaTBlaSky_y(unit="K") = mod.loaEnePlu.weaSta.reaWeaTBlaSky.y "Black-body sky temperature measurement";
+ Modelica.Blocks.Interfaces.RealOutput loaEnePlu_weaSta_reaWeaTDewPoi_y(unit="K") = mod.loaEnePlu.weaSta.reaWeaTDewPoi.y "Dew point temperature measurement";
+ Modelica.Blocks.Interfaces.RealOutput loaEnePlu_weaSta_reaWeaTDryBul_y(unit="K") = mod.loaEnePlu.weaSta.reaWeaTDryBul.y "Outside drybulb temperature measurement";
+ Modelica.Blocks.Interfaces.RealOutput loaEnePlu_weaSta_reaWeaTWetBul_y(unit="K") = mod.loaEnePlu.weaSta.reaWeaTWetBul.y "Wet bulb temperature measurement";
+ Modelica.Blocks.Interfaces.RealOutput loaEnePlu_weaSta_reaWeaWinDir_y(unit="rad") = mod.loaEnePlu.weaSta.reaWeaWinDir.y "Wind direction measurement";
+ Modelica.Blocks.Interfaces.RealOutput loaEnePlu_weaSta_reaWeaWinSpe_y(unit="m/s") = mod.loaEnePlu.weaSta.reaWeaWinSpe.y "Wind speed measurement";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor1_TSupAirSet_y(unit="K") = mod.hva.floor1.TSupAirSet.y "Supply air temperature setpoint for AHU";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor1_dpSet_y(unit="Pa") = mod.hva.floor1.dpSet.y "Supply duct pressure setpoint for AHU";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor1_duaFanAirHanUni_cooCoi_yCoo_y(unit="1") = mod.hva.floor1.duaFanAirHanUni.cooCoi.yCoo.y "Cooling coil valve control signal for AHU";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor1_duaFanAirHanUni_mixingBox_mixBox_yEA_y(unit="1") = mod.hva.floor1.duaFanAirHanUni.mixingBox.mixBox.yEA.y "Exhaust air damper position setpoint for AHU";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor1_duaFanAirHanUni_mixingBox_mixBox_yOA_y(unit="1") = mod.hva.floor1.duaFanAirHanUni.mixingBox.mixBox.yOA.y "Outside air damper position setpoint for AHU";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor1_duaFanAirHanUni_mixingBox_mixBox_yRet_y(unit="1") = mod.hva.floor1.duaFanAirHanUni.mixingBox.mixBox.yRet.y "Return air damper position setpoint for AHU";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor1_duaFanAirHanUni_oveSpeRetFan_y(unit="1") = mod.hva.floor1.duaFanAirHanUni.oveSpeRetFan.y "AHU return fan speed control signal";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor1_duaFanAirHanUni_supFan_oveSpeSupFan_y(unit="1") = mod.hva.floor1.duaFanAirHanUni.supFan.oveSpeSupFan.y "AHU supply fan speed control signal";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor1_fivZonVAV_vAV1_oveZonLoc_yDam_y(unit="1") = mod.hva.floor1.fivZonVAV.vAV1.oveZonLoc.yDam.y "Damper position setpoint for zone cor";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor1_fivZonVAV_vAV1_oveZonLoc_yReaHea_y(unit="1") = mod.hva.floor1.fivZonVAV.vAV1.oveZonLoc.yReaHea.y "Reheat control signal for zone cor";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor1_fivZonVAV_vAV2_oveZonLoc_yDam_y(unit="1") = mod.hva.floor1.fivZonVAV.vAV2.oveZonLoc.yDam.y "Damper position setpoint for zone sou";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor1_fivZonVAV_vAV2_oveZonLoc_yReaHea_y(unit="1") = mod.hva.floor1.fivZonVAV.vAV2.oveZonLoc.yReaHea.y "Reheat control signal for zone sou";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor1_fivZonVAV_vAV3_oveZonLoc_yDam_y(unit="1") = mod.hva.floor1.fivZonVAV.vAV3.oveZonLoc.yDam.y "Damper position setpoint for zone eas";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor1_fivZonVAV_vAV3_oveZonLoc_yReaHea_y(unit="1") = mod.hva.floor1.fivZonVAV.vAV3.oveZonLoc.yReaHea.y "Reheat control signal for zone eas";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor1_fivZonVAV_vAV4_oveZonLoc_yDam_y(unit="1") = mod.hva.floor1.fivZonVAV.vAV4.oveZonLoc.yDam.y "Damper position setpoint for zone nor";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor1_fivZonVAV_vAV4_oveZonLoc_yReaHea_y(unit="1") = mod.hva.floor1.fivZonVAV.vAV4.oveZonLoc.yReaHea.y "Reheat control signal for zone nor";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor1_fivZonVAV_vAV5_oveZonLoc_yDam_y(unit="1") = mod.hva.floor1.fivZonVAV.vAV5.oveZonLoc.yDam.y "Damper position setpoint for zone wes";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor1_fivZonVAV_vAV5_oveZonLoc_yReaHea_y(unit="1") = mod.hva.floor1.fivZonVAV.vAV5.oveZonLoc.yReaHea.y "Reheat control signal for zone wes";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor1_oveZonCor_TZonCooSet_y(unit="K") = mod.hva.floor1.oveZonCor.TZonCooSet.y "Zone air temperature cooling setpoint for zone bot_floor_cor";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor1_oveZonCor_TZonHeaSet_y(unit="K") = mod.hva.floor1.oveZonCor.TZonHeaSet.y "Zone air temperature heating setpoint for zone bot_floor_cor";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor1_oveZonEas_TZonCooSet_y(unit="K") = mod.hva.floor1.oveZonEas.TZonCooSet.y "Zone air temperature cooling setpoint for zone bot_floor_eas";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor1_oveZonEas_TZonHeaSet_y(unit="K") = mod.hva.floor1.oveZonEas.TZonHeaSet.y "Zone air temperature heating setpoint for zone bot_floor_eas";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor1_oveZonNor_TZonCooSet_y(unit="K") = mod.hva.floor1.oveZonNor.TZonCooSet.y "Zone air temperature cooling setpoint for zone bot_floor_nor";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor1_oveZonNor_TZonHeaSet_y(unit="K") = mod.hva.floor1.oveZonNor.TZonHeaSet.y "Zone air temperature heating setpoint for zone bot_floor_nor";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor1_oveZonSou_TZonCooSet_y(unit="K") = mod.hva.floor1.oveZonSou.TZonCooSet.y "Zone air temperature cooling setpoint for zone bot_floor_sou";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor1_oveZonSou_TZonHeaSet_y(unit="K") = mod.hva.floor1.oveZonSou.TZonHeaSet.y "Zone air temperature heating setpoint for zone bot_floor_sou";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor1_oveZonWes_TZonCooSet_y(unit="K") = mod.hva.floor1.oveZonWes.TZonCooSet.y "Zone air temperature cooling setpoint for zone bot_floor_wes";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor1_oveZonWes_TZonHeaSet_y(unit="K") = mod.hva.floor1.oveZonWes.TZonHeaSet.y "Zone air temperature heating setpoint for zone bot_floor_wes";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor2_TSupAirSet_y(unit="K") = mod.hva.floor2.TSupAirSet.y "Supply air temperature setpoint for AHU";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor2_dpSet_y(unit="Pa") = mod.hva.floor2.dpSet.y "Supply duct pressure setpoint for AHU";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor2_duaFanAirHanUni_cooCoi_yCoo_y(unit="1") = mod.hva.floor2.duaFanAirHanUni.cooCoi.yCoo.y "Cooling coil valve control signal for AHU";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor2_duaFanAirHanUni_mixingBox_mixBox_yEA_y(unit="1") = mod.hva.floor2.duaFanAirHanUni.mixingBox.mixBox.yEA.y "Exhaust air damper position setpoint for AHU";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor2_duaFanAirHanUni_mixingBox_mixBox_yOA_y(unit="1") = mod.hva.floor2.duaFanAirHanUni.mixingBox.mixBox.yOA.y "Outside air damper position setpoint for AHU";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor2_duaFanAirHanUni_mixingBox_mixBox_yRet_y(unit="1") = mod.hva.floor2.duaFanAirHanUni.mixingBox.mixBox.yRet.y "Return air damper position setpoint for AHU";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor2_duaFanAirHanUni_oveSpeRetFan_y(unit="1") = mod.hva.floor2.duaFanAirHanUni.oveSpeRetFan.y "AHU return fan speed control signal";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor2_duaFanAirHanUni_supFan_oveSpeSupFan_y(unit="1") = mod.hva.floor2.duaFanAirHanUni.supFan.oveSpeSupFan.y "AHU supply fan speed control signal";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor2_fivZonVAV_vAV1_oveZonLoc_yDam_y(unit="1") = mod.hva.floor2.fivZonVAV.vAV1.oveZonLoc.yDam.y "Damper position setpoint for zone cor";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor2_fivZonVAV_vAV1_oveZonLoc_yReaHea_y(unit="1") = mod.hva.floor2.fivZonVAV.vAV1.oveZonLoc.yReaHea.y "Reheat control signal for zone cor";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor2_fivZonVAV_vAV2_oveZonLoc_yDam_y(unit="1") = mod.hva.floor2.fivZonVAV.vAV2.oveZonLoc.yDam.y "Damper position setpoint for zone sou";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor2_fivZonVAV_vAV2_oveZonLoc_yReaHea_y(unit="1") = mod.hva.floor2.fivZonVAV.vAV2.oveZonLoc.yReaHea.y "Reheat control signal for zone sou";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor2_fivZonVAV_vAV3_oveZonLoc_yDam_y(unit="1") = mod.hva.floor2.fivZonVAV.vAV3.oveZonLoc.yDam.y "Damper position setpoint for zone eas";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor2_fivZonVAV_vAV3_oveZonLoc_yReaHea_y(unit="1") = mod.hva.floor2.fivZonVAV.vAV3.oveZonLoc.yReaHea.y "Reheat control signal for zone eas";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor2_fivZonVAV_vAV4_oveZonLoc_yDam_y(unit="1") = mod.hva.floor2.fivZonVAV.vAV4.oveZonLoc.yDam.y "Damper position setpoint for zone nor";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor2_fivZonVAV_vAV4_oveZonLoc_yReaHea_y(unit="1") = mod.hva.floor2.fivZonVAV.vAV4.oveZonLoc.yReaHea.y "Reheat control signal for zone nor";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor2_fivZonVAV_vAV5_oveZonLoc_yDam_y(unit="1") = mod.hva.floor2.fivZonVAV.vAV5.oveZonLoc.yDam.y "Damper position setpoint for zone wes";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor2_fivZonVAV_vAV5_oveZonLoc_yReaHea_y(unit="1") = mod.hva.floor2.fivZonVAV.vAV5.oveZonLoc.yReaHea.y "Reheat control signal for zone wes";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor2_oveZonCor_TZonCooSet_y(unit="K") = mod.hva.floor2.oveZonCor.TZonCooSet.y "Zone air temperature cooling setpoint for zone mid_floor_cor";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor2_oveZonCor_TZonHeaSet_y(unit="K") = mod.hva.floor2.oveZonCor.TZonHeaSet.y "Zone air temperature heating setpoint for zone mid_floor_cor";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor2_oveZonEas_TZonCooSet_y(unit="K") = mod.hva.floor2.oveZonEas.TZonCooSet.y "Zone air temperature cooling setpoint for zone mid_floor_eas";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor2_oveZonEas_TZonHeaSet_y(unit="K") = mod.hva.floor2.oveZonEas.TZonHeaSet.y "Zone air temperature heating setpoint for zone mid_floor_eas";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor2_oveZonNor_TZonCooSet_y(unit="K") = mod.hva.floor2.oveZonNor.TZonCooSet.y "Zone air temperature cooling setpoint for zone mid_floor_nor";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor2_oveZonNor_TZonHeaSet_y(unit="K") = mod.hva.floor2.oveZonNor.TZonHeaSet.y "Zone air temperature heating setpoint for zone mid_floor_nor";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor2_oveZonSou_TZonCooSet_y(unit="K") = mod.hva.floor2.oveZonSou.TZonCooSet.y "Zone air temperature cooling setpoint for zone mid_floor_sou";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor2_oveZonSou_TZonHeaSet_y(unit="K") = mod.hva.floor2.oveZonSou.TZonHeaSet.y "Zone air temperature heating setpoint for zone mid_floor_sou";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor2_oveZonWes_TZonCooSet_y(unit="K") = mod.hva.floor2.oveZonWes.TZonCooSet.y "Zone air temperature cooling setpoint for zone mid_floor_wes";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor2_oveZonWes_TZonHeaSet_y(unit="K") = mod.hva.floor2.oveZonWes.TZonHeaSet.y "Zone air temperature heating setpoint for zone mid_floor_wes";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor3_TSupAirSet_y(unit="K") = mod.hva.floor3.TSupAirSet.y "Supply air temperature setpoint for AHU";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor3_dpSet_y(unit="Pa") = mod.hva.floor3.dpSet.y "Supply duct pressure setpoint for AHU";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor3_duaFanAirHanUni_cooCoi_yCoo_y(unit="1") = mod.hva.floor3.duaFanAirHanUni.cooCoi.yCoo.y "Cooling coil valve control signal for AHU";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor3_duaFanAirHanUni_mixingBox_mixBox_yEA_y(unit="1") = mod.hva.floor3.duaFanAirHanUni.mixingBox.mixBox.yEA.y "Exhaust air damper position setpoint for AHU";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor3_duaFanAirHanUni_mixingBox_mixBox_yOA_y(unit="1") = mod.hva.floor3.duaFanAirHanUni.mixingBox.mixBox.yOA.y "Outside air damper position setpoint for AHU";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor3_duaFanAirHanUni_mixingBox_mixBox_yRet_y(unit="1") = mod.hva.floor3.duaFanAirHanUni.mixingBox.mixBox.yRet.y "Return air damper position setpoint for AHU";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor3_duaFanAirHanUni_oveSpeRetFan_y(unit="1") = mod.hva.floor3.duaFanAirHanUni.oveSpeRetFan.y "AHU return fan speed control signal";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor3_duaFanAirHanUni_supFan_oveSpeSupFan_y(unit="1") = mod.hva.floor3.duaFanAirHanUni.supFan.oveSpeSupFan.y "AHU supply fan speed control signal";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor3_fivZonVAV_vAV1_oveZonLoc_yDam_y(unit="1") = mod.hva.floor3.fivZonVAV.vAV1.oveZonLoc.yDam.y "Damper position setpoint for zone cor";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor3_fivZonVAV_vAV1_oveZonLoc_yReaHea_y(unit="1") = mod.hva.floor3.fivZonVAV.vAV1.oveZonLoc.yReaHea.y "Reheat control signal for zone cor";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor3_fivZonVAV_vAV2_oveZonLoc_yDam_y(unit="1") = mod.hva.floor3.fivZonVAV.vAV2.oveZonLoc.yDam.y "Damper position setpoint for zone sou";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor3_fivZonVAV_vAV2_oveZonLoc_yReaHea_y(unit="1") = mod.hva.floor3.fivZonVAV.vAV2.oveZonLoc.yReaHea.y "Reheat control signal for zone sou";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor3_fivZonVAV_vAV3_oveZonLoc_yDam_y(unit="1") = mod.hva.floor3.fivZonVAV.vAV3.oveZonLoc.yDam.y "Damper position setpoint for zone eas";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor3_fivZonVAV_vAV3_oveZonLoc_yReaHea_y(unit="1") = mod.hva.floor3.fivZonVAV.vAV3.oveZonLoc.yReaHea.y "Reheat control signal for zone eas";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor3_fivZonVAV_vAV4_oveZonLoc_yDam_y(unit="1") = mod.hva.floor3.fivZonVAV.vAV4.oveZonLoc.yDam.y "Damper position setpoint for zone nor";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor3_fivZonVAV_vAV4_oveZonLoc_yReaHea_y(unit="1") = mod.hva.floor3.fivZonVAV.vAV4.oveZonLoc.yReaHea.y "Reheat control signal for zone nor";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor3_fivZonVAV_vAV5_oveZonLoc_yDam_y(unit="1") = mod.hva.floor3.fivZonVAV.vAV5.oveZonLoc.yDam.y "Damper position setpoint for zone wes";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor3_fivZonVAV_vAV5_oveZonLoc_yReaHea_y(unit="1") = mod.hva.floor3.fivZonVAV.vAV5.oveZonLoc.yReaHea.y "Reheat control signal for zone wes";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor3_oveZonCor_TZonCooSet_y(unit="K") = mod.hva.floor3.oveZonCor.TZonCooSet.y "Zone air temperature cooling setpoint for zone top_floor_cor";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor3_oveZonCor_TZonHeaSet_y(unit="K") = mod.hva.floor3.oveZonCor.TZonHeaSet.y "Zone air temperature heating setpoint for zone top_floor_cor";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor3_oveZonEas_TZonCooSet_y(unit="K") = mod.hva.floor3.oveZonEas.TZonCooSet.y "Zone air temperature cooling setpoint for zone top_floor_eas";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor3_oveZonEas_TZonHeaSet_y(unit="K") = mod.hva.floor3.oveZonEas.TZonHeaSet.y "Zone air temperature heating setpoint for zone top_floor_eas";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor3_oveZonNor_TZonCooSet_y(unit="K") = mod.hva.floor3.oveZonNor.TZonCooSet.y "Zone air temperature cooling setpoint for zone top_floor_nor";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor3_oveZonNor_TZonHeaSet_y(unit="K") = mod.hva.floor3.oveZonNor.TZonHeaSet.y "Zone air temperature heating setpoint for zone top_floor_nor";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor3_oveZonSou_TZonCooSet_y(unit="K") = mod.hva.floor3.oveZonSou.TZonCooSet.y "Zone air temperature cooling setpoint for zone top_floor_sou";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor3_oveZonSou_TZonHeaSet_y(unit="K") = mod.hva.floor3.oveZonSou.TZonHeaSet.y "Zone air temperature heating setpoint for zone top_floor_sou";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor3_oveZonWes_TZonCooSet_y(unit="K") = mod.hva.floor3.oveZonWes.TZonCooSet.y "Zone air temperature cooling setpoint for zone top_floor_wes";
+ Modelica.Blocks.Interfaces.RealOutput hva_floor3_oveZonWes_TZonHeaSet_y(unit="K") = mod.hva.floor3.oveZonWes.TZonHeaSet.y "Zone air temperature heating setpoint for zone top_floor_wes";
+ Modelica.Blocks.Interfaces.RealOutput hva_oveChiWatSys_TW_set_y(unit="K") = mod.hva.oveChiWatSys.TW_set.y "Chilled/hot water supply setpoint";
+ Modelica.Blocks.Interfaces.RealOutput hva_oveChiWatSys_dp_set_y(unit="Pa") = mod.hva.oveChiWatSys.dp_set.y "Differential pressure setpoint";
+ Modelica.Blocks.Interfaces.RealOutput hva_oveHotWatSys_TW_set_y(unit="K") = mod.hva.oveHotWatSys.TW_set.y "Chilled/hot water supply setpoint";
+ Modelica.Blocks.Interfaces.RealOutput hva_oveHotWatSys_dp_set_y(unit="Pa") = mod.hva.oveHotWatSys.dp_set.y "Differential pressure setpoint";
+ // Original model
+ MultizoneOfficeComplexAir.TestCases.TestCase mod(hva(
+      floor1(
+  TSupAirSet(           uExt(y=hva_floor1_TSupAirSet_u),activate(y=hva_floor1_TSupAirSet_activate)),
+  dpSet(           uExt(y=hva_floor1_dpSet_u),activate(y=hva_floor1_dpSet_activate)),
+        duaFanAirHanUni(
+          cooCoi(
+  yCoo(                                  uExt(y=hva_floor1_duaFanAirHanUni_cooCoi_yCoo_u),activate(y=hva_floor1_duaFanAirHanUni_cooCoi_yCoo_activate))),
+          mixingBox(mixBox(
+  yEA(                                            uExt(y=hva_floor1_duaFanAirHanUni_mixingBox_mixBox_yEA_u),activate(y=hva_floor1_duaFanAirHanUni_mixingBox_mixBox_yEA_activate)),
+  yOA(                                            uExt(y=hva_floor1_duaFanAirHanUni_mixingBox_mixBox_yOA_u),activate(y=hva_floor1_duaFanAirHanUni_mixingBox_mixBox_yOA_activate)),
+  yRet(                                            uExt(y=hva_floor1_duaFanAirHanUni_mixingBox_mixBox_yRet_u),activate(y=hva_floor1_duaFanAirHanUni_mixingBox_mixBox_yRet_activate)))),
+  oveSpeRetFan(                           uExt(y=hva_floor1_duaFanAirHanUni_oveSpeRetFan_u),activate(y=hva_floor1_duaFanAirHanUni_oveSpeRetFan_activate)),
+          supFan(
+  oveSpeSupFan(                                  uExt(y=hva_floor1_duaFanAirHanUni_supFan_oveSpeSupFan_u),activate(y=hva_floor1_duaFanAirHanUni_supFan_oveSpeSupFan_activate)))),
+        fivZonVAV(
+          vAV1(oveZonLoc(
+  yDam(                                    uExt(y=hva_floor1_fivZonVAV_vAV1_oveZonLoc_yDam_u),activate(y=hva_floor1_fivZonVAV_vAV1_oveZonLoc_yDam_activate)),
+  yReaHea(                                    uExt(y=hva_floor1_fivZonVAV_vAV1_oveZonLoc_yReaHea_u),activate(y=hva_floor1_fivZonVAV_vAV1_oveZonLoc_yReaHea_activate)))),
+          vAV2(oveZonLoc(
+  yDam(                                    uExt(y=hva_floor1_fivZonVAV_vAV2_oveZonLoc_yDam_u),activate(y=hva_floor1_fivZonVAV_vAV2_oveZonLoc_yDam_activate)),
+  yReaHea(                                    uExt(y=hva_floor1_fivZonVAV_vAV2_oveZonLoc_yReaHea_u),activate(y=hva_floor1_fivZonVAV_vAV2_oveZonLoc_yReaHea_activate)))),
+          vAV3(oveZonLoc(
+  yDam(                                    uExt(y=hva_floor1_fivZonVAV_vAV3_oveZonLoc_yDam_u),activate(y=hva_floor1_fivZonVAV_vAV3_oveZonLoc_yDam_activate)),
+  yReaHea(                                    uExt(y=hva_floor1_fivZonVAV_vAV3_oveZonLoc_yReaHea_u),activate(y=hva_floor1_fivZonVAV_vAV3_oveZonLoc_yReaHea_activate)))),
+          vAV4(oveZonLoc(
+  yDam(                                    uExt(y=hva_floor1_fivZonVAV_vAV4_oveZonLoc_yDam_u),activate(y=hva_floor1_fivZonVAV_vAV4_oveZonLoc_yDam_activate)),
+  yReaHea(                                    uExt(y=hva_floor1_fivZonVAV_vAV4_oveZonLoc_yReaHea_u),activate(y=hva_floor1_fivZonVAV_vAV4_oveZonLoc_yReaHea_activate)))),
+          vAV5(oveZonLoc(
+  yDam(                                    uExt(y=hva_floor1_fivZonVAV_vAV5_oveZonLoc_yDam_u),activate(y=hva_floor1_fivZonVAV_vAV5_oveZonLoc_yDam_activate)),
+  yReaHea(                                    uExt(y=hva_floor1_fivZonVAV_vAV5_oveZonLoc_yReaHea_u),activate(y=hva_floor1_fivZonVAV_vAV5_oveZonLoc_yReaHea_activate))))),
+        oveZonCor(
+  TZonCooSet(                     uExt(y=hva_floor1_oveZonCor_TZonCooSet_u),activate(y=hva_floor1_oveZonCor_TZonCooSet_activate)),
+  TZonHeaSet(                     uExt(y=hva_floor1_oveZonCor_TZonHeaSet_u),activate(y=hva_floor1_oveZonCor_TZonHeaSet_activate))),
+        oveZonEas(
+  TZonCooSet(                     uExt(y=hva_floor1_oveZonEas_TZonCooSet_u),activate(y=hva_floor1_oveZonEas_TZonCooSet_activate)),
+  TZonHeaSet(                     uExt(y=hva_floor1_oveZonEas_TZonHeaSet_u),activate(y=hva_floor1_oveZonEas_TZonHeaSet_activate))),
+        oveZonNor(
+  TZonCooSet(                     uExt(y=hva_floor1_oveZonNor_TZonCooSet_u),activate(y=hva_floor1_oveZonNor_TZonCooSet_activate)),
+  TZonHeaSet(                     uExt(y=hva_floor1_oveZonNor_TZonHeaSet_u),activate(y=hva_floor1_oveZonNor_TZonHeaSet_activate))),
+        oveZonSou(
+  TZonCooSet(                     uExt(y=hva_floor1_oveZonSou_TZonCooSet_u),activate(y=hva_floor1_oveZonSou_TZonCooSet_activate)),
+  TZonHeaSet(                     uExt(y=hva_floor1_oveZonSou_TZonHeaSet_u),activate(y=hva_floor1_oveZonSou_TZonHeaSet_activate))),
+        oveZonWes(
+  TZonCooSet(                     uExt(y=hva_floor1_oveZonWes_TZonCooSet_u),activate(y=hva_floor1_oveZonWes_TZonCooSet_activate)),
+  TZonHeaSet(                     uExt(y=hva_floor1_oveZonWes_TZonHeaSet_u),activate(y=hva_floor1_oveZonWes_TZonHeaSet_activate)))),
+      floor2(
+  TSupAirSet(           uExt(y=hva_floor2_TSupAirSet_u),activate(y=hva_floor2_TSupAirSet_activate)),
+  dpSet(           uExt(y=hva_floor2_dpSet_u),activate(y=hva_floor2_dpSet_activate)),
+        duaFanAirHanUni(
+          cooCoi(
+  yCoo(                                  uExt(y=hva_floor2_duaFanAirHanUni_cooCoi_yCoo_u),activate(y=hva_floor2_duaFanAirHanUni_cooCoi_yCoo_activate))),
+          mixingBox(mixBox(
+  yEA(                                            uExt(y=hva_floor2_duaFanAirHanUni_mixingBox_mixBox_yEA_u),activate(y=hva_floor2_duaFanAirHanUni_mixingBox_mixBox_yEA_activate)),
+  yOA(                                            uExt(y=hva_floor2_duaFanAirHanUni_mixingBox_mixBox_yOA_u),activate(y=hva_floor2_duaFanAirHanUni_mixingBox_mixBox_yOA_activate)),
+  yRet(                                            uExt(y=hva_floor2_duaFanAirHanUni_mixingBox_mixBox_yRet_u),activate(y=hva_floor2_duaFanAirHanUni_mixingBox_mixBox_yRet_activate)))),
+  oveSpeRetFan(                           uExt(y=hva_floor2_duaFanAirHanUni_oveSpeRetFan_u),activate(y=hva_floor2_duaFanAirHanUni_oveSpeRetFan_activate)),
+          supFan(
+  oveSpeSupFan(                                  uExt(y=hva_floor2_duaFanAirHanUni_supFan_oveSpeSupFan_u),activate(y=hva_floor2_duaFanAirHanUni_supFan_oveSpeSupFan_activate)))),
+        fivZonVAV(
+          vAV1(oveZonLoc(
+  yDam(                                    uExt(y=hva_floor2_fivZonVAV_vAV1_oveZonLoc_yDam_u),activate(y=hva_floor2_fivZonVAV_vAV1_oveZonLoc_yDam_activate)),
+  yReaHea(                                    uExt(y=hva_floor2_fivZonVAV_vAV1_oveZonLoc_yReaHea_u),activate(y=hva_floor2_fivZonVAV_vAV1_oveZonLoc_yReaHea_activate)))),
+          vAV2(oveZonLoc(
+  yDam(                                    uExt(y=hva_floor2_fivZonVAV_vAV2_oveZonLoc_yDam_u),activate(y=hva_floor2_fivZonVAV_vAV2_oveZonLoc_yDam_activate)),
+  yReaHea(                                    uExt(y=hva_floor2_fivZonVAV_vAV2_oveZonLoc_yReaHea_u),activate(y=hva_floor2_fivZonVAV_vAV2_oveZonLoc_yReaHea_activate)))),
+          vAV3(oveZonLoc(
+  yDam(                                    uExt(y=hva_floor2_fivZonVAV_vAV3_oveZonLoc_yDam_u),activate(y=hva_floor2_fivZonVAV_vAV3_oveZonLoc_yDam_activate)),
+  yReaHea(                                    uExt(y=hva_floor2_fivZonVAV_vAV3_oveZonLoc_yReaHea_u),activate(y=hva_floor2_fivZonVAV_vAV3_oveZonLoc_yReaHea_activate)))),
+          vAV4(oveZonLoc(
+  yDam(                                    uExt(y=hva_floor2_fivZonVAV_vAV4_oveZonLoc_yDam_u),activate(y=hva_floor2_fivZonVAV_vAV4_oveZonLoc_yDam_activate)),
+  yReaHea(                                    uExt(y=hva_floor2_fivZonVAV_vAV4_oveZonLoc_yReaHea_u),activate(y=hva_floor2_fivZonVAV_vAV4_oveZonLoc_yReaHea_activate)))),
+          vAV5(oveZonLoc(
+  yDam(                                    uExt(y=hva_floor2_fivZonVAV_vAV5_oveZonLoc_yDam_u),activate(y=hva_floor2_fivZonVAV_vAV5_oveZonLoc_yDam_activate)),
+  yReaHea(                                    uExt(y=hva_floor2_fivZonVAV_vAV5_oveZonLoc_yReaHea_u),activate(y=hva_floor2_fivZonVAV_vAV5_oveZonLoc_yReaHea_activate))))),
+        oveZonCor(
+  TZonCooSet(                     uExt(y=hva_floor2_oveZonCor_TZonCooSet_u),activate(y=hva_floor2_oveZonCor_TZonCooSet_activate)),
+  TZonHeaSet(                     uExt(y=hva_floor2_oveZonCor_TZonHeaSet_u),activate(y=hva_floor2_oveZonCor_TZonHeaSet_activate))),
+        oveZonEas(
+  TZonCooSet(                     uExt(y=hva_floor2_oveZonEas_TZonCooSet_u),activate(y=hva_floor2_oveZonEas_TZonCooSet_activate)),
+  TZonHeaSet(                     uExt(y=hva_floor2_oveZonEas_TZonHeaSet_u),activate(y=hva_floor2_oveZonEas_TZonHeaSet_activate))),
+        oveZonNor(
+  TZonCooSet(                     uExt(y=hva_floor2_oveZonNor_TZonCooSet_u),activate(y=hva_floor2_oveZonNor_TZonCooSet_activate)),
+  TZonHeaSet(                     uExt(y=hva_floor2_oveZonNor_TZonHeaSet_u),activate(y=hva_floor2_oveZonNor_TZonHeaSet_activate))),
+        oveZonSou(
+  TZonCooSet(                     uExt(y=hva_floor2_oveZonSou_TZonCooSet_u),activate(y=hva_floor2_oveZonSou_TZonCooSet_activate)),
+  TZonHeaSet(                     uExt(y=hva_floor2_oveZonSou_TZonHeaSet_u),activate(y=hva_floor2_oveZonSou_TZonHeaSet_activate))),
+        oveZonWes(
+  TZonCooSet(                     uExt(y=hva_floor2_oveZonWes_TZonCooSet_u),activate(y=hva_floor2_oveZonWes_TZonCooSet_activate)),
+  TZonHeaSet(                     uExt(y=hva_floor2_oveZonWes_TZonHeaSet_u),activate(y=hva_floor2_oveZonWes_TZonHeaSet_activate)))),
+      floor3(
+  TSupAirSet(           uExt(y=hva_floor3_TSupAirSet_u),activate(y=hva_floor3_TSupAirSet_activate)),
+  dpSet(           uExt(y=hva_floor3_dpSet_u),activate(y=hva_floor3_dpSet_activate)),
+        duaFanAirHanUni(
+          cooCoi(
+  yCoo(                                  uExt(y=hva_floor3_duaFanAirHanUni_cooCoi_yCoo_u),activate(y=hva_floor3_duaFanAirHanUni_cooCoi_yCoo_activate))),
+          mixingBox(mixBox(
+  yEA(                                            uExt(y=hva_floor3_duaFanAirHanUni_mixingBox_mixBox_yEA_u),activate(y=hva_floor3_duaFanAirHanUni_mixingBox_mixBox_yEA_activate)),
+  yOA(                                            uExt(y=hva_floor3_duaFanAirHanUni_mixingBox_mixBox_yOA_u),activate(y=hva_floor3_duaFanAirHanUni_mixingBox_mixBox_yOA_activate)),
+  yRet(                                            uExt(y=hva_floor3_duaFanAirHanUni_mixingBox_mixBox_yRet_u),activate(y=hva_floor3_duaFanAirHanUni_mixingBox_mixBox_yRet_activate)))),
+  oveSpeRetFan(                           uExt(y=hva_floor3_duaFanAirHanUni_oveSpeRetFan_u),activate(y=hva_floor3_duaFanAirHanUni_oveSpeRetFan_activate)),
+          supFan(
+  oveSpeSupFan(                                  uExt(y=hva_floor3_duaFanAirHanUni_supFan_oveSpeSupFan_u),activate(y=hva_floor3_duaFanAirHanUni_supFan_oveSpeSupFan_activate)))),
+        fivZonVAV(
+          vAV1(oveZonLoc(
+  yDam(                                    uExt(y=hva_floor3_fivZonVAV_vAV1_oveZonLoc_yDam_u),activate(y=hva_floor3_fivZonVAV_vAV1_oveZonLoc_yDam_activate)),
+  yReaHea(                                    uExt(y=hva_floor3_fivZonVAV_vAV1_oveZonLoc_yReaHea_u),activate(y=hva_floor3_fivZonVAV_vAV1_oveZonLoc_yReaHea_activate)))),
+          vAV2(oveZonLoc(
+  yDam(                                    uExt(y=hva_floor3_fivZonVAV_vAV2_oveZonLoc_yDam_u),activate(y=hva_floor3_fivZonVAV_vAV2_oveZonLoc_yDam_activate)),
+  yReaHea(                                    uExt(y=hva_floor3_fivZonVAV_vAV2_oveZonLoc_yReaHea_u),activate(y=hva_floor3_fivZonVAV_vAV2_oveZonLoc_yReaHea_activate)))),
+          vAV3(oveZonLoc(
+  yDam(                                    uExt(y=hva_floor3_fivZonVAV_vAV3_oveZonLoc_yDam_u),activate(y=hva_floor3_fivZonVAV_vAV3_oveZonLoc_yDam_activate)),
+  yReaHea(                                    uExt(y=hva_floor3_fivZonVAV_vAV3_oveZonLoc_yReaHea_u),activate(y=hva_floor3_fivZonVAV_vAV3_oveZonLoc_yReaHea_activate)))),
+          vAV4(oveZonLoc(
+  yDam(                                    uExt(y=hva_floor3_fivZonVAV_vAV4_oveZonLoc_yDam_u),activate(y=hva_floor3_fivZonVAV_vAV4_oveZonLoc_yDam_activate)),
+  yReaHea(                                    uExt(y=hva_floor3_fivZonVAV_vAV4_oveZonLoc_yReaHea_u),activate(y=hva_floor3_fivZonVAV_vAV4_oveZonLoc_yReaHea_activate)))),
+          vAV5(oveZonLoc(
+  yDam(                                    uExt(y=hva_floor3_fivZonVAV_vAV5_oveZonLoc_yDam_u),activate(y=hva_floor3_fivZonVAV_vAV5_oveZonLoc_yDam_activate)),
+  yReaHea(                                    uExt(y=hva_floor3_fivZonVAV_vAV5_oveZonLoc_yReaHea_u),activate(y=hva_floor3_fivZonVAV_vAV5_oveZonLoc_yReaHea_activate))))),
+        oveZonCor(
+  TZonCooSet(                     uExt(y=hva_floor3_oveZonCor_TZonCooSet_u),activate(y=hva_floor3_oveZonCor_TZonCooSet_activate)),
+  TZonHeaSet(                     uExt(y=hva_floor3_oveZonCor_TZonHeaSet_u),activate(y=hva_floor3_oveZonCor_TZonHeaSet_activate))),
+        oveZonEas(
+  TZonCooSet(                     uExt(y=hva_floor3_oveZonEas_TZonCooSet_u),activate(y=hva_floor3_oveZonEas_TZonCooSet_activate)),
+  TZonHeaSet(                     uExt(y=hva_floor3_oveZonEas_TZonHeaSet_u),activate(y=hva_floor3_oveZonEas_TZonHeaSet_activate))),
+        oveZonNor(
+  TZonCooSet(                     uExt(y=hva_floor3_oveZonNor_TZonCooSet_u),activate(y=hva_floor3_oveZonNor_TZonCooSet_activate)),
+  TZonHeaSet(                     uExt(y=hva_floor3_oveZonNor_TZonHeaSet_u),activate(y=hva_floor3_oveZonNor_TZonHeaSet_activate))),
+        oveZonSou(
+  TZonCooSet(                     uExt(y=hva_floor3_oveZonSou_TZonCooSet_u),activate(y=hva_floor3_oveZonSou_TZonCooSet_activate)),
+  TZonHeaSet(                     uExt(y=hva_floor3_oveZonSou_TZonHeaSet_u),activate(y=hva_floor3_oveZonSou_TZonHeaSet_activate))),
+        oveZonWes(
+  TZonCooSet(                     uExt(y=hva_floor3_oveZonWes_TZonCooSet_u),activate(y=hva_floor3_oveZonWes_TZonCooSet_activate)),
+  TZonHeaSet(                     uExt(y=hva_floor3_oveZonWes_TZonHeaSet_u),activate(y=hva_floor3_oveZonWes_TZonHeaSet_activate)))),
+      oveChiWatSys(
+  TW_set(                 uExt(y=hva_oveChiWatSys_TW_set_u),activate(y=hva_oveChiWatSys_TW_set_activate)),
+  dp_set(                 uExt(y=hva_oveChiWatSys_dp_set_u),activate(y=hva_oveChiWatSys_dp_set_activate))),
+      oveHotWatSys(
+  TW_set(                 uExt(y=hva_oveHotWatSys_TW_set_u),activate(y=hva_oveHotWatSys_TW_set_activate)),
+  dp_set(                 uExt(y=hva_oveHotWatSys_dp_set_u),activate(y=hva_oveHotWatSys_dp_set_activate)))))
+                                                                                                           "Original model with overwrites";
 end wrapped;


### PR DESCRIPTION
Main updates:
1. Add two python scripts for generating the training dataset:
- `multizone_office_complex_air_excitations.py` is used for managing the training settings and post-process.
- `perturb_multizone_office_complex_air.py` is used to perturb the system using randomly generated control inputs.
Here is an example of zonal temperature based on generated training dataset. Please note that this plot is using the old Modelica system model. After re-compiled the FMU by Xing on the Linux system, we will rerun this data generation procedure.
![training_Tzon_day0-7_oldModel](https://github.com/user-attachments/assets/9765c609-eb05-42bd-85a0-6fdb86a645c7)
(dashed lines are perturbed variables, solid lines are zonal temperature measurements)

2. Update sizing information sheets of VAV, AHU, Chiller, Cooling tower, Boiler, pumps, etc. Detailed sizing values are summarized in the following tables, which are also included in the HTML doc file.
<img width="1154" alt="sizing_sheet1" src="https://github.com/user-attachments/assets/b11425a0-f5d6-4587-b0dd-02576645e75e">
<img width="1098" alt="sizing_sheet2" src="https://github.com/user-attachments/assets/a5eddd07-ab9a-4218-b612-bb11b4dda0f2">

3. Add zone-level and AHU-level CO2 measurements into the wrapped model and HTML doc file.
4. Add more measurements such as TCHW_sup, TCHW_ret, mCHW_tot, THW_sup, THW_ret, mHW_tot, etc.
5. Correct several typos of measurement names and descriptions in the HTML doc file.
